### PR TITLE
Support multiple VLAN networks per tenant space

### DIFF
--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -4,16 +4,17 @@ locals {
   namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
   namespaces              = var.namespaces != null ? (var.create_default_namespace ? distinct(concat([var.project_name], var.namespaces)) : var.namespaces) : (var.create_default_namespace ? [var.project_name] : [])
 
-  # create_net_ns is true when explicitly requested OR when a vlan_id is set.
+  # create_net_ns is true when explicitly requested OR when vlan_id has entries.
   # Keeping backward compat: callers already using vlan_id still get the namespace.
-  create_net_ns     = var.create_network_namespace || var.vlan_id != null
-  network_namespace = local.create_net_ns ? "${var.project_name}-net" : null
+  create_net_ns     = var.create_network_namespace || (var.vlan_id != null && length(var.vlan_id) > 0)
+  network_namespace = local.create_net_ns ? coalesce(var.network_namespace_name, "${var.project_name}-net") : null
 
   # VyOS path: compute a deterministic /23 subnet from 10.0.0.0/8 using the VLAN
-  # index. Only relevant when vyos_endpoint is set; auto-routed environments
-  # (physical switch / DigiOps-issued VLANs) do not need explicit subnets.
-  use_vyos       = var.vlan_id != null && var.vyos_endpoint != null
-  tenant_subnet  = local.use_vyos ? cidrsubnet("10.0.0.0/8", 15, var.vlan_id - 1000) : null
+  # index. Only relevant when vyos_endpoint is set and exactly one VLAN is given.
+  # Auto-routed environments (physical switch / DigiOps-issued VLANs) use multiple
+  # VLANs with route_mode=auto; no explicit subnets needed.
+  use_vyos       = var.vlan_id != null && length(var.vlan_id) > 0 && var.vyos_endpoint != null
+  tenant_subnet  = local.use_vyos ? cidrsubnet("10.0.0.0/8", 15, var.vlan_id[0] - 1000) : null
   tenant_gateway = local.use_vyos ? cidrhost(local.tenant_subnet, 1) : null
 }
 
@@ -53,6 +54,10 @@ resource "rancher2_project" "this" {
         var.namespace_storage_limit == null,
       ])
       error_message = "Quota variables (memory_limit, storage_limit, namespace_*_limit) are only applied when cpu_limit is set. Either set cpu_limit or remove the other quota variables."
+    }
+    precondition {
+      condition     = !local.use_vyos || length(var.vlan_id) == 1
+      error_message = "VyOS path requires exactly one VLAN ID. Set vyos_endpoint = null for multi-VLAN auto-route configurations."
     }
   }
 }
@@ -100,21 +105,21 @@ resource "rancher2_namespace" "network" {
 # the harvester_network resource to attach VMs to the correct VLAN.
 
 resource "harvester_network" "tenant" {
-  count                = var.vlan_id != null ? 1 : 0
-  name                 = "${var.project_name}-vlan${var.vlan_id}"
+  for_each             = var.vlan_id != null ? toset([for id in var.vlan_id : tostring(id)]) : toset([])
+  name                 = lookup(var.vlan_network_names, each.value, "${var.project_name}-vlan${each.value}")
   namespace            = rancher2_namespace.network[0].name
-  vlan_id              = var.vlan_id
+  vlan_id              = tonumber(each.value)
   cluster_network_name = var.cluster_network_name
 
-  # VyOS path: manual routing with a deterministic /23 from 10.0.0.0/8.
+  # VyOS path: manual routing with a deterministic /23 from 10.0.0.0/8 (single VLAN only).
   # DigiOps / physical-switch path: auto routing — the upstream router
   # advertises the gateway; no explicit CIDR or gateway needed here.
   route_mode    = local.use_vyos ? "manual" : "auto"
-  route_cidr    = local.tenant_subnet
-  route_gateway = local.tenant_gateway
+  route_cidr    = local.use_vyos ? local.tenant_subnet : null
+  route_gateway = local.use_vyos ? local.tenant_gateway : null
 
   # When VyOS is configured, wait for the vif/DHCP to be provisioned before
-  # the network is visible to tenant VMs. count=0 module depends_on is a no-op.
+  # the network is visible to tenant VMs. for_each with empty set is a no-op.
   depends_on = [rancher2_namespace.network, module.vyos_tenant]
 }
 
@@ -124,11 +129,11 @@ resource "harvester_network" "tenant" {
 # vif sub-interface, DHCP server, and NAT rule in addition.
 
 module "vyos_tenant" {
-  count  = var.vlan_id != null && var.vyos_endpoint != null ? 1 : 0
+  count  = local.use_vyos ? 1 : 0
   source = "../../network/vyos-tenant"
 
   tenant_name   = var.project_name
-  vlan_id       = var.vlan_id
+  vlan_id       = var.vlan_id[0]
   vyos_endpoint = var.vyos_endpoint
   vyos_api_key  = var.vyos_api_key
 }

--- a/modules/management/tenant-space/outputs.tf
+++ b/modules/management/tenant-space/outputs.tf
@@ -23,9 +23,9 @@ output "network_namespace_id" {
   description = "Rancher namespace ID of the network namespace. Non-null when create_network_namespace = true or vlan_id is set."
 }
 
-output "network_name" {
-  value       = var.vlan_id != null ? "${harvester_network.tenant[0].namespace}/${harvester_network.tenant[0].name}" : null
-  description = "Full harvester_network reference (<namespace>/<name>) for attaching tenant VMs. Null when vlan_id is not set."
+output "network_names" {
+  value       = { for id, r in harvester_network.tenant : id => "${r.namespace}/${r.name}" }
+  description = "Map of VLAN ID (string) → full harvester_network reference (<namespace>/<name>) for attaching tenant VMs. Empty map when vlan_id is null or empty."
 }
 
 output "subnet_cidr" {

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -126,6 +126,10 @@ variable "network_namespace_name" {
   type        = string
   description = "Override the name of the network namespace. Defaults to <project_name>-net. Use this when importing a brownfield namespace whose name differs from the default."
   default     = null
+  validation {
+    condition     = var.network_namespace_name == null ? true : trimspace(var.network_namespace_name) != ""
+    error_message = "network_namespace_name must be null or a non-empty string."
+  }
 }
 
 variable "vlan_network_names" {

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -110,13 +110,28 @@ variable "create_network_namespace" {
 }
 
 variable "vlan_id" {
-  type        = number
-  description = "VLAN ID for this tenant's network (>= 1000). When set, always creates the network namespace and a harvester_network. Routing mode depends on vyos_endpoint: if set, route_mode=manual with a deterministic /23 from 10.0.0.0/8 plus full VyOS vif/DHCP/NAT config; if null, route_mode=auto (upstream router / DigiOps-issued VLAN handles routing). When vlan_id is null, no network resources are created."
+  type        = list(number)
+  description = "List of VLAN IDs for this tenant's networks. Each entry creates a harvester_network in the network namespace. When non-empty, the network namespace is always created. VyOS path (vyos_endpoint set) requires exactly one VLAN ID — a deterministic /23 from 10.0.0.0/8 is computed and full VyOS vif/DHCP/NAT config is provisioned. Auto-route path (vyos_endpoint null) supports multiple VLANs — the upstream router handles routing. When null or empty, no network resources are created."
   default     = null
   validation {
-    condition     = var.vlan_id == null || (var.vlan_id >= 1 && var.vlan_id <= 4094)
-    error_message = "vlan_id must be a valid 802.1Q VLAN ID (1–4094)."
+    condition = var.vlan_id == null || (
+      length(var.vlan_id) > 0 &&
+      alltrue([for id in var.vlan_id : id >= 1 && id <= 4094])
+    )
+    error_message = "vlan_id must be null or a non-empty list of valid 802.1Q VLAN IDs (1–4094)."
   }
+}
+
+variable "network_namespace_name" {
+  type        = string
+  description = "Override the name of the network namespace. Defaults to <project_name>-net. Use this when importing a brownfield namespace whose name differs from the default."
+  default     = null
+}
+
+variable "vlan_network_names" {
+  type        = map(string)
+  description = "Map of VLAN ID (as string) to harvester_network resource name override. Use when importing brownfield networks whose names differ from the default <project_name>-vlan<id> pattern. Example: { \"608\" = \"vm-subnet-008\" }."
+  default     = {}
 }
 
 variable "cluster_network_name" {


### PR DESCRIPTION
## Summary

- `vlan_id` changed from `number` to `list(number)` — each entry provisions a separate `harvester_network` via `for_each`, so networks can be added or removed independently without replacing others
- Auto-route path (no `vyos_endpoint`) now supports multiple VLANs; VyOS path still requires exactly one VLAN (enforced by a `precondition`)
- `network_namespace_name` override allows brownfield callers to import an existing namespace whose name differs from the `<project>-net` default
- `vlan_network_names` map override allows brownfield callers to import existing `harvester_network` resources with non-default names
- `network_name` output replaced by `network_names` map keyed by VLAN ID string

## Test plan

- [ ] Plan with `vlan_id = [1000]` and `vyos_endpoint` set — confirms VyOS path still works, single VLAN, manual route
- [ ] Plan with `vlan_id = [608, 609]` and no `vyos_endpoint` — confirms multi-VLAN auto-route, two `harvester_network` resources created
- [ ] Plan with `vlan_id = [1000, 1001]` and `vyos_endpoint` set — VyOS precondition fires with clear error
- [ ] Import brownfield with `network_namespace_name` and `vlan_network_names` overrides — no diff after import
- [ ] Plan with `vlan_id = null` — no network resources created, `network_names` output is empty map

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)