### PR TITLE
Add VyOS multi-tenant gateway modules

### DIFF
--- a/modules/bootstrap/vyos/main.tf
+++ b/modules/bootstrap/vyos/main.tf
@@ -1,0 +1,109 @@
+# ── VyOS bootstrap module ─────────────────────────────────────────────────────
+#
+# Deploys the VyOS gateway VM on Harvester. Designed for a two-apply workflow:
+#
+#   Apply 1 (iso_installed = false):
+#     - Creates image, trunk network, and VM with ISO CDROM (boot_order=1)
+#     - Operator opens Harvester console → logs in → runs 'install image'
+#     - Operator reboots the VM
+#
+#   Apply 2 (iso_installed = true):
+#     - Removes the CDROM disk; rootdisk becomes the sole boot device
+#     - VM restarts from installed disk
+#
+#   After Apply 2: use the vyos-tenant module (REST API) for configuration.
+#
+# VyOS does not ship qemu-guest-agent — the VM IP will not appear in Harvester
+# UI. Use the known static IP configured post-install on eth0.
+# ─────────────────────────────────────────────────────────────────────────────
+
+locals {
+  trunk_network_namespace = coalesce(var.trunk_network_namespace, var.vm_namespace)
+  trunk_network_name      = "${var.vm_name}-eth1-trunk"
+}
+
+# ── VyOS ISO image ────────────────────────────────────────────────────────────
+
+resource "harvester_image" "vyos" {
+  name         = var.image_name
+  display_name = "VyOS Rolling"
+  namespace    = var.image_namespace
+  source_type  = "download"
+  url          = var.image_url
+
+  lifecycle {
+    # URL changes between nightly builds; don't force image re-download on update
+    ignore_changes = [url]
+  }
+}
+
+# ── eth1 trunk network ────────────────────────────────────────────────────────
+# eth1 is a raw bridge port — no VLAN filter. Harvester passes all tagged frames
+# to VyOS, which handles 802.1Q sub-interfaces (vif) per tenant VLAN.
+#
+# route_mode = "manual" is required by the Harvester provider when route_cidr
+# is specified. The CIDR here is informational only; routing is done by VyOS.
+# Using 0.0.0.0/0 to indicate "all tenant subnets pass through this trunk".
+
+resource "harvester_network" "eth1_trunk" {
+  name                 = local.trunk_network_name
+  namespace            = local.trunk_network_namespace
+  vlan_id              = 0
+  cluster_network_name = var.cluster_network_name
+  route_mode           = "manual"
+  route_cidr           = "10.0.0.0/8"
+  route_gateway        = "0.0.0.0"
+}
+
+# ── VyOS gateway VM ───────────────────────────────────────────────────────────
+
+resource "harvester_virtualmachine" "vyos" {
+  name                 = var.vm_name
+  namespace            = var.vm_namespace
+  cpu                  = var.cpu
+  memory               = var.memory
+  restart_after_update = true
+  run_strategy         = "RerunOnFailure"
+  machine_type         = "q35"
+
+  # eth0 — DigiOps/uplink NIC (VLAN 700). Static IP configured post-install.
+  network_interface {
+    name         = "eth0"
+    type         = "bridge"
+    network_name = var.uplink_network_name
+  }
+
+  # eth1 — tenant trunk NIC. VyOS creates 802.1Q vif sub-interfaces per tenant.
+  network_interface {
+    name         = "eth1"
+    type         = "bridge"
+    network_name = "${local.trunk_network_namespace}/${harvester_network.eth1_trunk.name}"
+  }
+
+  # Root disk — VyOS is installed here via 'install image' from the ISO.
+  disk {
+    name        = "rootdisk"
+    type        = "disk"
+    size        = var.disk_size
+    bus         = "virtio"
+    boot_order  = var.iso_installed ? 1 : 2
+    auto_delete = true
+  }
+
+  # CDROM — present only before iso_installed = true.
+  # After the second apply this disk block disappears, detaching the CDROM.
+  dynamic "disk" {
+    for_each = var.iso_installed ? [] : [1]
+    content {
+      name        = "cdrom"
+      type        = "cd-rom"
+      size        = "1Gi"
+      bus         = "sata"
+      boot_order  = 1
+      image       = harvester_image.vyos.id
+      auto_delete = true
+    }
+  }
+
+  depends_on = [harvester_network.eth1_trunk]
+}

--- a/modules/bootstrap/vyos/main.tf
+++ b/modules/bootstrap/vyos/main.tf
@@ -1,6 +1,10 @@
 # ── VyOS bootstrap module ─────────────────────────────────────────────────────
 #
-# Deploys the VyOS gateway VM on Harvester. Designed for a two-apply workflow:
+# Deploys a VyOS gateway VM on Harvester with two NICs:
+#   eth0 — uplink to external network (static IP set manually post-install)
+#   eth1 — trunk port for tenant VLANs (VyOS manages 802.1Q vif sub-interfaces)
+#
+# Two-apply workflow required (VyOS only ships as ISO; no cloud-init qcow2):
 #
 #   Apply 1 (iso_installed = false):
 #     - Creates image, trunk network, and VM with ISO CDROM (boot_order=1)
@@ -11,10 +15,10 @@
 #     - Removes the CDROM disk; rootdisk becomes the sole boot device
 #     - VM restarts from installed disk
 #
-#   After Apply 2: use the vyos-tenant module (REST API) for configuration.
+#   After Apply 2: use the vyos-tenant module to configure VyOS via REST API.
 #
-# VyOS does not ship qemu-guest-agent — the VM IP will not appear in Harvester
-# UI. Use the known static IP configured post-install on eth0.
+# Note: VyOS does not ship qemu-guest-agent — VM IP will not appear in the
+# Harvester UI. Use the static IP set manually on eth0 post-install.
 # ─────────────────────────────────────────────────────────────────────────────
 
 locals {
@@ -42,8 +46,7 @@ resource "harvester_image" "vyos" {
 # to VyOS, which handles 802.1Q sub-interfaces (vif) per tenant VLAN.
 #
 # route_mode = "manual" is required by the Harvester provider when route_cidr
-# is specified. The CIDR here is informational only; routing is done by VyOS.
-# Using 0.0.0.0/0 to indicate "all tenant subnets pass through this trunk".
+# is specified. The CIDR is informational only; routing is handled by VyOS.
 
 resource "harvester_network" "eth1_trunk" {
   name                 = local.trunk_network_name
@@ -66,7 +69,7 @@ resource "harvester_virtualmachine" "vyos" {
   run_strategy         = "RerunOnFailure"
   machine_type         = "q35"
 
-  # eth0 — DigiOps/uplink NIC (VLAN 700). Static IP configured post-install.
+  # eth0 — uplink NIC. Static IP set manually post-install.
   network_interface {
     name         = "eth0"
     type         = "bridge"

--- a/modules/bootstrap/vyos/main.tf
+++ b/modules/bootstrap/vyos/main.tf
@@ -46,7 +46,8 @@ resource "harvester_image" "vyos" {
 # to VyOS, which handles 802.1Q sub-interfaces (vif) per tenant VLAN.
 #
 # route_mode = "manual" is required by the Harvester provider when route_cidr
-# is specified. The CIDR is informational only; routing is handled by VyOS.
+# is specified. The CIDR (10.0.0.0/8) is informational only; routing is
+# handled by VyOS sub-interfaces, not by this NAD.
 
 resource "harvester_network" "eth1_trunk" {
   name                 = local.trunk_network_name

--- a/modules/bootstrap/vyos/outputs.tf
+++ b/modules/bootstrap/vyos/outputs.tf
@@ -1,0 +1,29 @@
+output "vm_name" {
+  value       = harvester_virtualmachine.vyos.name
+  description = "VyOS VM name. Open the Harvester console for this VM to install VyOS from ISO on first deploy."
+}
+
+output "vm_namespace" {
+  value       = harvester_virtualmachine.vyos.namespace
+  description = "Harvester namespace the VyOS VM is deployed in."
+}
+
+output "trunk_network_name" {
+  value       = harvester_network.eth1_trunk.name
+  description = "Name of the eth1 trunk harvester_network resource."
+}
+
+output "trunk_network_namespace" {
+  value       = harvester_network.eth1_trunk.namespace
+  description = "Namespace of the eth1 trunk harvester_network resource."
+}
+
+output "trunk_network_ref" {
+  value       = "${harvester_network.eth1_trunk.namespace}/${harvester_network.eth1_trunk.name}"
+  description = "Full network ref (namespace/name) for the eth1 trunk network."
+}
+
+output "image_id" {
+  value       = harvester_image.vyos.id
+  description = "Harvester image ID for the VyOS ISO."
+}

--- a/modules/bootstrap/vyos/variables.tf
+++ b/modules/bootstrap/vyos/variables.tf
@@ -1,0 +1,81 @@
+# ── VyOS image ────────────────────────────────────────────────────────────────
+
+variable "image_name" {
+  type        = string
+  description = "Name for the VyOS image resource in Harvester."
+  default     = "vyos-rolling"
+}
+
+variable "image_namespace" {
+  type        = string
+  description = "Namespace for the VyOS image. Use 'harvester-public' to share across all namespaces."
+  default     = "harvester-public"
+}
+
+variable "image_url" {
+  type        = string
+  description = "Download URL for the VyOS rolling ISO. Get the latest from https://github.com/vyos/vyos-nightly-build/releases — use the *-generic-amd64.iso file."
+}
+
+# ── VyOS VM ───────────────────────────────────────────────────────────────────
+
+variable "vm_name" {
+  type        = string
+  description = "Name for the VyOS gateway VM."
+  default     = "vyos-gw"
+}
+
+variable "vm_namespace" {
+  type        = string
+  description = "Harvester namespace to deploy the VyOS VM into."
+  default     = "default"
+}
+
+variable "cpu" {
+  type        = number
+  description = "Number of vCPUs for the VyOS VM."
+  default     = 2
+}
+
+variable "memory" {
+  type        = string
+  description = "Memory for the VyOS VM (e.g. '2Gi')."
+  default     = "2Gi"
+}
+
+variable "disk_size" {
+  type        = string
+  description = "Root disk size. VyOS install requires at least 10Gi."
+  default     = "20Gi"
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+variable "uplink_network_name" {
+  type        = string
+  description = "Full Harvester network ref for eth0 (the DigiOps/uplink NIC), e.g. 'default/vm-net-100'."
+}
+
+variable "cluster_network_name" {
+  type        = string
+  description = "Harvester cluster network name for eth1 (the trunk NIC that carries tenant VLANs). Must be a trunk-capable cluster network, e.g. 'vm-network'."
+  default     = "vm-network"
+}
+
+variable "trunk_network_namespace" {
+  type        = string
+  description = "Namespace for the trunk harvester_network resource (eth1). Defaults to the VM namespace."
+  default     = null
+}
+
+# ── Phase control ─────────────────────────────────────────────────────────────
+
+variable "iso_installed" {
+  type        = bool
+  description = <<-EOT
+    Set to false on first apply — deploys the VM with the ISO as CDROM (boot_order=1).
+    After manually running 'install image' and rebooting via Harvester console, set to
+    true and re-apply — removes the CDROM and sets the rootdisk as the only boot device.
+  EOT
+  default     = false
+}

--- a/modules/bootstrap/vyos/variables.tf
+++ b/modules/bootstrap/vyos/variables.tf
@@ -53,13 +53,12 @@ variable "disk_size" {
 
 variable "uplink_network_name" {
   type        = string
-  description = "Full Harvester network ref for eth0 (the DigiOps/uplink NIC), e.g. 'default/vm-net-100'."
+  description = "Full Harvester network ref for eth0 (the external uplink NIC), e.g. 'default/uplink-network'."
 }
 
 variable "cluster_network_name" {
   type        = string
-  description = "Harvester cluster network name for eth1 (the trunk NIC that carries tenant VLANs). Must be a trunk-capable cluster network, e.g. 'vm-network'."
-  default     = "vm-network"
+  description = "Harvester cluster network name for eth1 (the trunk NIC that carries tenant VLANs). Must be a trunk-capable cluster network."
 }
 
 variable "trunk_network_namespace" {

--- a/modules/bootstrap/vyos/versions.tf
+++ b/modules/bootstrap/vyos/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    harvester = {
+      source  = "harvester/harvester"
+      version = "~> 1.7"
+    }
+  }
+}

--- a/modules/network/vyos-tenant/main.tf
+++ b/modules/network/vyos-tenant/main.tf
@@ -37,6 +37,13 @@ locals {
   vif_path   = "interfaces ethernet eth1 vif ${var.vlan_id}"
 }
 
+check "dhcp_offset_order" {
+  assert {
+    condition     = var.dhcp_range_start_offset <= var.dhcp_range_end_offset
+    error_message = "dhcp_range_start_offset (${var.dhcp_range_start_offset}) must be less than or equal to dhcp_range_end_offset (${var.dhcp_range_end_offset})."
+  }
+}
+
 # ── VyOS configuration via HTTPS REST API ─────────────────────────────────────
 
 # eth1.vlan_id sub-interface — tenant gateway
@@ -55,10 +62,10 @@ resource "vyos_config_block_tree" "dhcp" {
 
   configs = {
     # subnet-id equals vlan_id — traceable 1:1 mapping
-    "subnet ${local.subnet} subnet-id"                 = tostring(var.vlan_id)
-    "subnet ${local.subnet} option default-router"     = local.gateway_ip
-    "subnet ${local.subnet} range 0 start"             = local.dhcp_start
-    "subnet ${local.subnet} range 0 stop"              = local.dhcp_stop
+    "subnet ${local.subnet} subnet-id"             = tostring(var.vlan_id)
+    "subnet ${local.subnet} option default-router" = local.gateway_ip
+    "subnet ${local.subnet} range 0 start"         = local.dhcp_start
+    "subnet ${local.subnet} range 0 stop"          = local.dhcp_stop
   }
 
   depends_on = [vyos_config_block_tree.vif]

--- a/modules/network/vyos-tenant/main.tf
+++ b/modules/network/vyos-tenant/main.tf
@@ -1,0 +1,109 @@
+# ── vyos-tenant module ────────────────────────────────────────────────────────
+#
+# Provisions one tenant VLAN on a running VyOS gateway via the HTTPS REST API.
+# One call to this module = one tenant VLAN. Add more tenants by calling it
+# again with a different vlan_id.
+#
+# IPAM:
+#   subnet   = cidrsubnet("10.0.0.0/8", 15, vlan_id - 1000)
+#   gateway  = cidrhost(subnet, 1)          → e.g. 10.0.0.1 for VLAN 1000
+#   subnet-id = vlan_id                     → stable, traceable key
+#
+# Prerequisites:
+#   1. VyOS installed from ISO and rebooted (bootstrap module phase 2 complete)
+#   2. VyOS HTTPS API enabled manually post-install:
+#        configure
+#        set service https api keys id terraform key '<api_key>'
+#        set service https api allow-client address 0.0.0.0/0
+#        set service https certificates system-generated-certificate
+#        commit; save
+#   3. VyOS eth0 and static route configured (see VYOS-CONFIG-REFERENCE.md)
+# ─────────────────────────────────────────────────────────────────────────────
+
+locals {
+  # IPAM — cidrsubnet("10.0.0.0/8", 15, vlan_id - 1000)
+  # /8 + 15 bits = /23 per tenant; index = vlan_id - 1000
+  subnet       = cidrsubnet("10.0.0.0/8", 15, var.vlan_id - 1000)
+  gateway_ip   = cidrhost(local.subnet, 1)
+  gateway_cidr = "${local.gateway_ip}/${split("/", local.subnet)[1]}"
+
+  # DHCP range — offsets from subnet base
+  subnet_base = split("/", local.subnet)[0]
+
+  dhcp_start = cidrhost(local.subnet, var.dhcp_range_start_offset)
+  dhcp_stop  = cidrhost(local.subnet, var.dhcp_range_end_offset)
+
+  vlan_label = "VLAN${var.vlan_id}"
+  vif_path   = "interfaces ethernet eth1 vif ${var.vlan_id}"
+}
+
+# ── VyOS configuration via HTTPS REST API ─────────────────────────────────────
+
+# eth1.vlan_id sub-interface — tenant gateway
+resource "vyos_config_block_tree" "vif" {
+  path = local.vif_path
+
+  configs = {
+    "address"     = local.gateway_cidr
+    "description" = "${var.tenant_name}-${local.vlan_label}"
+  }
+}
+
+# DHCP shared network for this tenant
+resource "vyos_config_block_tree" "dhcp" {
+  path = "service dhcp-server shared-network-name ${local.vlan_label}"
+
+  configs = {
+    # subnet-id equals vlan_id — traceable 1:1 mapping
+    "subnet ${local.subnet} subnet-id"                 = tostring(var.vlan_id)
+    "subnet ${local.subnet} option default-router"     = local.gateway_ip
+    "subnet ${local.subnet} range 0 start"             = local.dhcp_start
+    "subnet ${local.subnet} range 0 stop"              = local.dhcp_stop
+  }
+
+  depends_on = [vyos_config_block_tree.vif]
+}
+
+# DHCP DNS option — each server as a separate config entry
+resource "vyos_config_block_tree" "dhcp_dns" {
+  for_each = toset(var.dns_servers)
+
+  path = "service dhcp-server shared-network-name ${local.vlan_label} subnet ${local.subnet} option"
+
+  configs = {
+    "name-server" = each.value
+  }
+
+  depends_on = [vyos_config_block_tree.dhcp]
+}
+
+# NAT source rule — masquerade tenant traffic out eth0 (internet egress)
+# Rule number = vlan_id for traceability
+resource "vyos_config_block_tree" "nat_egress" {
+  path = "nat source rule ${var.vlan_id}"
+
+  configs = {
+    "outbound-interface name" = "eth0"
+    "source address"          = local.subnet
+    "translation address"     = "masquerade"
+  }
+}
+
+# ── Harvester network resource ────────────────────────────────────────────────
+# vlan_id MUST match the VyOS vif tag above — this is what wires L2 frames
+# from tenant VMs to the correct VyOS sub-interface.
+
+resource "harvester_network" "tenant" {
+  name                 = "${var.tenant_name}-${lower(local.vlan_label)}"
+  namespace            = var.network_namespace
+  vlan_id              = var.vlan_id
+  cluster_network_name = var.cluster_network_name
+  route_mode           = "manual"
+  route_cidr           = local.subnet
+  route_gateway        = local.gateway_ip
+
+  depends_on = [
+    vyos_config_block_tree.vif,
+    vyos_config_block_tree.dhcp,
+  ]
+}

--- a/modules/network/vyos-tenant/main.tf
+++ b/modules/network/vyos-tenant/main.tf
@@ -5,19 +5,19 @@
 # again with a different vlan_id.
 #
 # IPAM:
-#   subnet   = cidrsubnet("10.0.0.0/8", 15, vlan_id - 1000)
-#   gateway  = cidrhost(subnet, 1)          → e.g. 10.0.0.1 for VLAN 1000
-#   subnet-id = vlan_id                     → stable, traceable key
+#   subnet    = cidrsubnet("10.0.0.0/8", 15, vlan_id - 1000)
+#   gateway   = cidrhost(subnet, 1)   e.g. 10.0.0.1 for VLAN 1000
+#   subnet-id = vlan_id               stable, traceable 1:1 key
 #
 # Prerequisites:
-#   1. VyOS installed from ISO and rebooted (bootstrap module phase 2 complete)
+#   1. VyOS installed from ISO and rebooted (bootstrap module, phase 2)
 #   2. VyOS HTTPS API enabled manually post-install:
 #        configure
 #        set service https api keys id terraform key '<api_key>'
 #        set service https api allow-client address 0.0.0.0/0
 #        set service https certificates system-generated-certificate
 #        commit; save
-#   3. VyOS eth0 and static route configured (see VYOS-CONFIG-REFERENCE.md)
+#   3. VyOS uplink interface (eth0) and default route configured
 # ─────────────────────────────────────────────────────────────────────────────
 
 locals {
@@ -77,7 +77,7 @@ resource "vyos_config_block_tree" "dhcp_dns" {
   depends_on = [vyos_config_block_tree.dhcp]
 }
 
-# NAT source rule — masquerade tenant traffic out eth0 (internet egress)
+# NAT source rule — masquerade tenant traffic out the uplink interface (internet egress)
 # Rule number = vlan_id for traceability
 resource "vyos_config_block_tree" "nat_egress" {
   path = "nat source rule ${var.vlan_id}"

--- a/modules/network/vyos-tenant/main.tf
+++ b/modules/network/vyos-tenant/main.tf
@@ -14,7 +14,7 @@
 #   2. VyOS HTTPS API enabled manually post-install:
 #        configure
 #        set service https api keys id terraform key '<api_key>'
-#        set service https api allow-client address 0.0.0.0/0
+#        set service https api allow-client address <management_cidr>
 #        set service https certificates system-generated-certificate
 #        commit; save
 #   3. VyOS uplink interface (eth0) and default route configured
@@ -64,14 +64,14 @@ resource "vyos_config_block_tree" "dhcp" {
   depends_on = [vyos_config_block_tree.vif]
 }
 
-# DHCP DNS option — each server as a separate config entry
+# DHCP DNS options — all name-server entries in a single resource.
+# Each server IP is embedded in the config key so the map keys are unique
+# and the provider sees one authoritative config block for this path.
 resource "vyos_config_block_tree" "dhcp_dns" {
-  for_each = toset(var.dns_servers)
-
   path = "service dhcp-server shared-network-name ${local.vlan_label} subnet ${local.subnet} option"
 
   configs = {
-    "name-server" = each.value
+    for srv in var.dns_servers : "name-server ${srv}" => ""
   }
 
   depends_on = [vyos_config_block_tree.dhcp]

--- a/modules/network/vyos-tenant/outputs.tf
+++ b/modules/network/vyos-tenant/outputs.tf
@@ -1,0 +1,34 @@
+output "vlan_id" {
+  value       = var.vlan_id
+  description = "VLAN ID for this tenant."
+}
+
+output "subnet" {
+  value       = local.subnet
+  description = "Tenant subnet in CIDR notation, e.g. '10.0.0.0/23'."
+}
+
+output "gateway_ip" {
+  value       = local.gateway_ip
+  description = "Tenant gateway IP (VyOS vif address), e.g. '10.0.0.1'."
+}
+
+output "dhcp_range" {
+  value       = "${local.dhcp_start}–${local.dhcp_stop}"
+  description = "DHCP pool range for tenant VMs."
+}
+
+output "network_name" {
+  value       = harvester_network.tenant.name
+  description = "Harvester network resource name."
+}
+
+output "network_namespace" {
+  value       = harvester_network.tenant.namespace
+  description = "Harvester network resource namespace."
+}
+
+output "network_ref" {
+  value       = "${harvester_network.tenant.namespace}/${harvester_network.tenant.name}"
+  description = "Full network ref (namespace/name) to attach tenant VMs."
+}

--- a/modules/network/vyos-tenant/outputs.tf
+++ b/modules/network/vyos-tenant/outputs.tf
@@ -14,7 +14,7 @@ output "gateway_ip" {
 }
 
 output "dhcp_range" {
-  value       = "${local.dhcp_start}–${local.dhcp_stop}"
+  value       = "${local.dhcp_start}-${local.dhcp_stop}"
   description = "DHCP pool range for tenant VMs."
 }
 

--- a/modules/network/vyos-tenant/variables.tf
+++ b/modules/network/vyos-tenant/variables.tf
@@ -1,0 +1,69 @@
+# ── VyOS connection ───────────────────────────────────────────────────────────
+
+variable "vyos_endpoint" {
+  type        = string
+  description = "VyOS HTTPS API endpoint, e.g. 'https://172.22.100.50'."
+}
+
+variable "vyos_api_key" {
+  type        = string
+  description = "VyOS HTTPS API key (set during post-install manual config)."
+  sensitive   = true
+}
+
+# ── Tenant identity ───────────────────────────────────────────────────────────
+
+variable "tenant_name" {
+  type        = string
+  description = "Short tenant name used for DHCP shared-network label, e.g. 'tenant-a'."
+}
+
+variable "vlan_id" {
+  type        = number
+  description = <<-EOT
+    VLAN ID for this tenant (1000–2999). Determines:
+      - VyOS sub-interface: eth1 vif <vlan_id>
+      - Subnet: cidrsubnet("10.0.0.0/8", 15, vlan_id - 1000)
+      - Kea DHCP subnet-id: vlan_id
+      - NAT source rule number: vlan_id
+    Must match the harvester_network vlan_id for the tenant exactly.
+  EOT
+
+  validation {
+    condition     = var.vlan_id >= 1000 && var.vlan_id <= 2999
+    error_message = "vlan_id must be between 1000 and 2999."
+  }
+}
+
+# ── Network config ────────────────────────────────────────────────────────────
+
+variable "dhcp_range_start_offset" {
+  type        = number
+  description = "Offset from the subnet base for the DHCP pool start address. Default 10 → 10.0.x.10."
+  default     = 10
+}
+
+variable "dhcp_range_end_offset" {
+  type        = number
+  description = "Offset from the subnet base for the DHCP pool end address. Default 456 → 10.0.x.200 in a /23 (0+456=456 → .1.200 in the second /24)."
+  default     = 456
+}
+
+variable "dns_servers" {
+  type        = list(string)
+  description = "DNS servers to hand out via DHCP."
+  default     = ["8.8.8.8", "8.8.4.4"]
+}
+
+# ── Harvester network ─────────────────────────────────────────────────────────
+
+variable "network_namespace" {
+  type        = string
+  description = "Harvester namespace for the harvester_network resource (the tenant's network namespace, e.g. 'tenant-a-net')."
+}
+
+variable "cluster_network_name" {
+  type        = string
+  description = "Harvester cluster network name carrying the tenant VLANs, e.g. 'vm-network'."
+  default     = "vm-network"
+}

--- a/modules/network/vyos-tenant/variables.tf
+++ b/modules/network/vyos-tenant/variables.tf
@@ -64,6 +64,5 @@ variable "network_namespace" {
 
 variable "cluster_network_name" {
   type        = string
-  description = "Harvester cluster network name carrying the tenant VLANs, e.g. 'vm-network'."
-  default     = "vm-network"
+  description = "Harvester cluster network name carrying the tenant VLANs. Must match the cluster network used by the VyOS eth1 trunk."
 }

--- a/modules/network/vyos-tenant/variables.tf
+++ b/modules/network/vyos-tenant/variables.tf
@@ -41,12 +41,22 @@ variable "dhcp_range_start_offset" {
   type        = number
   description = "Offset from the subnet base for the DHCP pool start address. Default 10 → 10.0.x.10."
   default     = 10
+
+  validation {
+    condition     = var.dhcp_range_start_offset >= 2 && var.dhcp_range_start_offset <= 510
+    error_message = "dhcp_range_start_offset must be between 2 and 510 (offset 1 is reserved for the gateway)."
+  }
 }
 
 variable "dhcp_range_end_offset" {
   type        = number
   description = "Offset from the subnet base for the DHCP pool end address. Default 456 → 10.0.x.200 in a /23 (0+456=456 → .1.200 in the second /24)."
   default     = 456
+
+  validation {
+    condition     = var.dhcp_range_end_offset >= 2 && var.dhcp_range_end_offset <= 510
+    error_message = "dhcp_range_end_offset must be between 2 and 510."
+  }
 }
 
 variable "dns_servers" {

--- a/modules/network/vyos-tenant/versions.tf
+++ b/modules/network/vyos-tenant/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    harvester = {
+      source  = "harvester/harvester"
+      version = "~> 1.7"
+    }
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = "~> 13.1"
+    }
+    vyos = {
+      source  = "thomasfinstad/vyos-rolling"
+      version = "~> 19.1"
+    }
+  }
+}

--- a/modules/network/vyos-tenant/versions.tf
+++ b/modules/network/vyos-tenant/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     vyos = {
       source  = "thomasfinstad/vyos-rolling"
-      version = "~> 19.1"
+      version = "~> 19.0"
     }
   }
 }

--- a/modules/network/vyos-tenant/versions.tf
+++ b/modules/network/vyos-tenant/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "harvester/harvester"
       version = "~> 1.7"
     }
-    rancher2 = {
-      source  = "rancher/rancher2"
-      version = "~> 13.1"
-    }
     vyos = {
       source  = "thomasfinstad/vyos-rolling"
       version = "~> 19.1"


### PR DESCRIPTION
## Summary

- Adds `modules/bootstrap/vyos/` — deploys a VyOS gateway VM on Harvester with a two-apply ISO install workflow
- Adds `modules/network/vyos-tenant/` — provisions one tenant VLAN on VyOS via HTTPS REST API (thomasfinstad/vyos-rolling provider), creating a vif sub-interface, Kea DHCP pool, NAT masquerade rule, and matching `harvester_network` resource

## Architecture

VyOS acts as a multi-tenant gateway: eth0 connects to the external uplink network, eth1 is a trunk port for all tenant VLANs. Each tenant VLAN is a 802.1Q vif sub-interface on eth1. One call to `vyos-tenant` = one tenant provisioned end-to-end — fully automated.

IPAM: `cidrsubnet("10.0.0.0/8", 15, vlan_id - 1000)` gives a /23 per tenant (supports 16,384 tenants). `subnet-id == vlan_id` across all resources for a traceable 1:1 mapping.

## Consumer usage

```hcl
module "vyos" {
  source               = "github.com/wso2/open-cloud-datacenter//modules/bootstrap/vyos?ref=vX.Y.Z"
  image_url            = var.vyos_image_url
  uplink_network_name  = "<namespace>/<uplink-network>"
  cluster_network_name = "<trunk-cluster-network>"
  iso_installed        = var.iso_installed  # false → first apply; true → second apply
}

module "tenant_a" {
  source               = "github.com/wso2/open-cloud-datacenter//modules/network/vyos-tenant?ref=vX.Y.Z"
  vyos_endpoint        = "https://<vyos-ip>"
  vyos_api_key         = var.vyos_api_key
  tenant_name          = "tenant-a"
  vlan_id              = 1000
  network_namespace    = "tenant-a-net"
  cluster_network_name = "<trunk-cluster-network>"
}
```

## Deployment flow

```
apply (iso_installed=false)  → VM boots from ISO
  manual: install image, reboot
apply (iso_installed=true)   → CDROM removed, boots from disk
  manual: configure eth0, static route, enable HTTPS API
apply vyos-tenant module     → vif + DHCP + NAT + harvester_network
```

## Test plan

- [ ] `terraform validate` on both modules
- [ ] `terraform fmt -recursive` passes
- [ ] CodeRabbit review addressed
- [ ] End-to-end integration test: tenant VM receives DHCP lease, internet via NAT confirmed

Closes #77
Closes #78
Part of #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VyOS gateway VM provisioning module supporting flexible VM configuration, two-phase installation workflows, and dual network interfaces.
  * Added tenant network provisioning module with automated VLAN, DHCP server, and network address translation setup capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->