### PR TITLE
Fix perpetual diff in machine_selector_config key order

### DIFF
--- a/modules/workloads/k8s-cluster/main.tf
+++ b/modules/workloads/k8s-cluster/main.tf
@@ -10,6 +10,13 @@ terraform {
 
 locals {
   pools_by_name = { for p in var.machine_pools : p.name => p }
+
+  # Key order is fixed to match what Rancher stores in state. Using yamlencode
+  # sorts keys alphabetically (cloud-provider-config before cloud-provider-name)
+  # causing a perpetual no-op diff on brownfield clusters.
+  machine_selector_config = var.cloud_provider_config_secret != "" ? (
+    "cloud-provider-config: secret://fleet-default:${var.cloud_provider_config_secret}\ncloud-provider-name: harvester\nprotect-kernel-defaults: false\n"
+  ) : "cloud-provider-name: harvester\nprotect-kernel-defaults: false\n"
 }
 
 # One machine config per pool.
@@ -113,15 +120,8 @@ resource "rancher2_cluster_v2" "this" {
           # harvesterconfig* secret already exists. For new clusters Rancher's
           # provisioner creates the secret automatically when cloud-provider-name
           # is harvester — no explicit cloud-provider-config key needed on create.
-          config = yamlencode(merge(
-            {
-              "cloud-provider-name"     = "harvester"
-              "protect-kernel-defaults" = false
-            },
-            var.cloud_provider_config_secret != "" ? {
-              "cloud-provider-config" = "secret://fleet-default:${var.cloud_provider_config_secret}"
-            } : {}
-          ))
+          #
+          config = local.machine_selector_config
         }
       }
 


### PR DESCRIPTION
## Problem

`yamlencode` sorts map keys alphabetically, so `cloud-provider-config` always appears before `cloud-provider-name` in the generated YAML. Rancher stores the keys in a different order in state, causing a perpetual no-op diff on every plan for brownfield clusters that have `cloud_provider_config_secret` set:

```
~ machine_selector_config {
    ~ config = <<-EOT
        - cloud-provider-config: secret://fleet-default:harvesterconfigiapn1
        - cloud-provider-name: harvester
          protect-kernel-defaults: false
      EOT
  }
```

## Fix

Replace `yamlencode` with a string literal in a `locals` block with keys in the order Rancher expects:

```
cloud-provider-config: secret://fleet-default:<secret>
cloud-provider-name: harvester
protect-kernel-defaults: false
```

## Test plan

- [ ] `terraform plan -target=<cluster with cloud_provider_config_secret set>` shows no diff in `machine_selector_config`
- [ ] `terraform plan -target=<cluster without cloud_provider_config_secret>` shows no diff in `machine_selector_config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced reliability of cluster configuration generation through improved determinism in machine selector configuration handling, ensuring more consistent and predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->