### PR TITLE
Add credential_namespace variable to harvester-integration

### DIFF
--- a/modules/management/harvester-integration/main.tf
+++ b/modules/management/harvester-integration/main.tf
@@ -209,6 +209,15 @@ locals {
   }) : ""
 }
 
+# Guard: patch_coredns = true requires both rancher_lb_ip and rancher_hostname.
+# Without them, the hosts block renders empty strings and breaks CoreDNS resolution.
+check "coredns_patch_vars_set" {
+  assert {
+    condition     = !var.patch_coredns || (var.rancher_lb_ip != "" && var.rancher_hostname != "")
+    error_message = "patch_coredns = true requires both rancher_lb_ip and rancher_hostname to be set."
+  }
+}
+
 # Validate that the kubeconfig contains embedded CA data (certificate-authority file paths
 # are not supported when building a portable SA kubeconfig for Rancher).
 check "harvester_kubeconfig_has_embedded_ca" {

--- a/modules/management/harvester-integration/main.tf
+++ b/modules/management/harvester-integration/main.tf
@@ -75,7 +75,7 @@ resource "kubernetes_service_account" "rancher_credential" {
   count = var.create_cloud_credential ? 1 : 0
   metadata {
     name      = "rancher-cloud-credential"
-    namespace = "kube-system"
+    namespace = var.credential_namespace
   }
 }
 
@@ -100,7 +100,7 @@ resource "kubernetes_secret" "rancher_credential_token" {
   count = var.create_cloud_credential ? 1 : 0
   metadata {
     name      = "rancher-cloud-credential-token"
-    namespace = "kube-system"
+    namespace = var.credential_namespace
     annotations = {
       "kubernetes.io/service-account.name" = kubernetes_service_account.rancher_credential[0].metadata[0].name
     }
@@ -108,6 +108,54 @@ resource "kubernetes_secret" "rancher_credential_token" {
   type = "kubernetes.io/service-account-token"
 
   depends_on = [kubernetes_service_account.rancher_credential]
+}
+
+locals {
+  _coredns_corefile_patched = <<-EOT
+    .:53 {
+        errors
+        health {
+            lameduck 10s
+        }
+        ready
+        hosts {
+            ${var.rancher_lb_ip} ${var.rancher_hostname}
+            fallthrough
+        }
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
+        }
+        prometheus 0.0.0.0:9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+  EOT
+
+  _coredns_corefile_default = <<-EOT
+    .:53 {
+        errors
+        health {
+            lameduck 10s
+        }
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
+        }
+        prometheus 0.0.0.0:9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+  EOT
 }
 
 locals {
@@ -264,39 +312,18 @@ resource "harvester_setting" "registration_url" {
 # hostname. This replaces the Corefile with one that includes a hosts entry mapping
 # rancher_lb_ip → rancher_hostname, allowing nodes to reach Rancher during bootstrap.
 # Set patch_coredns = false (default) when using a publicly resolvable domain.
+#
+# The resource is always present so that toggling patch_coredns from true → false
+# restores the standard Corefile rather than destroying the key entirely (which
+# would leave CoreDNS with an empty config and break cluster DNS).
 resource "kubernetes_config_map_v1_data" "harvester_coredns_patch" {
-  count = var.patch_coredns ? 1 : 0
-
   metadata {
     name      = "rke2-coredns-rke2-coredns"
     namespace = "kube-system"
   }
 
   data = {
-    Corefile = <<-EOT
-      .:53 {
-          errors
-          health {
-              lameduck 10s
-          }
-          ready
-          hosts {
-              ${var.rancher_lb_ip} ${var.rancher_hostname}
-              fallthrough
-          }
-          kubernetes cluster.local in-addr.arpa ip6.arpa {
-              pods insecure
-              fallthrough in-addr.arpa ip6.arpa
-              ttl 30
-          }
-          prometheus 0.0.0.0:9153
-          forward . /etc/resolv.conf
-          cache 30
-          loop
-          reload
-          loadbalance
-      }
-    EOT
+    Corefile = var.patch_coredns ? local._coredns_corefile_patched : local._coredns_corefile_default
   }
 
   # Overwrite the ConfigMap data managed by the rke2-coredns Helm chart.

--- a/modules/management/harvester-integration/variables.tf
+++ b/modules/management/harvester-integration/variables.tf
@@ -20,6 +20,10 @@ variable "credential_namespace" {
   type        = string
   description = "Kubernetes namespace for the cloud credential ServiceAccount and token Secret on Harvester. Override to match an existing namespace when importing brownfield state."
   default     = "kube-system"
+  validation {
+    condition     = trim(var.credential_namespace) != ""
+    error_message = "credential_namespace must be a non-empty Kubernetes namespace."
+  }
 }
 
 variable "cluster_labels" {

--- a/modules/management/harvester-integration/variables.tf
+++ b/modules/management/harvester-integration/variables.tf
@@ -16,6 +16,12 @@ variable "cloud_credential_name" {
   default     = "harvester-local-creds"
 }
 
+variable "credential_namespace" {
+  type        = string
+  description = "Kubernetes namespace for the cloud credential ServiceAccount and token Secret on Harvester. Override to match an existing namespace when importing brownfield state."
+  default     = "kube-system"
+}
+
 variable "cluster_labels" {
   type        = map(string)
   description = "Additional labels to set on the Harvester cluster object in Rancher. Merged with the required provider.cattle.io=harvester label."


### PR DESCRIPTION
## Summary

- Add `credential_namespace` variable to the `harvester-integration` module, allowing the Kubernetes namespace for the cloud credential ServiceAccount and token Secret to be configured (default: `kube-system`)
- Fix CoreDNS ConfigMap resource to always be present, using a conditional Corefile (patched vs default) instead of `count = 0` which would destroy the entire Corefile key and break cluster DNS

## Why

The `credential_namespace` variable is needed for brownfield imports where the SA and Secret were originally created in a namespace other than the default `kube-system` (e.g., `default`). Without this variable, `terraform plan` forces a destroy+recreate of the SA, ClusterRoleBinding, and Secret — which would briefly break cloud credential authentication.

The CoreDNS fix prevents a dangerous plan where `patch_coredns = false` would destroy the `Corefile` key entirely, leaving CoreDNS with no configuration and breaking cluster DNS.

## Test plan

- [ ] `terraform plan` with `credential_namespace = "default"` shows no changes for existing SA/Secret in `default` namespace
- [ ] `patch_coredns = false` restores the standard Corefile (no hosts block) instead of destroying the key
- [ ] `patch_coredns = true` correctly injects `rancher_lb_ip → rancher_hostname` in the hosts block

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)