### PR TITLE
Fix vyos provider source in vyos-tenant module

### DIFF
--- a/modules/network/vyos-tenant/main.tf
+++ b/modules/network/vyos-tenant/main.tf
@@ -28,13 +28,10 @@ locals {
   gateway_cidr = "${local.gateway_ip}/${split("/", local.subnet)[1]}"
 
   # DHCP range — offsets from subnet base
-  subnet_base = split("/", local.subnet)[0]
-
   dhcp_start = cidrhost(local.subnet, var.dhcp_range_start_offset)
   dhcp_stop  = cidrhost(local.subnet, var.dhcp_range_end_offset)
 
   vlan_label = "VLAN${var.vlan_id}"
-  vif_path   = "interfaces ethernet eth1 vif ${var.vlan_id}"
 }
 
 check "dhcp_offset_order" {
@@ -48,52 +45,49 @@ check "dhcp_offset_order" {
 
 # eth1.vlan_id sub-interface — tenant gateway
 resource "vyos_config_block_tree" "vif" {
-  path = local.vif_path
-
-  configs = {
-    "address"     = local.gateway_cidr
-    "description" = "${var.tenant_name}-${local.vlan_label}"
-  }
+  path = ["interfaces", "ethernet", "eth1", "vif", tostring(var.vlan_id)]
+  section = jsonencode({
+    address     = local.gateway_cidr
+    description = "${var.tenant_name}-${local.vlan_label}"
+  })
 }
 
-# DHCP shared network for this tenant
+# DHCP shared network for this tenant.
+# dns_servers is expressed as a JSON array; the provider emits one
+# /configure set command per element (multi-value leaf node support).
 resource "vyos_config_block_tree" "dhcp" {
-  path = "service dhcp-server shared-network-name ${local.vlan_label}"
-
-  configs = {
-    # subnet-id equals vlan_id — traceable 1:1 mapping
-    "subnet ${local.subnet} subnet-id"             = tostring(var.vlan_id)
-    "subnet ${local.subnet} option default-router" = local.gateway_ip
-    "subnet ${local.subnet} range 0 start"         = local.dhcp_start
-    "subnet ${local.subnet} range 0 stop"          = local.dhcp_stop
-  }
+  path = ["service", "dhcp-server", "shared-network-name", local.vlan_label]
+  section = jsonencode({
+    subnet = {
+      (local.subnet) = {
+        # subnet-id equals vlan_id — traceable 1:1 mapping
+        subnet-id = var.vlan_id
+        option = {
+          default-router = local.gateway_ip
+          name-server    = var.dns_servers
+        }
+        range = {
+          "0" = {
+            start = local.dhcp_start
+            stop  = local.dhcp_stop
+          }
+        }
+      }
+    }
+  })
 
   depends_on = [vyos_config_block_tree.vif]
-}
-
-# DHCP DNS options — all name-server entries in a single resource.
-# Each server IP is embedded in the config key so the map keys are unique
-# and the provider sees one authoritative config block for this path.
-resource "vyos_config_block_tree" "dhcp_dns" {
-  path = "service dhcp-server shared-network-name ${local.vlan_label} subnet ${local.subnet} option"
-
-  configs = {
-    for srv in var.dns_servers : "name-server ${srv}" => ""
-  }
-
-  depends_on = [vyos_config_block_tree.dhcp]
 }
 
 # NAT source rule — masquerade tenant traffic out the uplink interface (internet egress)
 # Rule number = vlan_id for traceability
 resource "vyos_config_block_tree" "nat_egress" {
-  path = "nat source rule ${var.vlan_id}"
-
-  configs = {
-    "outbound-interface name" = "eth0"
-    "source address"          = local.subnet
-    "translation address"     = "masquerade"
-  }
+  path = ["nat", "source", "rule", tostring(var.vlan_id)]
+  section = jsonencode({
+    outbound-interface = { name = "eth0" }
+    source             = { address = local.subnet }
+    translation        = { address = "masquerade" }
+  })
 }
 
 # ── Harvester network resource ────────────────────────────────────────────────

--- a/modules/network/vyos-tenant/outputs.tf
+++ b/modules/network/vyos-tenant/outputs.tf
@@ -8,6 +8,11 @@ output "subnet" {
   description = "Tenant subnet in CIDR notation, e.g. '10.0.0.0/23'."
 }
 
+output "subnet_cidr" {
+  value       = local.subnet
+  description = "Alias for subnet. Tenant subnet in CIDR notation, e.g. '10.0.0.0/23'."
+}
+
 output "gateway_ip" {
   value       = local.gateway_ip
   description = "Tenant gateway IP (VyOS vif address), e.g. '10.0.0.1'."

--- a/modules/network/vyos-tenant/versions.tf
+++ b/modules/network/vyos-tenant/versions.tf
@@ -7,8 +7,8 @@ terraform {
       version = "~> 1.7"
     }
     vyos = {
-      source  = "thomasfinstad/vyos-rolling"
-      version = "~> 19.0"
+      source  = "hiranadikari/vyos"
+      version = "~> 0.1"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes the \`modules/network/vyos-tenant\` module to work with the \`hiranadikari/vyos\` provider.

**Two issues fixed:**

1. **Wrong provider source** — was \`thomasfinstad/vyos-rolling ~> 19.0\`, which doesn't expose \`vyos_config_block_tree\`.

2. **Wrong resource schema** — the \`thomasfinstad\` provider uses \`path\` (space-separated string) + \`configs\` (flat map). The \`hiranadikari/vyos\` provider uses:
   - \`path\` → list of strings
   - \`section\` → \`jsonencode({...})\` nested map

All four \`vyos_config_block_tree\` resources are rewritten accordingly. The separate \`dhcp_dns\` resource is merged into the main \`dhcp\` section — \`dns_servers\` is now a JSON array; the provider emits one \`/configure set\` command per element (multi-value leaf node support added in the same release of the provider).

Unused locals (\`vif_path\`, \`subnet_base\`) removed.

## Test plan

- [ ] \`terraform init\` pulls \`hiranadikari/vyos\`
- [ ] \`terraform plan\` with a VLAN 1000 tenant shows no schema errors
- [ ] \`terraform apply\` configures vif, DHCP (with multiple name-servers), and NAT on VyOS

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)