### PR TITLE
Ignore cloudinit changes after VM is provisioned

### DIFF
--- a/modules/workloads/vm/main.tf
+++ b/modules/workloads/vm/main.tf
@@ -54,4 +54,12 @@ resource "harvester_virtualmachine" "this" {
       network_data = var.network_data
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # cloud-init runs only on first boot; template changes after provisioning
+      # have no effect and should not trigger a VM restart.
+      cloudinit,
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `lifecycle { ignore_changes = [cloudinit] }` to the `harvester_virtualmachine` resource
- cloud-init runs only on first boot — any subsequent change to `user_data` (template reformats, indentation fixes, key rotation) has no runtime effect but previously triggered a VM restart

## Test plan

- [ ] `terraform plan` on an existing VM shows no changes when `user_data` template is modified
- [ ] New VMs still receive correct cloud-init on first boot

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated VM resource configuration to prevent unnecessary redeployment when cloud-init configuration changes after initial provisioning, improving stability and reducing unintended infrastructure updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->