### PR TITLE
Wait for SA token and skip infrastructure namespaces

### DIFF
--- a/modules/management/namespace-credential-provisioner/scripts/reconcile.sh
+++ b/modules/management/namespace-credential-provisioner/scripts/reconcile.sh
@@ -383,11 +383,19 @@ on_added_cluster() {
   fi
 
   # Only provision if we manage this namespace (SA token exists on Harvester).
+  # The namespace watch may still be initialising the SA when the cluster event
+  # arrives — poll for up to 90s before giving up.
   local sa_name="harvester-cloud-provider-${vm_namespace}"
-  if ! kubectl get secret "${sa_name}-token" -n "$vm_namespace" &>/dev/null; then
-    log "  [cluster] namespace ${vm_namespace} not managed by this reconciler — skipping"
-    return
-  fi
+  local waited=0
+  while ! kubectl get secret "${sa_name}-token" -n "$vm_namespace" &>/dev/null; do
+    if [[ $waited -ge 90 ]]; then
+      log "  [cluster] namespace ${vm_namespace} not managed by this reconciler — skipping"
+      return 0
+    fi
+    log "  [cluster] waiting for SA token in ${vm_namespace} (${waited}s)..."
+    sleep 5
+    waited=$((waited + 5))
+  done
 
   log "  [cluster] provisioning ${secret_name} for cluster ${cluster_name} (namespace: ${vm_namespace})"
   write_harvesterconfig "$secret_name" "$cluster_name" "$vm_namespace" \
@@ -440,6 +448,7 @@ namespace_watch_loop() {
 
         is_system_namespace "$ns" && continue
         [[ "$role" == "network-namespace" ]] && continue
+        [[ "$role" == "infrastructure" ]] && continue
 
         if [[ -n "$deletion_ts" ]]; then
           if grep -qxF "$ns" "$PROCESSED_NS_FILE" 2>/dev/null; then
@@ -540,6 +549,7 @@ kubectl get namespaces -o json | jq -r '
   [[ -z "$project_id" ]] && continue
   is_system_namespace "$ns" && continue
   [[ "$role" == "network-namespace" ]] && continue
+  [[ "$role" == "infrastructure" ]] && continue
   sa_name="harvester-cloud-provider-${ns}"
   if kubectl get secret "${sa_name}-token" -n "$ns" &>/dev/null; then
     # Cloud-provider credentials already exist. Check for the VM-access kubeconfig


### PR DESCRIPTION
## Summary
Two reconciler hardening fixes for `namespace-credential-provisioner`:

- **Cluster watch race with namespace watch.** When a cluster is created in close succession with its tenant namespace, the cluster event can arrive before the namespace watch has minted the cloud-provider ServiceAccount token. The previous logic logged `namespace not managed by this reconciler` and gave up, leaving the cluster without a `harvesterconfig` secret. Poll for the token for up to 90 seconds before deciding the namespace is unmanaged.
- **Infrastructure namespaces.** Namespaces labelled `role=infrastructure` are managed outside the tenant lifecycle and must not have tenant cloud-provider or VM-access credentials provisioned. Skip them in both the watch loop and the reconciler-restart sweep, alongside the existing `network-namespace` skip.

## Test plan
- [ ] Reconciler running on a cluster where a tenant namespace and cluster are created back-to-back — `harvesterconfig-<cluster>` is created on the second poll cycle instead of being skipped permanently
- [ ] A namespace labelled `role=infrastructure` does not get a `harvester-cloud-provider-*` ServiceAccount or RoleBinding created
- [ ] Existing `role=network-namespace` skip still works (regression check)
- [ ] Reconciler restart sweep does not re-process infrastructure namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)