### PR TITLE
Decouple VyOS integration from network namespace in tenant-space

### DIFF
--- a/modules/management/tenant-space/.terraform.lock.hcl
+++ b/modules/management/tenant-space/.terraform.lock.hcl
@@ -1,0 +1,75 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/harvester/harvester" {
+  version     = "1.7.1"
+  constraints = "~> 1.7"
+  hashes = [
+    "h1:yiVwfxydpA09GDYEiK2eUiL9xQuxGXd2SKUJ8ll/J6I=",
+    "zh:3ab9c4f10315bb674d5f0b25cfe3e5c673c9172cdc54ef53a039823395cfa0d6",
+    "zh:a89c20cb5248793c96ccf8a5a0a41f17a9ee61bf9d9b35320b1c973b32124cd6",
+    "zh:b623902abd84689563946d29fe6212e7a7baad42e3c3857ef3611e5fdd99e660",
+    "zh:babc5423271112b44ae3f1dc4f78c10b947d08e4e95671310c1ae30b143013eb",
+  ]
+}
+
+provider "registry.terraform.io/hiranadikari/vyos" {
+  version     = "0.1.1"
+  constraints = "~> 0.1"
+  hashes = [
+    "h1:+kAQIWGihQZaW6Z3NKqDzA+CJ2+k+xjNS2MtvRx54z0=",
+    "zh:09accee512ba84176694a314849579d8a9ab5e271ef7ff8be08b74d57a4a5750",
+    "zh:1f5de2ef8eb4c74c000313a971df26090fee579729ad41121f66bbc804d1d0f5",
+    "zh:4a0fc05a664f13bd63f3eb896d0cecee45f2473229a36d8335e5ff8c35d6f85a",
+    "zh:4d2493ab5c76d9b6474f58cd00c30cf2b27ec3d5e21eda803924055003994859",
+    "zh:5062f63e8d95e18df0b3c18b81428563bd80e21c445c645e14cf4f0f58c7e63e",
+    "zh:85a38bb09c17dfe9cb6cd8ebc701cadd472506724fb12ab852089dca514ae448",
+    "zh:9e6c5885904d9c862238cc33c29ea6fa79df2d87084dd7eb2b42677438f44c99",
+    "zh:a23d11c8d4dfb8cf03d06c0157bc6f80aeb68938c5eeb4d060342eccc28ab50f",
+    "zh:a79b4667dcf339804b4a422a6ef520e58ed1257070becd841ed336f6a32c7dcb",
+    "zh:aa89f0664eae993ccb369232988536421e7313269f30cdbb96f10aad5afe2285",
+    "zh:eb4e86f8f0152a28d085936cfe92a160bda0dd153e01cbcc264ac37f063ff938",
+    "zh:fe0e582ad41cac3b916f87a00c2cb7dca098408947905b5c22d3ad2eea7e053e",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "13.2.0"
+  constraints = "~> 13.1"
+  hashes = [
+    "h1:5SuPvwHqN56FJRpaRjZ5t7PGALI4ltbywo31w7POIE0=",
+    "zh:1735debe26e4798b2da45aa498552f61f86b8aff36ae9a67b0e79b5bce12b5ce",
+    "zh:5589882ce8eb42cfaf3722828c4dea5f9f41c2319685420bf29b171c163c5199",
+    "zh:74837dd9511017905846e8936b294f77649f7e14eab231196743c1ce3fae2578",
+    "zh:866157d316f9c10ee7908eb01ea008a0a036fb888dffdceb79f0cc56996ac069",
+    "zh:9c8c356722fe528ad6c8bc74a209e064b91936a1f77716b9525f1b096908885e",
+    "zh:a36e98e82bc9ef14f9b10ef6538c54e1f94234cd96d0cf5c9baf31b5c7d11259",
+    "zh:cb89df32a9e7bde368f526a71497c9ad855e52e2adf30cecdd9fbae2fbb959e3",
+    "zh:cca8722aa429514d7388f23d69d5131eac81d4926bbad8a8c78457cff018539e",
+    "zh:d29a4293db694939a450db8b0f1d27f15a39ebd15919f8d032c6e2e80ada5659",
+    "zh:d990f1b187d1c6779d38a2620c685b2c3efc79be4d603ed6b041ecbdfcc1e79b",
+  ]
+}
+
+provider "registry.terraform.io/thomasfinstad/vyos-rolling" {
+  version     = "19.1.202502130"
+  constraints = "~> 19.0"
+  hashes = [
+    "h1:eaGIbMPfgRDmU70PwQcrH4DUqOHnI76Fo7aJYoSKmDM=",
+    "zh:0e52a6baa9da0fd8fe7821ad4da1c1e470429f4082b7547c572951af4f7f9c0f",
+    "zh:142935b65d263df2d3538e79f3a2275784eb21eec69287bdbe5eeaed26f6ecc8",
+    "zh:14e82f5ad4c2807bf775a8421683d152d72c9e5cb20974f513fd9352c79b8994",
+    "zh:1dc82301a8dfb3570187c19564ce1cd61f13cd7b109d5fedebefd5364aa4d6ce",
+    "zh:234be34bb64cfa4db631ed2fc9b58dc422bc1a6e067e857e814c2d8151a78825",
+    "zh:3afca56132f53cd4bcc0c0132e6c4ceb31d2f2710267068d8451664886fc865b",
+    "zh:469888eaae501e0a425fd3ec43530685d483a72ef58af990541aed5a140be2e9",
+    "zh:541d4532c875b2ee7ecb98da9a1461e76788893b623b0adf7c634d9fff7770e3",
+    "zh:77656460ca0de6752e927aa8bff786cdef3fc1a1bbcda2f3af0ec4302b8401f0",
+    "zh:7960b8f271d07c33ed5694546513be79d344c570658f95bb415de81cadb108f7",
+    "zh:9f6466b96d082a211634fc0d5905096d09dc833e4973756cd8972753bd71e1ff",
+    "zh:a39e66c1d32992dbd664f143aae549814e454af8062062557439b9f7e7875e53",
+    "zh:c60b4fb4e5f75852e9c47f1adada43904c8fd151e17237d004146eb6fdf46821",
+    "zh:ddf86c5ab3fdc82d1fb37e40a3b65a5870d070748187d7a92e16a7b2fd3ae5e3",
+    "zh:fd73a53ce3915ab04eaf78ae1f9018a13d21b663ae893828fd5319d39a11624a",
+  ]
+}

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -2,10 +2,15 @@ locals {
   namespace_cpu_limit     = var.namespace_cpu_limit != null ? var.namespace_cpu_limit : var.cpu_limit
   namespace_memory_limit  = var.namespace_memory_limit != null ? var.namespace_memory_limit : var.memory_limit
   namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
-  namespaces              = var.namespaces != null ? var.namespaces : [var.project_name]
-  network_namespace       = var.vlan_id != null ? "${var.project_name}-net" : null
-  tenant_subnet           = var.vlan_id != null ? cidrsubnet("10.0.0.0/8", 15, var.vlan_id - 1000) : null
-  tenant_gateway          = var.vlan_id != null ? cidrhost(local.tenant_subnet, 1) : null
+  namespaces              = var.namespaces != null ? distinct(concat([var.project_name], var.namespaces)) : [var.project_name]
+
+  # create_net_ns is true when explicitly requested OR when a vlan_id is set.
+  # Keeping backward compat: callers already using vlan_id still get the namespace.
+  create_net_ns     = var.create_network_namespace || var.vlan_id != null
+  network_namespace = local.create_net_ns ? "${var.project_name}-net" : null
+
+  tenant_subnet  = var.vlan_id != null ? cidrsubnet("10.0.0.0/8", 15, var.vlan_id - 1000) : null
+  tenant_gateway = var.vlan_id != null ? cidrhost(local.tenant_subnet, 1) : null
 }
 
 resource "rancher2_project" "this" {
@@ -66,10 +71,12 @@ resource "rancher2_namespace" "this" {
   }
 }
 
-# ── Network namespace (only when vlan_id is set) ──────────────────────────────
+# ── Network namespace ─────────────────────────────────────────────────────────
+# Created when create_network_namespace = true OR when vlan_id is set.
+# Labelled so the credential reconciler skips it (no harvesterconfig needed).
 
 resource "rancher2_namespace" "network" {
-  count            = var.vlan_id != null ? 1 : 0
+  count            = local.create_net_ns ? 1 : 0
   name             = local.network_namespace
   project_id       = rancher2_project.this.id
   wait_for_cluster = false
@@ -98,7 +105,9 @@ resource "harvester_network" "tenant" {
   route_cidr           = local.tenant_subnet
   route_gateway        = local.tenant_gateway
 
-  depends_on = [rancher2_namespace.network]
+  # When VyOS is configured, wait for the vif/DHCP to be provisioned before
+  # the network is visible to tenant VMs. count=0 module depends_on is a no-op.
+  depends_on = [rancher2_namespace.network, module.vyos_tenant]
 }
 
 # ── VyOS configuration (only when vyos_endpoint is also set) ──────────────────
@@ -110,12 +119,10 @@ module "vyos_tenant" {
   count  = var.vlan_id != null && var.vyos_endpoint != null ? 1 : 0
   source = "../../network/vyos-tenant"
 
-  tenant_name          = var.project_name
-  vlan_id              = var.vlan_id
-  network_namespace    = rancher2_namespace.network[0].name
-  cluster_network_name = var.cluster_network_name
-  vyos_endpoint        = var.vyos_endpoint
-  vyos_api_key         = var.vyos_api_key
+  tenant_name   = var.project_name
+  vlan_id       = var.vlan_id
+  vyos_endpoint = var.vyos_endpoint
+  vyos_api_key  = var.vyos_api_key
 }
 
 # ── One binding per (group, role) pair. ───────────────────────────────────────

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -9,8 +9,12 @@ locals {
   create_net_ns     = var.create_network_namespace || var.vlan_id != null
   network_namespace = local.create_net_ns ? "${var.project_name}-net" : null
 
-  tenant_subnet  = var.vlan_id != null ? cidrsubnet("10.0.0.0/8", 15, var.vlan_id - 1000) : null
-  tenant_gateway = var.vlan_id != null ? cidrhost(local.tenant_subnet, 1) : null
+  # VyOS path: compute a deterministic /23 subnet from 10.0.0.0/8 using the VLAN
+  # index. Only relevant when vyos_endpoint is set; auto-routed environments
+  # (physical switch / DigiOps-issued VLANs) do not need explicit subnets.
+  use_vyos       = var.vlan_id != null && var.vyos_endpoint != null
+  tenant_subnet  = local.use_vyos ? cidrsubnet("10.0.0.0/8", 15, var.vlan_id - 1000) : null
+  tenant_gateway = local.use_vyos ? cidrhost(local.tenant_subnet, 1) : null
 }
 
 resource "rancher2_project" "this" {
@@ -101,9 +105,13 @@ resource "harvester_network" "tenant" {
   namespace            = rancher2_namespace.network[0].name
   vlan_id              = var.vlan_id
   cluster_network_name = var.cluster_network_name
-  route_mode           = "manual"
-  route_cidr           = local.tenant_subnet
-  route_gateway        = local.tenant_gateway
+
+  # VyOS path: manual routing with a deterministic /23 from 10.0.0.0/8.
+  # DigiOps / physical-switch path: auto routing — the upstream router
+  # advertises the gateway; no explicit CIDR or gateway needed here.
+  route_mode    = local.use_vyos ? "manual" : "auto"
+  route_cidr    = local.tenant_subnet
+  route_gateway = local.tenant_gateway
 
   # When VyOS is configured, wait for the vif/DHCP to be provisioned before
   # the network is visible to tenant VMs. count=0 module depends_on is a no-op.

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -4,6 +4,8 @@ locals {
   namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
   namespaces              = var.namespaces != null ? var.namespaces : [var.project_name]
   network_namespace       = var.vlan_id != null ? "${var.project_name}-net" : null
+  tenant_subnet           = var.vlan_id != null ? cidrsubnet("10.0.0.0/8", 15, var.vlan_id - 1000) : null
+  tenant_gateway          = var.vlan_id != null ? cidrhost(local.tenant_subnet, 1) : null
 }
 
 resource "rancher2_project" "this" {
@@ -72,15 +74,40 @@ resource "rancher2_namespace" "network" {
   project_id       = rancher2_project.this.id
   wait_for_cluster = false
 
+  labels = {
+    "platform.wso2.com/role" = "network-namespace"
+  }
+
   lifecycle {
     ignore_changes = [description]
   }
 }
 
-# ── VyOS tenant network (only when vlan_id is set) ────────────────────────────
+# ── Harvester network (whenever vlan_id is set, with or without VyOS) ─────────
+# Created directly here so it exists regardless of whether VyOS is configured.
+# Environments using physical switch VLAN assignment skip VyOS but still need
+# the harvester_network resource to attach VMs to the correct VLAN.
+
+resource "harvester_network" "tenant" {
+  count                = var.vlan_id != null ? 1 : 0
+  name                 = "${var.project_name}-vlan${var.vlan_id}"
+  namespace            = rancher2_namespace.network[0].name
+  vlan_id              = var.vlan_id
+  cluster_network_name = var.cluster_network_name
+  route_mode           = "manual"
+  route_cidr           = local.tenant_subnet
+  route_gateway        = local.tenant_gateway
+
+  depends_on = [rancher2_namespace.network]
+}
+
+# ── VyOS configuration (only when vyos_endpoint is also set) ──────────────────
+# Environments using physical switch VLAN assignment omit vyos_endpoint and
+# only get the harvester_network above. Environments with VyOS get the full
+# vif sub-interface, DHCP server, and NAT rule in addition.
 
 module "vyos_tenant" {
-  count  = var.vlan_id != null ? 1 : 0
+  count  = var.vlan_id != null && var.vyos_endpoint != null ? 1 : 0
   source = "../../network/vyos-tenant"
 
   tenant_name          = var.project_name

--- a/modules/management/tenant-space/outputs.tf
+++ b/modules/management/tenant-space/outputs.tf
@@ -29,11 +29,11 @@ output "network_name" {
 }
 
 output "subnet_cidr" {
-  value       = var.vlan_id != null ? local.tenant_subnet : null
-  description = "Tenant /23 subnet CIDR (e.g. 10.0.0.0/23). Null when vlan_id is not set."
+  value       = local.tenant_subnet
+  description = "Tenant /23 subnet CIDR (e.g. 10.0.0.0/23). Non-null only when vlan_id and vyos_endpoint are both set."
 }
 
 output "gateway_ip" {
-  value       = var.vlan_id != null ? local.tenant_gateway : null
-  description = "VyOS gateway IP for this tenant. Null when vlan_id is not set."
+  value       = local.tenant_gateway
+  description = "VyOS gateway IP for this tenant (first host in subnet_cidr). Non-null only when vlan_id and vyos_endpoint are both set."
 }

--- a/modules/management/tenant-space/outputs.tf
+++ b/modules/management/tenant-space/outputs.tf
@@ -14,21 +14,26 @@ output "namespace_ids" {
 }
 
 output "network_namespace" {
-  value       = var.vlan_id != null ? rancher2_namespace.network[0].name : null
-  description = "Name of the network namespace created for this tenant. Null when vlan_id is not set."
+  value       = local.create_net_ns ? rancher2_namespace.network[0].name : null
+  description = "Name of the network namespace (<project_name>-net). Non-null when create_network_namespace = true or vlan_id is set."
+}
+
+output "network_namespace_id" {
+  value       = local.create_net_ns ? rancher2_namespace.network[0].id : null
+  description = "Rancher namespace ID of the network namespace. Non-null when create_network_namespace = true or vlan_id is set."
 }
 
 output "network_name" {
-  value       = var.vlan_id != null ? module.vyos_tenant[0].network_name : null
-  description = "Full harvester_network reference (<namespace>/<name>) for use in VM definitions. Null when vlan_id is not set."
+  value       = var.vlan_id != null ? "${harvester_network.tenant[0].namespace}/${harvester_network.tenant[0].name}" : null
+  description = "Full harvester_network reference (<namespace>/<name>) for attaching tenant VMs. Null when vlan_id is not set."
 }
 
 output "subnet_cidr" {
-  value       = var.vlan_id != null ? module.vyos_tenant[0].subnet_cidr : null
-  description = "Tenant /23 subnet CIDR. Null when vlan_id is not set."
+  value       = var.vlan_id != null ? local.tenant_subnet : null
+  description = "Tenant /23 subnet CIDR (e.g. 10.0.0.0/23). Null when vlan_id is not set."
 }
 
 output "gateway_ip" {
-  value       = var.vlan_id != null ? module.vyos_tenant[0].gateway_ip : null
+  value       = var.vlan_id != null ? local.tenant_gateway : null
   description = "VyOS gateway IP for this tenant. Null when vlan_id is not set."
 }

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -105,11 +105,11 @@ variable "create_network_namespace" {
 
 variable "vlan_id" {
   type        = number
-  description = "VLAN ID for this tenant's network (>= 1000). When set, creates the network namespace (if not already), a harvester_network, and optionally VyOS config when vyos_endpoint is also provided. When null, no network or VyOS resources are created."
+  description = "VLAN ID for this tenant's network (>= 1000). When set, always creates the network namespace and a harvester_network. Routing mode depends on vyos_endpoint: if set, route_mode=manual with a deterministic /23 from 10.0.0.0/8 plus full VyOS vif/DHCP/NAT config; if null, route_mode=auto (upstream router / DigiOps-issued VLAN handles routing). When vlan_id is null, no network resources are created."
   default     = null
   validation {
-    condition     = var.vlan_id == null || var.vlan_id >= 1000
-    error_message = "vlan_id must be >= 1000."
+    condition     = var.vlan_id == null || (var.vlan_id >= 1 && var.vlan_id <= 4094)
+    error_message = "vlan_id must be a valid 802.1Q VLAN ID (1–4094)."
   }
 }
 

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -97,9 +97,15 @@ variable "namespace_storage_limit" {
 #
 # Requires the vyos and harvester providers to be configured in the caller.
 
+variable "create_network_namespace" {
+  type        = bool
+  description = "When true, creates a dedicated <project_name>-net namespace labelled platform.wso2.com/role=network-namespace. Also true implicitly when vlan_id is set. Use this flag to pre-provision the namespace before a VLAN is assigned."
+  default     = false
+}
+
 variable "vlan_id" {
   type        = number
-  description = "VLAN ID for this tenant's network (>= 1000). When set, creates the network namespace, harvester_network, and VyOS config. When null, no network resources are created."
+  description = "VLAN ID for this tenant's network (>= 1000). When set, creates the network namespace (if not already), a harvester_network, and optionally VyOS config when vyos_endpoint is also provided. When null, no network or VyOS resources are created."
   default     = null
   validation {
     condition     = var.vlan_id == null || var.vlan_id >= 1000

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -119,18 +119,6 @@ variable "cluster_network_name" {
   default     = "vm-network"
 }
 
-variable "vyos_endpoint" {
-  type        = string
-  description = "VyOS HTTPS API endpoint (e.g. https://192.168.x.x). When set alongside vlan_id, configures VyOS vif, DHCP, and NAT for the tenant. Omit for environments using physical switch VLAN assignment."
-  default     = null
-}
-
-variable "vyos_api_key" {
-  type        = string
-  sensitive   = true
-  description = "VyOS HTTPS API key. Required when vyos_endpoint is set."
-  default     = null
-}
 
 # Role bindings — one binding is created per (group, role) pair.
 

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -113,6 +113,19 @@ variable "cluster_network_name" {
   default     = "vm-network"
 }
 
+variable "vyos_endpoint" {
+  type        = string
+  description = "VyOS HTTPS API endpoint (e.g. https://192.168.x.x). When set alongside vlan_id, configures VyOS vif, DHCP, and NAT for the tenant. Omit for environments using physical switch VLAN assignment."
+  default     = null
+}
+
+variable "vyos_api_key" {
+  type        = string
+  sensitive   = true
+  description = "VyOS HTTPS API key. Required when vyos_endpoint is set."
+  default     = null
+}
+
 # Role bindings — one binding is created per (group, role) pair.
 
 variable "group_role_bindings" {

--- a/modules/management/tenant-space/versions.tf
+++ b/modules/management/tenant-space/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "harvester/harvester"
       version = "~> 1.7"
     }
-}
+  }
 }

--- a/modules/management/tenant-space/versions.tf
+++ b/modules/management/tenant-space/versions.tf
@@ -9,9 +9,5 @@ terraform {
       source  = "harvester/harvester"
       version = "~> 1.7"
     }
-    vyos = {
-      source  = "hiranadikari/vyos"
-      version = "~> 0.1"
-    }
-  }
+}
 }

--- a/modules/network/vyos-tenant/main.tf
+++ b/modules/network/vyos-tenant/main.tf
@@ -1,8 +1,13 @@
 # ── vyos-tenant module ────────────────────────────────────────────────────────
 #
-# Provisions one tenant VLAN on a running VyOS gateway via the HTTPS REST API.
+# Configures one tenant VLAN on a running VyOS gateway via the HTTPS REST API.
 # One call to this module = one tenant VLAN. Add more tenants by calling it
 # again with a different vlan_id.
+#
+# This module handles VyOS-side config only (vif sub-interface, DHCP server,
+# NAT rule). The Harvester network resource (harvester_network) is created by
+# the caller — typically the tenant-space module — so it exists regardless of
+# whether VyOS is configured.
 #
 # IPAM:
 #   subnet    = cidrsubnet("10.0.0.0/8", 15, vlan_id - 1000)
@@ -27,7 +32,6 @@ locals {
   gateway_ip   = cidrhost(local.subnet, 1)
   gateway_cidr = "${local.gateway_ip}/${split("/", local.subnet)[1]}"
 
-  # DHCP range — offsets from subnet base
   dhcp_start = cidrhost(local.subnet, var.dhcp_range_start_offset)
   dhcp_stop  = cidrhost(local.subnet, var.dhcp_range_end_offset)
 
@@ -92,23 +96,4 @@ resource "vyos_config_block_tree" "nat_egress" {
     source             = { address = local.subnet }
     translation        = { address = "masquerade" }
   })
-}
-
-# ── Harvester network resource ────────────────────────────────────────────────
-# vlan_id MUST match the VyOS vif tag above — this is what wires L2 frames
-# from tenant VMs to the correct VyOS sub-interface.
-
-resource "harvester_network" "tenant" {
-  name                 = "${var.tenant_name}-${lower(local.vlan_label)}"
-  namespace            = var.network_namespace
-  vlan_id              = var.vlan_id
-  cluster_network_name = var.cluster_network_name
-  route_mode           = "manual"
-  route_cidr           = local.subnet
-  route_gateway        = local.gateway_ip
-
-  depends_on = [
-    vyos_config_block_tree.vif,
-    vyos_config_block_tree.dhcp,
-  ]
 }

--- a/modules/network/vyos-tenant/main.tf
+++ b/modules/network/vyos-tenant/main.tf
@@ -76,6 +76,10 @@ resource "vyos_config_block_tree" "dhcp" {
     }
   })
 
+  lifecycle {
+    ignore_changes = [section]
+  }
+
   depends_on = [vyos_config_block_tree.vif]
 }
 

--- a/modules/network/vyos-tenant/outputs.tf
+++ b/modules/network/vyos-tenant/outputs.tf
@@ -23,17 +23,7 @@ output "dhcp_range" {
   description = "DHCP pool range for tenant VMs."
 }
 
-output "network_name" {
-  value       = harvester_network.tenant.name
-  description = "Harvester network resource name."
-}
-
-output "network_namespace" {
-  value       = harvester_network.tenant.namespace
-  description = "Harvester network resource namespace."
-}
-
-output "network_ref" {
-  value       = "${harvester_network.tenant.namespace}/${harvester_network.tenant.name}"
-  description = "Full network ref (namespace/name) to attach tenant VMs."
+output "subnet_cidr" {
+  value       = local.subnet
+  description = "Alias for subnet. Tenant /23 subnet in CIDR notation."
 }

--- a/modules/network/vyos-tenant/outputs.tf
+++ b/modules/network/vyos-tenant/outputs.tf
@@ -8,11 +8,6 @@ output "subnet" {
   description = "Tenant subnet in CIDR notation, e.g. '10.0.0.0/23'."
 }
 
-output "subnet_cidr" {
-  value       = local.subnet
-  description = "Alias for subnet. Tenant subnet in CIDR notation, e.g. '10.0.0.0/23'."
-}
-
 output "gateway_ip" {
   value       = local.gateway_ip
   description = "Tenant gateway IP (VyOS vif address), e.g. '10.0.0.1'."

--- a/modules/network/vyos-tenant/variables.tf
+++ b/modules/network/vyos-tenant/variables.tf
@@ -64,15 +64,3 @@ variable "dns_servers" {
   description = "DNS servers to hand out via DHCP."
   default     = ["8.8.8.8", "8.8.4.4"]
 }
-
-# ── Harvester network ─────────────────────────────────────────────────────────
-
-variable "network_namespace" {
-  type        = string
-  description = "Harvester namespace for the harvester_network resource (the tenant's network namespace, e.g. 'tenant-a-net')."
-}
-
-variable "cluster_network_name" {
-  type        = string
-  description = "Harvester cluster network name carrying the tenant VLANs. Must match the cluster network used by the VyOS eth1 trunk."
-}

--- a/modules/network/vyos-tenant/versions.tf
+++ b/modules/network/vyos-tenant/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.5"
 
   required_providers {
-    harvester = {
-      source  = "harvester/harvester"
-      version = "~> 1.7"
-    }
     vyos = {
       source  = "hiranadikari/vyos"
       version = "~> 0.1"


### PR DESCRIPTION
## Summary

- `vlan_id` alone now creates network namespace + `harvester_network` — no VyOS required (physical switch / manually configured VLAN environments)
- New `create_network_namespace` flag (default: `false`) pre-provisions the `<project_name>-net` namespace before a VLAN is assigned
- `vlan_id` + `vyos_endpoint` additionally configures VyOS vif/DHCP/NAT
- Fixes harvester_network ownership collision: moved from `vyos-tenant` into `tenant-space` so both modules no longer create the same resource simultaneously
- `harvester_network` depends_on `module.vyos_tenant` — VyOS vif committed before network is visible to VMs
- Fixes `namespaces` local to use `distinct(concat([project_name], namespaces))` so the project namespace is always included
- Adds `network_namespace_id` output
- `subnet_cidr` / `gateway_ip` outputs now derive from locals directly rather than routing through vyos-tenant module
- Labels the network namespace with `platform.wso2.com/role=network-namespace` (used by reconciler in #62 to skip it)
- `route_mode` is now `"auto"` when `vyos_endpoint` is not set — upstream router handles DHCP/routing for externally managed VLANs; `"manual"` with deterministic 10.0.0.0/8 subnetting only when VyOS is configured (closes #65)
- Relaxed `vlan_id` validation from `>= 1000` to the full 802.1Q range (1–4094)

## Behaviour matrix

| `create_network_namespace` | `vlan_id` | `vyos_endpoint` | Result |
|---|---|---|---|
| false | null | — | No network resources |
| **true** | null | — | Network namespace only |
| false/true | set | null | Network namespace + `harvester_network` (`route_mode=auto`) |
| false/true | set | set | Network namespace + `harvester_network` (`route_mode=manual`) + VyOS config |

## Backward compatibility

Existing callers without `vlan_id`: no change (new flag defaults to false).

Existing callers with `vlan_id` set: `harvester_network` moves from address
`module.<name>.module.vyos_tenant[0].harvester_network.tenant` to
`module.<name>.harvester_network.tenant[0]`. A targeted import is needed on
first apply against an environment that previously applied with VyOS:
```
terraform import 'module.<name>.harvester_network.tenant[0]' <namespace>/<name>
```
New environments (no prior state) are unaffected.

## Test plan

- [ ] `create_network_namespace = true`, no `vlan_id` → only `<name>-net` namespace created
- [ ] `vlan_id` set, no `vyos_endpoint` → namespace + `harvester_network` with `route_mode=auto`, no VyOS API calls
- [ ] `vlan_id` + `vyos_endpoint` → full stack: namespace + network (`route_mode=manual`) + VyOS vif/DHCP/NAT
- [ ] Existing caller with no `vlan_id` → zero plan diff
- [ ] `vlan_id` below 1000 accepted when `vyos_endpoint` not set

Closes #63
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)