### PR TITLE
Add flag to control default namespace creation

### DIFF
--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -2,7 +2,7 @@ locals {
   namespace_cpu_limit     = var.namespace_cpu_limit != null ? var.namespace_cpu_limit : var.cpu_limit
   namespace_memory_limit  = var.namespace_memory_limit != null ? var.namespace_memory_limit : var.memory_limit
   namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
-  namespaces              = var.namespaces != null ? (var.create_default_namespace ? distinct(concat([var.project_name], var.namespaces)) : var.namespaces) : [var.project_name]
+  namespaces              = var.namespaces != null ? (var.create_default_namespace ? distinct(concat([var.project_name], var.namespaces)) : var.namespaces) : (var.create_default_namespace ? [var.project_name] : [])
 
   # create_net_ns is true when explicitly requested OR when a vlan_id is set.
   # Keeping backward compat: callers already using vlan_id still get the namespace.

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -2,7 +2,7 @@ locals {
   namespace_cpu_limit     = var.namespace_cpu_limit != null ? var.namespace_cpu_limit : var.cpu_limit
   namespace_memory_limit  = var.namespace_memory_limit != null ? var.namespace_memory_limit : var.memory_limit
   namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
-  namespaces              = var.namespaces != null ? distinct(concat([var.project_name], var.namespaces)) : [var.project_name]
+  namespaces              = var.namespaces != null ? (var.create_default_namespace ? distinct(concat([var.project_name], var.namespaces)) : var.namespaces) : [var.project_name]
 
   # create_net_ns is true when explicitly requested OR when a vlan_id is set.
   # Keeping backward compat: callers already using vlan_id still get the namespace.

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -8,6 +8,12 @@ variable "project_name" {
   description = "Name of the Rancher project for this tenant."
 }
 
+variable "create_default_namespace" {
+  type        = bool
+  description = "When true (default), a namespace named after the project is always included alongside any explicitly listed namespaces. Set to false for brownfield projects where the project-name namespace was never created or is managed outside Terraform."
+  default     = true
+}
+
 variable "namespaces" {
   type        = list(string)
   description = "Kubernetes namespace names to create within the project. Defaults to [project_name] — a single namespace matching the project. Pass additional names to create more."


### PR DESCRIPTION
## Summary

- Updates all existing tenant-space module calls to set
  `create_default_namespace = false`
- Prevents unexpected namespace creation for brownfield tenants that were
  imported without a project-name namespace
- One project (`WSO2 Cloud`) has a name that is not a valid Kubernetes
  namespace identifier — auto-creation would have caused `terraform apply`
  to fail without this opt-out

New tenants added going forward can omit the flag (defaults to `true`) and
will automatically get a default namespace matching the project name.

Depends on wso2/open-cloud-datacenter#<pr-number> which introduces the
`create_default_namespace` variable.