### PR TITLE
Add labels, annotations, taints, registries, machine_config_overrides, and machine_global_config to k8s-cluster

### DIFF
--- a/modules/workloads/k8s-cluster/main.tf
+++ b/modules/workloads/k8s-cluster/main.tf
@@ -82,6 +82,13 @@ resource "rancher2_cluster_v2" "this" {
       condition     = !var.manage_rke_config || length(var.machine_pools) > 0
       error_message = "machine_pools must contain at least one entry when manage_rke_config is true."
     }
+    precondition {
+      condition = length(setsubtract(
+        toset(keys(var.machine_config_overrides)),
+        toset([for p in var.machine_pools : p.name])
+      )) == 0
+      error_message = "All machine_config_overrides keys must match a pool name in machine_pools."
+    }
   }
 
   dynamic "rke_config" {

--- a/modules/workloads/k8s-cluster/variables.tf
+++ b/modules/workloads/k8s-cluster/variables.tf
@@ -88,6 +88,15 @@ variable "machine_pools" {
     ])
     error_message = "Each machine pool must have a unique name, integer quantity/disk_size > 0, and at least one role (control_plane, etcd, or worker) enabled."
   }
+
+  validation {
+    condition = alltrue([
+      for p in var.machine_pools : alltrue([
+        for t in p.taints : contains(["NoSchedule", "PreferNoSchedule", "NoExecute"], t.effect)
+      ])
+    ])
+    error_message = "Each taint effect must be one of: NoSchedule, PreferNoSchedule, NoExecute."
+  }
 }
 
 # ── Node cloud-init ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends the `k8s-cluster` module with new per-pool and cluster-level variables to enable full Terraform lifecycle management of brownfield RKE2 clusters and support dedicated node pool scheduling.

## Changes

### Per-pool: labels, annotations, taints (`variables.tf` + `main.tf`)

**`labels`** (`optional(map(string), {})`) and **`annotations`** (`optional(map(string), {})`)
Applied as Kubernetes node labels/annotations to all nodes in the pool. Both default to empty — existing callers require no changes.

**`taints`** (`optional(list(object({ key, value, effect })), [])`)
Applied as Kubernetes node taints. Effect must be one of `NoSchedule`, `PreferNoSchedule`, or `NoExecute`. Emitted as a dynamic `taints` block inside each `machine_pools` entry.

Example — dedicated build pool for Argo Workflows:
```hcl
labels = { "nodepool" = "build-nodepool" }
taints = [{ key = "argo-build", value = "dedicated", effect = "NoSchedule" }]
```

### Cluster-level: machine_config_overrides, registries, machine_global_config

**`machine_config_overrides`** (`map(object({ kind, name }))`, default `{}`)
Per-pool map that references pre-existing `HarvesterConfig` objects, skipping `rancher2_machine_config_v2` creation for named pools. Enables staged migration of brownfield clusters one pool at a time via two-phase apply.

**`registries`** (`object({ configs, mirrors })`, default `null`)
Optional dynamic `registries` block for private registry auth secrets, TLS, CA bundles, and pull-through mirrors.

**`machine_global_config`** (`string`, default `null`)
Full YAML override for `machine_global_config`. Falls back to cni-based default when `null`. Allows custom `kube-proxy-arg` for IPVS without a wrapper module.

### Narrowed `lifecycle.ignore_changes`

Replaced the broad `rke_config` ignore with specific sub-fields (`chart_values`, drain options) so pool, label, taint, registry, and machine config changes are detected and applied via Terraform.

## Related

Part of [wso2-enterprise/wso2-datacenter-project#38](https://github.com/wso2-enterprise/wso2-datacenter-project/issues/38) — Import and manage all LK RKE2 clusters via Terraform.

## Test plan

- [ ] `labels` / `annotations` — verify set on nodes; verify absence when not specified
- [ ] `taints` — verify taint applied to pool nodes; verify only tolerated pods schedule there
- [ ] `machine_config_overrides` — pools in map skip machine config creation; others create normally
- [ ] `registries` — dynamic block emitted when set, absent when `null`
- [ ] `machine_global_config` — custom YAML used when set; cni default used when `null`
- [ ] `lifecycle.ignore_changes` — pool/label/taint changes produce plan diff; chart_values and drain options do not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-pool machine configuration overrides; optional global machine configuration with YAML fallback; conditional private registry support (configs, auth/TLS, mirrors).
  * Per-pool labels and taints for finer node grouping and scheduling control.

* **Behavior Improvements**
  * Cluster now references overrides when present and otherwise uses generated configs.
  * More granular ignore rules for cluster updates, reducing unnecessary drift handling.
  * Added validation requiring override keys to match existing pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->