### PR TITLE
Add vm-creator, vm-operator, cluster-operator roles; optional tenant namespaces

### DIFF
--- a/modules/management/cluster-roles/main.tf
+++ b/modules/management/cluster-roles/main.tf
@@ -102,6 +102,137 @@ resource "rancher2_role_template" "network_manager" {
   }
 }
 
+# Cluster-scoped prerequisite for tenants who need to create VMs.
+# Harvester stores shared resources (images, networks, SSH keypairs) outside
+# project namespaces — project-owner alone cannot see them. This role provides
+# the minimum cluster-level read access required for the VM creation flow:
+#   - VM image dropdown (VirtualMachineImage in default/harvester-public)
+#   - Network dropdown (NetworkAttachmentDefinition in harvester-public)
+#   - SSH keypair dropdown (KeyPair in the tenant's namespace, but listed cluster-wide)
+#
+# Pair with a project role (vm-manager or project-owner) via a separate
+# rancher2_cluster_role_template_binding for the same group.
+resource "rancher2_role_template" "vm_creator" {
+  name        = "vm-creator"
+  description = "Cluster-level read access to shared Harvester resources (VM images, networks, SSH keypairs) needed to create VMs. Pair with a project role for full VM lifecycle."
+  context     = "cluster"
+
+  # VM images are stored in the default or harvester-public namespace.
+  # Without this, the image dropdown is empty when creating a VM.
+  rules {
+    api_groups = ["harvesterhci.io"]
+    resources  = ["virtualmachineimages"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # NetworkAttachmentDefinitions in harvester-public are the network references
+  # VMs use. Without this, the network interface dropdown is empty.
+  rules {
+    api_groups = ["k8s.cni.cncf.io"]
+    resources  = ["network-attachment-definitions"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # SSH keypairs — read cluster-wide so the keypair dropdown populates.
+  # The keypair itself lives in the tenant's namespace; the cluster-level
+  # read is required for the Harvester UI to enumerate them.
+  rules {
+    api_groups = ["harvesterhci.io"]
+    resources  = ["keypairs"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+# Project-scoped role for teams that operate but do not provision VMs.
+# Grants power operations (start/stop/restart) and console/VNC access only.
+# Intentionally excludes create, delete, migrate, and all data volume mutations
+# so operators cannot provision or decommission VMs — only run them.
+resource "rancher2_role_template" "vm_operator" {
+  name        = "vm-operator"
+  description = "Start, stop, restart, and access the console of existing VMs. No create, delete, or migrate permissions."
+  context     = "project"
+
+  # Read-only view of VM objects — operators need to see what exists
+  rules {
+    api_groups = ["kubevirt.io"]
+    resources  = ["virtualmachines", "virtualmachineinstances"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # Power operations and console/VNC — migrate intentionally excluded
+  rules {
+    api_groups = ["subresources.kubevirt.io"]
+    resources  = ["virtualmachines/start", "virtualmachines/stop", "virtualmachines/restart", "virtualmachineinstances/vnc", "virtualmachineinstances/console"]
+    verbs      = ["get", "update"]
+  }
+
+  # VM metrics for Harvester dashboard graphs
+  rules {
+    api_groups = ["subresources.kubevirt.io"]
+    resources  = ["virtualmachineinstances/metrics"]
+    verbs      = ["get"]
+  }
+
+  # Read-only access to available VM images (needed to see disk info in UI)
+  rules {
+    api_groups = ["harvesterhci.io"]
+    resources  = ["virtualmachineimages"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # Service proxy for Harvester UI routing
+  rules {
+    api_groups = [""]
+    resources  = ["services/proxy"]
+    verbs      = ["get"]
+  }
+}
+
+# Cluster-scoped role for SREs who manage RKE2 node capacity.
+# Grants the ability to scale machine pools and patch cluster specs without
+# permission to create new clusters or delete existing ones.
+resource "rancher2_role_template" "cluster_operator" {
+  name        = "cluster-operator"
+  description = "Scale and reconfigure RKE2 machine pools. No permission to create or delete clusters."
+  context     = "cluster"
+
+  # Rancher provisioning v2 cluster object — can edit (scale nodes) but not create/delete.
+  # Machine pool count and nodeConfig live inside the cluster spec.
+  rules {
+    api_groups = ["provisioning.cattle.io"]
+    resources  = ["clusters"]
+    verbs      = ["get", "list", "watch", "update", "patch"]
+  }
+
+  # Read-only view of RKE2 control plane state
+  rules {
+    api_groups = ["rke.cattle.io"]
+    resources  = ["rkecontrolplanes"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # etcd snapshots — read existing + create manual on-demand snapshots
+  rules {
+    api_groups = ["rke.cattle.io"]
+    resources  = ["etcdsnapshots"]
+    verbs      = ["get", "list", "watch", "create"]
+  }
+
+  # CAPI machine deployments and sets — needed to scale node pools
+  rules {
+    api_groups = ["cluster.x-k8s.io"]
+    resources  = ["machinedeployments", "machinesets"]
+    verbs      = ["get", "list", "watch", "update", "patch"]
+  }
+
+  # Rancher management cluster object — read-only (UI navigation, cluster health)
+  rules {
+    api_groups = ["management.cattle.io"]
+    resources  = ["clusters"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
 # Grants read-only visibility into VM status and metrics for the Harvester
 # dashboard. Intentionally excludes all mutating verbs (update, patch, delete)
 # and subresources that control VM power state (start, stop, restart, migrate).

--- a/modules/management/cluster-roles/outputs.tf
+++ b/modules/management/cluster-roles/outputs.tf
@@ -12,3 +12,18 @@ output "network_manager_role_id" {
   value       = rancher2_role_template.network_manager.id
   description = "Role template ID for the network-manager cluster role. Pass to rancher2_cluster_role_template_binding for the DC ops OIDC group."
 }
+
+output "vm_creator_role_id" {
+  value       = rancher2_role_template.vm_creator.id
+  description = "Role template ID for the vm-creator cluster role. Bind at cluster level alongside a project role (vm-manager or project-owner) to allow VM creation."
+}
+
+output "vm_operator_role_id" {
+  value       = rancher2_role_template.vm_operator.id
+  description = "Role template ID for the vm-operator role. Pass to tenant-space module's group_role_bindings for teams that operate but do not provision VMs."
+}
+
+output "cluster_operator_role_id" {
+  value       = rancher2_role_template.cluster_operator.id
+  description = "Role template ID for the cluster-operator cluster role. Pass to rancher2_cluster_role_template_binding for SREs who scale RKE2 node pools."
+}

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -10,7 +10,7 @@ variable "project_name" {
 
 variable "namespaces" {
   type        = list(string)
-  description = "One or more Kubernetes namespace names to create within the project. Must contain at least one unique entry."
+  description = "One or more Kubernetes namespace names to create within the project. At minimum, provide one namespace named after the project — this ensures the namespace dropdown is populated when creating VMs or RKE2 clusters in Rancher/Harvester. All names must be unique RFC 1123 DNS labels (lowercase alphanumeric and hyphens, max 63 chars)."
   validation {
     condition = (
       length(var.namespaces) > 0 &&
@@ -20,7 +20,7 @@ variable "namespaces" {
         can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", ns))
       ])
     )
-    error_message = "All namespace names must be unique, non-empty, at most 63 characters, and match RFC 1123 DNS label format (lowercase alphanumeric and hyphens, must start and end with alphanumeric)."
+    error_message = "At least one namespace is required. All names must be unique, at most 63 characters, and match RFC 1123 DNS label format (lowercase alphanumeric and hyphens, must start and end with alphanumeric)."
   }
 }
 


### PR DESCRIPTION
## Summary

Extends the DC platform RBAC framework (wso2-enterprise/wso2-datacenter-project#73) with three new role templates. Validated in lk-dev against a real Asgardeo OIDC group.

Closes #36

---

## Changes

### `modules/management/cluster-roles` — three new role templates

**`vm-creator`** (cluster context)
Prerequisite for any tenant who creates VMs. VM images, network attachment definitions, and SSH keypairs are stored outside project namespaces — `project-owner` alone leaves all three dropdowns empty. This role provides the minimum cluster-level read to unblock the VM creation flow. Also grants access to Harvester Virtualization Management UI; writes remain scoped to the tenant's project by RBAC.
- `harvesterhci.io/virtualmachineimages` — get, list, watch
- `k8s.cni.cncf.io/network-attachment-definitions` — get, list, watch
- `harvesterhci.io/keypairs` — get, list, watch

**`vm-operator`** (project context)
Power operations and console access only — no create, delete, or migrate.
- `kubevirt.io/virtualmachines`, `virtualmachineinstances` — get, list, watch
- `subresources.kubevirt.io` start/stop/restart, vnc/console — get, update
- `subresources.kubevirt.io/metrics` — get
- `harvesterhci.io/virtualmachineimages` — get, list, watch
- `services/proxy` — get

**`cluster-operator`** (cluster context)
Scale and reconfigure RKE2 machine pools without cluster create/delete access. Includes manual etcd snapshot creation.
- `provisioning.cattle.io/clusters` — get, list, watch, update, patch
- `rke.cattle.io/rkecontrolplanes` — get, list, watch
- `rke.cattle.io/etcdsnapshots` — get, list, watch, create
- `cluster.x-k8s.io/machinedeployments`, `machinesets` — get, list, watch, update, patch
- `management.cattle.io/clusters` — get, list, watch

New outputs: `vm_creator_role_id`, `vm_operator_role_id`, `cluster_operator_role_id`

### `modules/management/tenant-space` — namespace description update

Updated `namespaces` description to document the convention: always provide at least one namespace named after the project. This ensures the namespace dropdown is populated when creating VMs or RKE2 clusters in Rancher/Harvester — without it, users hit a dead end and must manually create a namespace in Harvester before proceeding.

---

## Standard tenant setup

```hcl
module "cluster_roles" {
  source = "github.com/wso2/open-cloud-datacenter//modules/management/cluster-roles?ref=v0.5.8"
}

module "choreo_sre_space" {
  source       = "github.com/wso2/open-cloud-datacenter//modules/management/tenant-space?ref=v0.5.8"
  cluster_id   = local.harvester_cluster_id
  project_name = "choreo-sre"
  namespaces   = ["choreo-sre"]  # default namespace, team creates more as needed
  cpu_limit    = "8"
  memory_limit = "32Gi"

  group_role_bindings = [
    { group_principal_id = "genericoidc_group://choreo-sre", role_template_id = "project-owner" },
    { group_principal_id = "genericoidc_group://choreo-sre", role_template_id = module.cluster_roles.vm_manager_role_id },
  ]
  depends_on = [module.cluster_roles]
}

# Cluster-level binding — separate resource, always alongside the module call
resource "rancher2_cluster_role_template_binding" "choreo_sre_vm_creator" {
  name               = "choreo-sre-vm-creator"
  cluster_id         = local.harvester_cluster_id
  role_template_id   = module.cluster_roles.vm_creator_role_id
  group_principal_id = "genericoidc_group://choreo-sre"
  depends_on         = [module.cluster_roles]
}
```

## Test results

Verified in lk-dev against a real Asgardeo OIDC group (`dc-ops`):
- ✅ User sees only the project their group is bound to
- ✅ VM image, network, and keypair dropdowns populate after `vm-creator` binding
- ✅ Access to Harvester Virtualization Management confirmed; writes scoped to project
- ✅ Quota enforcement: VM spec exceeding project CPU/memory limit fails to launch
- ✅ Unbound project is invisible to the group member

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three cluster role templates (VM Creator, VM Operator, Cluster Operator) to provide granular operational permissions and exported their IDs for integration.
* **Documentation**
  * Clarified tenant-space namespace messaging to require at least one namespace and suggest using a project-named namespace; validation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->