### PR TITLE
Add brownfield override variables to vm module

### DIFF
--- a/modules/workloads/vm/README.md
+++ b/modules/workloads/vm/README.md
@@ -156,6 +156,38 @@ module "app_vm" {
 > `chpasswd:` / `ssh_authorized_keys:` keys instead.
 
 ### With scheduled backups
+### Importing a brownfield VM
+
+When a VM already exists (e.g. created via the Harvester UI) and you want to
+bring it under Terraform management without forcing destructive renames, set
+the `*_name` / `*_auto_delete` / `input_devices` overrides to match the VM's
+current spec. Defaults target greenfield conventions; override only to match
+existing state.
+
+```hcl
+module "legacy_vm" {
+  source = "github.com/wso2-enterprise/open-cloud-datacenter//modules/workloads/vm?ref=v0.x.y"
+
+  name         = "legacy-host"
+  namespace    = "team-ns"
+  cpu          = 2
+  memory       = "8Gi"
+  disk_size    = "40Gi"
+  image_name   = "default/image-abc12" # match the existing image ID
+  network_name = "team-ns/vlan-600"
+
+  # Brownfield overrides — match what the Harvester UI created
+  disk_name              = "disk-0"
+  disk_auto_delete       = false
+  network_interface_name = "default"
+  ssh_key_ids            = ["default/shared-key"]
+  input_devices          = [{ name = "tablet", type = "tablet", bus = "usb" }]
+}
+```
+
+After declaring the module, `terraform import module.legacy_vm.harvester_virtualmachine.this <namespace>/<name>` and run `terraform plan` — the plan should show zero changes.
+
+### Referencing images from the management phase
 
 ```hcl
 module "app_vm" {
@@ -215,6 +247,17 @@ module "vm" {
 | `backup_retain` | Number of snapshots to retain | `number` | `5` | no |
 | `backup_enabled` | Whether the backup schedule is active | `bool` | `true` | no |
 | `backup_max_failure` | Max consecutive backup failures before suspending | `number` | `4` | no |
+| `ssh_public_key` | SSH public key content. Used when `create_ssh_key = true`. | `string` | `null` | no |
+| `create_ssh_key` | When true, create a `harvester_ssh_key` from `ssh_public_key`. | `bool` | `false` | no |
+| `wait_for_lease` | Wait for IP lease on primary NIC. Set false for static cloud-init IPs. | `bool` | `true` | no |
+| `user_data` | Cloud-init user-data YAML. Creates a cloud-init secret when set. | `string` | `null` | no |
+| `network_data` | Cloud-init network-data config (requires `user_data` to be set). | `string` | `""` | no |
+| `disk_name` | Name of the root disk volume. Override to match brownfield VMs. | `string` | `"rootdisk"` | no |
+| `disk_auto_delete` | Whether the root disk's PVC is deleted with the VM. | `bool` | `true` | no |
+| `network_interface_name` | Name of the primary NIC. Override to match brownfield VMs. | `string` | `"nic-1"` | no |
+| `restart_after_update` | Whether Terraform restarts the VM when its spec changes. | `bool` | `true` | no |
+| `ssh_key_ids` | Existing Harvester SSH key IDs (`namespace/name`) to attach. | `list(string)` | `[]` | no |
+| `input_devices` | Input devices (e.g. USB tablet) to attach. | `list(object)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/workloads/vm/main.tf
+++ b/modules/workloads/vm/main.tf
@@ -25,7 +25,7 @@ resource "harvester_ssh_key" "this" {
 resource "harvester_virtualmachine" "this" {
   name                 = var.name
   namespace            = var.namespace
-  restart_after_update = true
+  restart_after_update = var.restart_after_update
 
   cpu    = var.cpu
   memory = var.memory
@@ -33,22 +33,25 @@ resource "harvester_virtualmachine" "this" {
   run_strategy = var.run_strategy
   machine_type = "q35"
 
-  ssh_keys = var.create_ssh_key ? [harvester_ssh_key.this[0].id] : []
+  ssh_keys = concat(
+    var.create_ssh_key ? [harvester_ssh_key.this[0].id] : [],
+    var.ssh_key_ids,
+  )
 
   network_interface {
-    name           = "nic-1"
+    name           = var.network_interface_name
     wait_for_lease = var.wait_for_lease
     network_name   = var.network_name
   }
 
   disk {
-    name        = "rootdisk"
+    name        = var.disk_name
     type        = "disk"
     size        = var.disk_size
     bus         = "virtio"
     boot_order  = 1
     image       = var.image_name
-    auto_delete = true
+    auto_delete = var.disk_auto_delete
   }
 
   dynamic "disk" {
@@ -59,6 +62,15 @@ resource "harvester_virtualmachine" "this" {
       bus         = "virtio"
       image       = disk.value.image
       auto_delete = disk.value.auto_delete
+    }
+  }
+
+  dynamic "input" {
+    for_each = var.input_devices
+    content {
+      name = input.value.name
+      type = input.value.type
+      bus  = input.value.bus
     }
   }
 

--- a/modules/workloads/vm/variables.tf
+++ b/modules/workloads/vm/variables.tf
@@ -107,6 +107,51 @@ variable "additional_disks" {
   default     = []
 }
 
+# --- Brownfield overrides ---
+# These let the module wrap VMs that were created outside Terraform (e.g. via
+# the Harvester UI) without forcing destructive renames on import. Defaults
+# match greenfield conventions; override only when matching existing state.
+
+variable "disk_name" {
+  type        = string
+  description = "Name of the root disk volume. Harvester-UI-created VMs use \"disk-0\"; module-created VMs use \"rootdisk\"."
+  default     = "rootdisk"
+}
+
+variable "disk_auto_delete" {
+  type        = bool
+  description = "Whether the root disk's PVC is deleted when the VM is deleted. UI-created VMs typically have this false."
+  default     = true
+}
+
+variable "network_interface_name" {
+  type        = string
+  description = "Name of the primary network interface. Harvester-UI-created VMs use \"default\"; module-created VMs use \"nic-1\"."
+  default     = "nic-1"
+}
+
+variable "restart_after_update" {
+  type        = bool
+  description = "Whether Terraform restarts the VM to apply spec changes. Set false to defer restarts on live VMs."
+  default     = true
+}
+
+variable "ssh_key_ids" {
+  type        = list(string)
+  description = "Existing Harvester SSH key IDs (namespace/name) to attach, in addition to any key created by create_ssh_key. Use this to reference pre-existing shared keys."
+  default     = []
+}
+
+variable "input_devices" {
+  type = list(object({
+    name = string
+    type = string
+    bus  = optional(string, "usb")
+  }))
+  description = "Input devices (e.g. USB tablet) to attach. Harvester-UI-created VMs include a tablet by default; module-created VMs add none."
+  default     = []
+}
+
 # --- Scheduled backups ---
 
 variable "backup_schedule" {


### PR DESCRIPTION
## Summary

- Six new optional input variables let callers wrap VMs created outside Terraform (e.g. via the Harvester UI) without forcing destructive renames on import:
  - `disk_name` (default `"rootdisk"`) — root volume name
  - `disk_auto_delete` (default `true`) — whether the root PVC is deleted with the VM
  - `network_interface_name` (default `"nic-1"`) — primary NIC name
  - `restart_after_update` (default `true`) — whether the provider restarts the VM on spec changes
  - `ssh_key_ids` (default `[]`) — list of existing `namespace/name` keypair IDs to attach alongside any `create_ssh_key`-managed key
  - `input_devices` (default `[]`) — input devices (e.g. USB tablet) to attach
- README gains an "Importing a brownfield VM" section and the inputs table lists the new variables.

## Backward compatibility

Greenfield callers unaffected — every new variable defaults to the previously hard-coded value, so `terraform plan` on existing VM module instances shows zero diff.

## Test plan

- [ ] Plan existing caller with no new variables set — zero diff
- [ ] Import a UI-created VM with `disk_name = "disk-0"`, `network_interface_name = "default"`, `disk_auto_delete = false`, `input_devices = [{ name = "tablet", type = "tablet", bus = "usb" }]`, `ssh_key_ids = ["default/akini"]` — zero diff after `terraform import`
- [ ] Create a greenfield VM with defaults — disk named `rootdisk`, NIC named `nic-1`, no input devices attached