### PR TITLE
fix: management/tenant-module quota management + vm module enhancements

### DIFF
--- a/modules/identity/providers/asgardeo/versions.tf
+++ b/modules/identity/providers/asgardeo/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3"
   required_providers {
     asgardeo = {
-      source = "hiranadikari/asgardeo"
+      source  = "hiranadikari/asgardeo"
       version = "~> 0.1"
     }
   }

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -88,7 +88,6 @@ resource "rancher2_namespace" "this" {
   # field.cattle.io/projectId label is required for the harvester UI to show neccessary quotas for the namespace
   labels = {
     "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
-    "platform.wso2.com/role"    = "project-default-namespace"
   }
 
   # description may be set manually in Rancher UI; ignore to avoid removing it.

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -85,6 +85,12 @@ resource "rancher2_namespace" "this" {
   # quota would block VM creation when Rancher auto-applies a zero-limit
   # ResourceQuota to namespaces created via the API.
 
+  # field.cattle.io/projectId label is required for the harvester UI to show neccessary quotas for the namespace
+  labels = {
+    "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
+    "platform.wso2.com/role"    = "project-default-namespace"
+  }
+
   # description may be set manually in Rancher UI; ignore to avoid removing it.
   lifecycle {
     ignore_changes = [description, labels["kubernetes.io/metadata.name"]]
@@ -101,13 +107,26 @@ resource "rancher2_namespace" "network" {
   project_id       = rancher2_project.this.id
   wait_for_cluster = false
 
+  # Set 0 limits so that no VMs can be provisioned in this namespace
+  resource_quota {
+    limit {
+      limits_cpu       = "0"
+      limits_memory    = "0Mi"
+      requests_storage = "0Gi"
+    }
+  }
+
+  # field.cattle.io/projectId label is required for the harvester UI to show neccessary quotas for the namespace
   labels = {
-    "platform.wso2.com/role" = "network-namespace"
+    "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
+    "platform.wso2.com/role"    = "network-namespace"
   }
 
   lifecycle {
     ignore_changes = [description, labels["kubernetes.io/metadata.name"]]
   }
+
+  depends_on = [rancher2_namespace.this]
 }
 
 # ── Harvester network (whenever vlan_id is set, with or without VyOS) ─────────

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -85,7 +85,7 @@ resource "rancher2_namespace" "this" {
   # quota would block VM creation when Rancher auto-applies a zero-limit
   # ResourceQuota to namespaces created via the API.
 
-  # field.cattle.io/projectId label is required for the harvester UI to show neccessary quotas for the namespace
+  # field.cattle.io/projectId label is required for the harvester UI to show necessary quotas for the namespace
   labels = {
     "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
   }
@@ -115,7 +115,7 @@ resource "rancher2_namespace" "network" {
     }
   }
 
-  # field.cattle.io/projectId label is required for the harvester UI to show neccessary quotas for the namespace
+  # field.cattle.io/projectId label is required for the harvester UI to show necessary quotas for the namespace
   labels = {
     "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
     "platform.wso2.com/role"    = "network-namespace"

--- a/modules/workloads/vm/main.tf
+++ b/modules/workloads/vm/main.tf
@@ -91,11 +91,23 @@ resource "harvester_virtualmachine" "this" {
     }
   }
 
+  # cloudinitdisk is automatically created when cloudinit is created. 
+  # We ignore the size of the cloudinitdisk as it is managed by cloudinit.
+  dynamic "disk" {
+    for_each = length(harvester_cloudinit_secret.this) > 0 ? [1] : []
+    content {
+      name = "cloudinitdisk"
+      type = "disk"
+      bus  = "virtio"
+      size = "0Gi"
+    }
+  }
+
   lifecycle {
     ignore_changes = [
-      # Harvester/KubeVirt automatically injects a `cloudinitdisk` at runtime.
-      # Ignoring it to prevent drifts.
-      disk,
+      # Ignore the entire cloudinitdisk at index 1.
+      # The Size of the cloudinit disk is managed automatically by cloudinit and ignored in terraform.
+      disk[1].size
     ]
   }
 }

--- a/modules/workloads/vm/main.tf
+++ b/modules/workloads/vm/main.tf
@@ -13,6 +13,15 @@ locals {
   effective_user_data = var.user_data != null ? var.user_data : local._generated_user_data
 }
 
+# Optional Harvester Cloud-Init Secret to hold the cloud-init data.
+resource "harvester_cloudinit_secret" "this" {
+  count = local.effective_user_data != null ? 1 : 0
+
+  name      = "${var.name}-cloud-config"
+  namespace = var.namespace
+  user_data = local.effective_user_data
+}
+
 # Optional SSH key — created only when ssh_public_key is provided.
 resource "harvester_ssh_key" "this" {
   count = var.create_ssh_key ? 1 : 0
@@ -75,18 +84,18 @@ resource "harvester_virtualmachine" "this" {
   }
 
   dynamic "cloudinit" {
-    for_each = local.effective_user_data != null ? [1] : []
+    for_each = length(harvester_cloudinit_secret.this) > 0 ? [1] : []
     content {
-      user_data    = local.effective_user_data
-      network_data = var.network_data
+      user_data_secret_name = harvester_cloudinit_secret.this[0].name
+      network_data          = var.network_data
     }
   }
 
   lifecycle {
     ignore_changes = [
-      # cloud-init runs only on first boot; template changes after provisioning
-      # have no effect and should not trigger a VM restart.
-      cloudinit,
+      # Harvester/KubeVirt automatically injects a `cloudinitdisk` at runtime.
+      # Ignoring it to prevent drifts.
+      disk,
     ]
   }
 }

--- a/modules/workloads/vm/outputs.tf
+++ b/modules/workloads/vm/outputs.tf
@@ -24,6 +24,6 @@ output "backup_schedule_name" {
 }
 
 output "ip_addresses" {
-  value       = [for iface in harvester_virtualmachine.this.network_interface : iface.ip_address]
+  value       = compact([for iface in harvester_virtualmachine.this.network_interface : try(iface.ip_address, null)])
   description = "List of all IP addresses assigned to the VM interfaces."
 }

--- a/modules/workloads/vm/outputs.tf
+++ b/modules/workloads/vm/outputs.tf
@@ -22,3 +22,8 @@ output "backup_schedule_name" {
   value       = var.backup_schedule != null ? kubernetes_manifest.scheduled_backup[0].manifest.metadata.name : null
   description = "Name of the scheduled VM backup, or null if no backup schedule was configured."
 }
+
+output "ip_addresses" {
+  value       = [for iface in harvester_virtualmachine.this.network_interface : iface.ip_address]
+  description = "List of all IP addresses assigned to the VM interfaces."
+}

--- a/modules/workloads/vm/templates/cloud-init.tpl
+++ b/modules/workloads/vm/templates/cloud-init.tpl
@@ -1,4 +1,10 @@
 #cloud-config
+packages:
+  - qemu-guest-agent
+
+runcmd:
+  - systemctl enable --now qemu-guest-agent
+
 ssh_pwauth: True
 %{~ if password != null }
 chpasswd:


### PR DESCRIPTION
## Title: Various Enhancements for the tenant-space and vm modules

### Description
This PR introduces several enhancements for the tenant-level workload provisioning in tenant-space  module and workload/vm modules
  
### Key Changes

- **Fixed Namespace Quota Visibility**: Added `field.cattle.io/projectId` labels to tenant namespaces. Without these labels, Harvester fails to associate the namespace with the correct Rancher project, hiding quota information from the UI.
- **Fixed Cloud-Init Drift**: Replaced raw `user_data` strings with the native `harvester_cloudinit_secret` resource. This prevents Terraform from detecting "Sensitive Value" changes caused by Harvester's internal YAML normalization.
- **Handled Dynamic Disks**: Implemented `ignore_changes` for the `disk` list on the `harvester_virtualmachine` resource. This prevents Terraform from attempting to delete the server-side generated `cloudinitdisk`.
- **Automated Guest Agent**: Updated the core cloud-init template to include `qemu-guest-agent`. This is critical for Harvester to report VM IP addresses and metrics back to the API.


### Verification Results
- **Drift Test**: Verified that `terraform plan` returns "No changes" on consecutive runs after initial provisioning.
- **Networking Test**: Confirmed that IP addresses are correctly reported in Terraform outputs once the Guest Agent starts
