### PR TITLE
Add optional management NIC and fix disk lifecycle in vyos module

### DIFF
--- a/modules/bootstrap/vyos/main.tf
+++ b/modules/bootstrap/vyos/main.tf
@@ -121,11 +121,11 @@ resource "harvester_virtualmachine" "vyos" {
     }
   }
 
-  # Ignore disk changes after initial provisioning. Harvester may flip
-  # auto_delete on the rootdisk after the CDROM is removed, causing a
-  # perpetual diff. The disk content is not managed by Terraform.
+  # Harvester may flip auto_delete on the rootdisk after the CDROM is
+  # removed, causing a perpetual diff. Ignore only that attribute so all
+  # other disk config changes (size, bus, etc.) remain Terraform-managed.
   lifecycle {
-    ignore_changes = [disk]
+    ignore_changes = [disk[0].auto_delete]
   }
 
   depends_on = [harvester_network.eth1_trunk]

--- a/modules/bootstrap/vyos/main.tf
+++ b/modules/bootstrap/vyos/main.tf
@@ -84,6 +84,18 @@ resource "harvester_virtualmachine" "vyos" {
     network_name = "${local.trunk_network_namespace}/${harvester_network.eth1_trunk.name}"
   }
 
+  # eth2 — optional management NIC. Attaches VyOS to the Harvester management
+  # cluster network so in-cluster processes (e.g. DHCP reconciler pods with
+  # hostNetwork) can reach the VyOS HTTPS API at a stable management IP.
+  dynamic "network_interface" {
+    for_each = var.management_network_name != null ? [1] : []
+    content {
+      name         = "eth2"
+      type         = "bridge"
+      network_name = var.management_network_name
+    }
+  }
+
   # Root disk — VyOS is installed here via 'install image' from the ISO.
   disk {
     name        = "rootdisk"
@@ -107,6 +119,13 @@ resource "harvester_virtualmachine" "vyos" {
       image       = harvester_image.vyos.id
       auto_delete = true
     }
+  }
+
+  # Ignore disk changes after initial provisioning. Harvester may flip
+  # auto_delete on the rootdisk after the CDROM is removed, causing a
+  # perpetual diff. The disk content is not managed by Terraform.
+  lifecycle {
+    ignore_changes = [disk]
   }
 
   depends_on = [harvester_network.eth1_trunk]

--- a/modules/bootstrap/vyos/variables.tf
+++ b/modules/bootstrap/vyos/variables.tf
@@ -71,6 +71,13 @@ variable "management_network_name" {
   type        = string
   description = "Full Harvester network ref for the optional eth2 management NIC, e.g. 'default/vyos-mgmt'. When set, attaches a third NIC on the Harvester management cluster network so in-cluster processes can reach the VyOS HTTPS API without routing through the external uplink."
   default     = null
+  validation {
+    condition = var.management_network_name == null || (
+      trimspace(var.management_network_name) != "" &&
+      can(regex("^[^/]+/[^/]+$", var.management_network_name))
+    )
+    error_message = "management_network_name must be null or in 'namespace/name' format (e.g. 'default/vyos-mgmt')."
+  }
 }
 
 # ── Phase control ─────────────────────────────────────────────────────────────

--- a/modules/bootstrap/vyos/variables.tf
+++ b/modules/bootstrap/vyos/variables.tf
@@ -67,6 +67,12 @@ variable "trunk_network_namespace" {
   default     = null
 }
 
+variable "management_network_name" {
+  type        = string
+  description = "Full Harvester network ref for the optional eth2 management NIC, e.g. 'default/vyos-mgmt'. When set, attaches a third NIC on the Harvester management cluster network so in-cluster processes can reach the VyOS HTTPS API without routing through the external uplink."
+  default     = null
+}
+
 # ── Phase control ─────────────────────────────────────────────────────────────
 
 variable "iso_installed" {


### PR DESCRIPTION
## Summary

- Adds optional `management_network_name` variable for an eth2 NIC on the Harvester management cluster network (`mgmt-br`). When set, in-cluster processes (e.g. DHCP reconciler pods with `hostNetwork`) can reach the VyOS HTTPS API at a stable `192.168.10.x` IP without routing through the external VLAN uplink.
- Adds `lifecycle { ignore_changes = [disk] }` on the VM resource to prevent a perpetual diff caused by Harvester flipping `auto_delete` on the rootdisk after the CDROM is detached on second apply.

## Test plan

- [ ] `terraform plan` with `management_network_name = null` shows no eth2 NIC — existing deployments unaffected
- [ ] `terraform plan` with `management_network_name = "default/vyos-mgmt"` shows eth2 added to the VM
- [ ] Second apply with `iso_installed = true` produces no disk diff on an already-installed VM

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional third network interface (eth2) for management network connectivity on VyOS VMs via configurable management network parameter.
  * Enhanced Terraform state management to prevent unnecessary configuration drift detection from disk attribute modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->