### PR TITLE
Expose cloud_credential_id from harvester-integration module

### DIFF
--- a/modules/management/harvester-integration/outputs.tf
+++ b/modules/management/harvester-integration/outputs.tf
@@ -7,3 +7,8 @@ output "harvester_cluster_name" {
   value       = rancher2_cluster.harvester_hci.name
   description = "Name of the Harvester cluster as registered in Rancher."
 }
+
+output "cloud_credential_id" {
+  value       = length(rancher2_cloud_credential.harvester) > 0 ? rancher2_cloud_credential.harvester[0].id : null
+  description = "Rancher cloud credential ID (cattle-global-data:cc-xxxx) for the Harvester driver. Null when create_cloud_credential = false (brownfield). Pass to k8s-cluster module's cloud_credential_id."
+}


### PR DESCRIPTION
## Summary

- Adds `cloud_credential_id` output to `modules/management/harvester-integration`
- Returns the `rancher2_cloud_credential` ID (`cattle-global-data:cc-xxxx`) when `create_cloud_credential = true`
- Returns `null` when `create_cloud_credential = false` (brownfield — credential exists outside Terraform)

## Why

Downstream layers (e.g. `08-workloads`) that provision RKE2 clusters via the `k8s-cluster` module need `cloud_credential_id`. Without this output, the ID must be hardcoded or looked up manually from the Rancher UI/API.

## Consumer pattern

```hcl
# 02-management/outputs.tf
output "cloud_credential_id" {
  value = module.harvester_integration.cloud_credential_id
}

# 08-workloads — reference via remote state
data "terraform_remote_state" "management" { ... }

module "my_cluster" {
  source              = "...k8s-cluster..."
  cloud_credential_id = data.terraform_remote_state.management.outputs.cloud_credential_id
  ...
}
```

## Test plan

- [ ] Apply `02-management` with `create_cloud_credential = true` — verify output matches the `cc-xxxx` ID visible in Rancher UI
- [ ] Apply with `create_cloud_credential = false` — verify output is `null` and no error

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)