### PR TITLE
Add optional scheduled backup support to vm module

### DIFF
--- a/modules/workloads/vm/main.tf
+++ b/modules/workloads/vm/main.tf
@@ -55,3 +55,32 @@ resource "harvester_virtualmachine" "this" {
     }
   }
 }
+
+# Optional scheduled backup — created only when backup_schedule is set.
+# Uses kubernetes_manifest because harvester_schedule_backup requires provider >= 1.8.
+resource "kubernetes_manifest" "scheduled_backup" {
+  count = var.backup_schedule != null ? 1 : 0
+
+  manifest = {
+    apiVersion = "harvesterhci.io/v1beta1"
+    kind       = "ScheduleVMBackup"
+    metadata = {
+      name      = "${var.name}-backup"
+      namespace = var.namespace
+    }
+    spec = {
+      cron       = var.backup_schedule
+      retain     = var.backup_retain
+      maxFailure = var.backup_max_failure
+      suspend    = !var.backup_enabled
+      vmbackup = {
+        source = {
+          apiGroup = "kubevirt.io"
+          kind     = "VirtualMachine"
+          name     = harvester_virtualmachine.this.name
+        }
+        type = "backup"
+      }
+    }
+  }
+}

--- a/modules/workloads/vm/outputs.tf
+++ b/modules/workloads/vm/outputs.tf
@@ -17,3 +17,8 @@ output "ssh_key_id" {
   value       = var.ssh_public_key != null ? harvester_ssh_key.this[0].id : null
   description = "Harvester SSH key ID attached to the VM, or null if no SSH key was provided."
 }
+
+output "backup_schedule_name" {
+  value       = var.backup_schedule != null ? kubernetes_manifest.scheduled_backup[0].manifest.metadata.name : null
+  description = "Name of the scheduled VM backup, or null if no backup schedule was configured."
+}

--- a/modules/workloads/vm/variables.tf
+++ b/modules/workloads/vm/variables.tf
@@ -87,3 +87,29 @@ variable "additional_disks" {
   description = "List of additional disks to attach to the VM."
   default     = []
 }
+
+# --- Scheduled backups ---
+
+variable "backup_schedule" {
+  type        = string
+  description = "Cron schedule for VM backups in UTC (e.g. \"0 2 * * *\" for daily at 2 AM). Set to null to disable scheduled backups."
+  default     = null
+}
+
+variable "backup_retain" {
+  type        = number
+  description = "Number of backups to retain when scheduled backups are enabled."
+  default     = 5
+}
+
+variable "backup_enabled" {
+  type        = bool
+  description = "Whether the backup schedule is active. Only applies when backup_schedule is set."
+  default     = true
+}
+
+variable "backup_max_failure" {
+  type        = number
+  description = "Maximum consecutive failed backup attempts before suspending the schedule."
+  default     = 4
+}

--- a/modules/workloads/vm/versions.tf
+++ b/modules/workloads/vm/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "harvester/harvester"
       version = "~> 1.7"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds optional scheduled VM backup support to the `workloads/vm` module. When `backup_schedule` is set, a Harvester `ScheduleVMBackup` CRD is created alongside the VM using `kubernetes_manifest`.

### New variables

| Variable | Type | Default | Description |
|---|---|---|---|
| `backup_schedule` | string | `null` | Cron schedule in UTC. Set to enable backups. |
| `backup_retain` | number | `5` | Number of backups to retain |
| `backup_enabled` | bool | `true` | Whether the schedule is active |
| `backup_max_failure` | number | `4` | Max consecutive failures before suspending |

### Usage

```hcl
module "my_vm" {
  source = "github.com/wso2/open-cloud-datacenter//modules/workloads/vm?ref=<tag>"

  name      = "my-vm"
  namespace = "my-namespace"
  # ... existing config ...

  # Optional: enable daily backups at 2 AM UTC, keep 7
  backup_schedule = "0 2 * * *"
  backup_retain   = 7

  providers = {
    kubernetes = kubernetes.harvester
  }
}
```

VMs without `backup_schedule` set are unaffected.

### Implementation note

Uses `kubernetes_manifest` to create the `ScheduleVMBackup` CRD directly. The module now requires a `kubernetes` provider to be passed.

## Test plan

- [x] Tested on LK workloads layer with `jenkins-builder-slave` VM
- [x] `terraform plan` — shows 1 new `kubernetes_manifest` resource, no VM changes
- [x] `terraform apply` — `ScheduleVMBackup` CRD created successfully in Harvester
- [x] Verified backup schedule visible in Harvester UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scheduled virtual machine backups with configurable cron schedules, retention policies, and maximum failure thresholds.
  * Backup functionality can be enabled or disabled and is optional through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->