### PR TITLE
Fix kubernetes.io/metadata.name label drift in tenant-space namespaces

### DIFF
--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -87,7 +87,7 @@ resource "rancher2_namespace" "this" {
 
   # description may be set manually in Rancher UI; ignore to avoid removing it.
   lifecycle {
-    ignore_changes = [description]
+    ignore_changes = [description, labels["kubernetes.io/metadata.name"]]
   }
 }
 
@@ -106,7 +106,7 @@ resource "rancher2_namespace" "network" {
   }
 
   lifecycle {
-    ignore_changes = [description]
+    ignore_changes = [description, labels["kubernetes.io/metadata.name"]]
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `labels["kubernetes.io/metadata.name"]` to `lifecycle { ignore_changes }` on both `rancher2_namespace.this` and `rancher2_namespace.network` in the tenant-space module

Kubernetes automatically adds `kubernetes.io/metadata.name` to every namespace. The rancher2 provider detects it as unmanaged drift and proposes removing it on every plan run, producing persistent noise:

```
~ labels = {
  - "kubernetes.io/metadata.name" = "some-ns" -> null
}
```

## Test plan

- [ ] `terraform plan` against an existing deployment shows no diff for this label
- [ ] Existing `description` ignore behaviour unchanged

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)