### PR TITLE
Add super linter scan on PR approval

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,6 +4,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     if: github.event.review.state == 'approved'
@@ -11,16 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Check out the head of the PR specifically
           ref: ${{ github.event.pull_request.head.sha }}
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
+          # Disable credential persistence to harden the runner
+          persist-credentials: false
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v7
+        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: main
+          DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose
Add super linter scan on PR approval

## Goals
Adding a Super-Linter scan on pull request approval is important because it automates code quality enforcement, catches errors and security vulnerabilities early, ensures code consistency across teams, and streamlines the human code review process.


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated code-quality workflow that runs when pull request reviews are approved.
  * Linting now executes against the full PR commit history on CI, improving accuracy of reported issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->