### PR TITLE
[Workloads] Add support for multiple additional disks to the VM module

### DIFF
--- a/modules/workloads/vm/main.tf
+++ b/modules/workloads/vm/main.tf
@@ -36,6 +36,17 @@ resource "harvester_virtualmachine" "this" {
     auto_delete = true
   }
 
+  dynamic "disk" {
+    for_each = var.additional_disks
+    content {
+      name        = disk.value.name
+      size        = disk.value.size
+      bus         = "virtio"
+      image       = disk.value.image
+      auto_delete = disk.value.auto_delete
+    }
+  }
+
   dynamic "cloudinit" {
     for_each = var.user_data != null ? [1] : []
     content {

--- a/modules/workloads/vm/variables.tf
+++ b/modules/workloads/vm/variables.tf
@@ -76,3 +76,14 @@ variable "wait_for_lease" {
   description = "Whether Terraform should wait for an IP lease on the primary NIC. Set to false when using static IPs via cloud-init network_data without qemu-guest-agent."
   default     = true
 }
+
+variable "additional_disks" {
+  type = list(object({
+    name        = string
+    size        = string
+    image       = optional(string)
+    auto_delete = optional(bool, true)
+  }))
+  description = "List of additional disks to attach to the VM."
+  default     = []
+}


### PR DESCRIPTION
## Purpose
The current workloads/vm module only supports a single root disk. This PR enables attaching multiple additional disks to the virtual machine.

## Goals
- Add support for multiple additional disks via a new additional_disks variable.
- Use a dynamic disk block in the harvester_virtualmachine resource.

## Approach
- Introduced additional_disks variable as a list of objects.
- Implemented a dynamic disk block that iterates through additional_disks.
- Maintained backward compatibility for the root disk.

## User stories
As a developer, I want to attach additional data disks to a Harvester VM so that I can separate OS and data storage.

## Release note
Enables the attachment of multiple additional disks to virtual machines in the workloads/vm module.

## Automation tests
- Verified with terraform validate in a consumer project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Virtual machine module now supports attaching additional disks with customizable properties including name, size, image source, and auto-deletion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->