### PR TITLE
Add dc-controlplane management module

### DIFF
--- a/modules/management/dc-controlplane/main.tf
+++ b/modules/management/dc-controlplane/main.tf
@@ -1,0 +1,107 @@
+# ── Project + VM namespace ────────────────────────────────────────────────────
+# Assigns the VM namespace to a Rancher project, which causes Rancher to
+# annotate the namespace with field.cattle.io/projectId. The
+# namespace-credential-provisioner watches for that annotation (on namespaces
+# without the network-namespace label) and creates two things:
+#   1. harvester-cloud-provider-<ns> ServiceAccount + token in the namespace
+#   2. harvesterconfig-<cluster> secret in fleet-default, referenced by the
+#      cluster's cloud-provider-config
+module "project" {
+  source = "../tenant-space"
+
+  cluster_id               = var.harvester_cluster_id
+  project_name             = var.project_name
+  create_default_namespace = true
+  group_role_bindings      = []
+}
+
+# ── Management network NAD ────────────────────────────────────────────────────
+# Untagged bridge on the mgmt cluster network. Cluster VMs live on the same
+# L2 segment as the LoadBalancer IPPool so kube-vip can ARP-announce VIPs.
+resource "harvester_network" "mgmt" {
+  name                 = "${var.project_name}-mgmt"
+  namespace            = var.project_name
+  vlan_id              = 0
+  cluster_network_name = var.mgmt_cluster_network
+  route_mode           = "auto"
+
+  lifecycle {
+    ignore_changes = [labels]
+  }
+
+  depends_on = [module.project]
+}
+
+# ── LoadBalancer IPPool ───────────────────────────────────────────────────────
+resource "harvester_ippool" "lb" {
+  name = "${var.cluster_name}-lb"
+
+  range {
+    start   = var.lb_range_start
+    end     = var.lb_range_end
+    subnet  = var.lb_subnet
+    gateway = var.lb_gateway
+  }
+}
+
+# ── RKE2 cluster ─────────────────────────────────────────────────────────────
+# cloud_provider_config_secret references the secret that the
+# namespace-credential-provisioner creates automatically once the VM namespace
+# is assigned to a project (via module.project above).
+#
+# The default machine_global_config tolerates the multi-hundred-ms etcd fsync
+# latencies seen on Harvester/Longhorn-backed VM disks. Two adjustments:
+#
+#   * kube-apiserver: extend `etcd-healthcheck-timeout` from 2s → 10s so the
+#     readyz etcd probe absorbs WAL fsync spikes instead of marking the
+#     apiserver NotReady and oscillating Rancher between bootstrapping/active.
+#
+#   * kube-controller-manager / kube-scheduler: extend leader-election
+#     lease/renew/retry from the 15s/10s/2s defaults to 60s/45s/10s so that
+#     leader-renewal API calls (which write to etcd) tolerate slow fsyncs
+#     instead of losing the lease and crashlooping every ~80 seconds.
+#
+# Note: the apiserver flag is `etcd-healthcheck-timeout` (one word).
+# `etcd-health-check-timeout` is a typo and the binary rejects it on startup.
+locals {
+  machine_global_config = var.machine_global_config != null ? var.machine_global_config : <<-YAML
+    cni: cilium
+    disable-kube-proxy: false
+    etcd-expose-metrics: false
+    kube-apiserver-arg:
+      - etcd-healthcheck-timeout=10s
+    kube-controller-manager-arg:
+      - leader-elect-lease-duration=60s
+      - leader-elect-renew-deadline=45s
+      - leader-elect-retry-period=10s
+    kube-scheduler-arg:
+      - leader-elect-lease-duration=60s
+      - leader-elect-renew-deadline=45s
+      - leader-elect-retry-period=10s
+  YAML
+}
+
+module "cluster" {
+  source = "../../workloads/k8s-cluster"
+
+  cluster_name        = var.cluster_name
+  kubernetes_version  = var.kubernetes_version
+  cloud_credential_id = var.cloud_credential_id
+
+  cloud_provider_config_secret    = "harvesterconfig-${var.cluster_name}"
+  enable_harvester_cloud_provider = true
+
+  machine_global_config = local.machine_global_config
+
+  machine_pools = [
+    for pool in var.machine_pools : merge(pool, { vm_namespace = var.project_name })
+  ]
+
+  user_data         = var.user_data
+  manage_rke_config = var.manage_rke_config
+
+  depends_on = [
+    harvester_network.mgmt,
+    harvester_ippool.lb,
+  ]
+}

--- a/modules/management/dc-controlplane/outputs.tf
+++ b/modules/management/dc-controlplane/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_id" {
+  value       = module.cluster.cluster_id
+  description = "Rancher cluster ID of the provisioned control-plane cluster."
+}
+
+output "cluster_name" {
+  value       = var.cluster_name
+  description = "Name of the RKE2 cluster."
+}
+
+output "project_id" {
+  value       = module.project.project_id
+  description = "Rancher project ID for the control-plane project."
+}
+
+output "mgmt_network_name" {
+  value       = "${var.project_name}/${harvester_network.mgmt.name}"
+  description = "Fully-qualified Harvester NAD name (namespace/name) for the management network."
+}

--- a/modules/management/dc-controlplane/variables.tf
+++ b/modules/management/dc-controlplane/variables.tf
@@ -1,0 +1,90 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the RKE2 cluster for the control plane (e.g. 'dcapi-controlplane-rke2')."
+}
+
+variable "project_name" {
+  type        = string
+  description = "Rancher project name. Also used as the VM namespace and NAD namespace."
+  default     = "dc-api"
+}
+
+variable "harvester_cluster_id" {
+  type        = string
+  description = "Rancher cluster ID of the Harvester HCI cluster."
+}
+
+variable "cloud_credential_id" {
+  type        = string
+  description = "Rancher cloud credential ID for provisioning VMs on Harvester."
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "RKE2 version string (e.g. 'v1.33.10+rke2r3')."
+}
+
+variable "mgmt_cluster_network" {
+  type        = string
+  description = "Harvester cluster network for the management NAD."
+  default     = "mgmt"
+}
+
+variable "lb_range_start" {
+  type        = string
+  description = "First IP in the LoadBalancer VIP range for the control-plane cluster."
+}
+
+variable "lb_range_end" {
+  type        = string
+  description = "Last IP in the LoadBalancer VIP range."
+}
+
+variable "lb_subnet" {
+  type        = string
+  description = "Subnet CIDR containing the LoadBalancer VIP range."
+}
+
+variable "lb_gateway" {
+  type        = string
+  description = "Default gateway for the LoadBalancer VIP subnet."
+}
+
+variable "machine_pools" {
+  type = list(object({
+    name           = string
+    quantity       = number
+    cpu_count      = string
+    memory_size    = string
+    disk_size      = number
+    image_name     = string
+    networks       = list(string)
+    control_plane  = bool
+    etcd           = bool
+    worker         = bool
+    machine_labels = optional(map(string), {})
+    taints = optional(list(object({
+      key    = string
+      value  = string
+      effect = string
+    })), [])
+  }))
+  description = "Machine pool definitions. vm_namespace is set automatically to var.project_name."
+}
+
+variable "user_data" {
+  type        = string
+  description = "Cloud-init user_data for cluster nodes."
+}
+
+variable "manage_rke_config" {
+  type        = bool
+  description = "When true, Terraform manages the full RKE2 machine configuration."
+  default     = true
+}
+
+variable "machine_global_config" {
+  type        = string
+  description = "Full machine_global_config YAML for the cluster. Defaults to a config with extended kube-apiserver etcd healthcheck timeout and extended kube-controller-manager / kube-scheduler leader-election timeouts, to tolerate higher disk I/O latency on Harvester/Longhorn-backed storage."
+  default     = null
+}

--- a/modules/management/dc-controlplane/variables.tf
+++ b/modules/management/dc-controlplane/variables.tf
@@ -75,6 +75,7 @@ variable "machine_pools" {
 variable "user_data" {
   type        = string
   description = "Cloud-init user_data for cluster nodes."
+  sensitive   = true
 }
 
 variable "manage_rke_config" {

--- a/modules/management/dc-controlplane/versions.tf
+++ b/modules/management/dc-controlplane/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = "~> 13.1"
+    }
+    harvester = {
+      source  = "harvester/harvester"
+      version = "~> 1.7"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
A new opinionated module under `modules/management/dc-controlplane` that wraps:
- `modules/management/tenant-space` — Rancher project, DC-API VM namespace, Harvester NAD and LB IPPool for the namespace
- `modules/workloads/k8s-cluster` — RKE2 cluster on Harvester with the Harvester cloud provider attached

Consumers pass machine-pool definitions and cloud-init user-data. The module handles the rest.

The default `machine_global_config` is tuned for Harvester/Longhorn-backed VM disks:
- `kube-apiserver-arg: etcd-healthcheck-timeout=10s` — extends the apiserver's etcd `/readyz` probe from 2s so transient WAL fsync spikes don't oscillate Rancher between bootstrapping and active.
- `kube-controller-manager-arg` / `kube-scheduler-arg`: `leader-elect-lease-duration=60s`, `leader-elect-renew-deadline=45s`, `leader-elect-retry-period=10s` — tolerates the multi-hundred-millisecond etcd fsync latencies typical on replicated Longhorn volumes. Without these, both controllers lose their leader leases and crashloop every ~80 seconds during initial bring-up.

The flag name is `etcd-healthcheck-timeout` (one word) — `etcd-health-check-timeout` (two-dash variant) is rejected by the kube-apiserver binary.

## Test plan
- [ ] `terraform validate` succeeds in a consumer that wires the required providers (`rancher2`, `harvester`, `kubernetes.harvester`) into the module
- [ ] Provisioning a single-control-plane RKE2 cluster on Harvester reaches `Active` in Rancher without kube-controller-manager / kube-scheduler crashloops
- [ ] `kubectl logs -n kube-system kube-scheduler-* | grep -c "failed to renew"` reports 0 over a 5-minute window post bring-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)