### PR TITLE
Grant tenant cloud-provider SAs RWX RBAC on Harvester

### DIFF
--- a/modules/management/namespace-credential-provisioner/README.md
+++ b/modules/management/namespace-credential-provisioner/README.md
@@ -15,11 +15,18 @@ For every namespace labelled as a tenant namespace, the provisioner creates:
 2. A long-lived SA token Secret
 3. `harvester-vm-kubeconfig` Secret in the namespace — a namespace-scoped kubeconfig
    consumers use to authenticate the `harvester` Terraform provider
+4. `harvester-cloud-provider-<ns>-rwx` RoleBindings in `harvester-system` and
+   `longhorn-system`, granting the tenant cloud-provider SA the permissions
+   harvester-csi-driver needs at startup to enable RWX support on guest clusters
+   (read/write `networkfilesystems.harvesterhci.io`, read `volumes.longhorn.io`).
+   Bound against the shared `harvester-cloud-provider-rwx` ClusterRole this
+   module also creates.
 
 On startup the provisioner backfills any existing namespaces that are missing the
-`harvester-vm-kubeconfig` Secret (upgrade path).
+`harvester-vm-kubeconfig` Secret or the RWX RoleBindings (upgrade path).
 
-On namespace deletion it cleans up the cross-namespace `harvester-public` RoleBinding.
+On namespace deletion it cleans up the cross-namespace `harvester-public` RoleBinding
+and the RWX RoleBindings in `harvester-system` / `longhorn-system`.
 
 ## Why this matters
 

--- a/modules/management/namespace-credential-provisioner/main.tf
+++ b/modules/management/namespace-credential-provisioner/main.tf
@@ -73,6 +73,30 @@ resource "kubernetes_cluster_role_binding_v1" "provisioner" {
   }
 }
 
+# ── ClusterRole — RWX support for tenant cloud-provider SAs ───────────────────
+# Bound by the reconciler per-tenant into harvester-system and longhorn-system.
+# Required so harvester-csi-driver running on guest RKE2 clusters can probe
+# NetworkFileSystem / Longhorn Volume resources at startup; without these the
+# driver silently disables RWX support and every RWX CreateVolume returns
+# `access mode MULTI_NODE_MULTI_WRITER is not supported`.
+resource "kubernetes_cluster_role_v1" "cloud_provider_rwx" {
+  metadata {
+    name = "harvester-cloud-provider-rwx"
+  }
+
+  rule {
+    api_groups = ["harvesterhci.io"]
+    resources  = ["networkfilesystems"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["longhorn.io"]
+    resources  = ["volumes"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
 # ── Secret — Rancher kubeconfig ───────────────────────────────────────────────
 # The reconciler writes harvesterconfig-<ns> into Rancher's fleet-default.
 # This kubeconfig is mounted read-only into the pod.
@@ -189,5 +213,8 @@ resource "kubernetes_deployment_v1" "provisioner" {
     }
   }
 
-  depends_on = [kubernetes_cluster_role_binding_v1.provisioner]
+  depends_on = [
+    kubernetes_cluster_role_binding_v1.provisioner,
+    kubernetes_cluster_role_v1.cloud_provider_rwx,
+  ]
 }

--- a/modules/management/namespace-credential-provisioner/scripts/reconcile.sh
+++ b/modules/management/namespace-credential-provisioner/scripts/reconcile.sh
@@ -78,6 +78,28 @@ is_system_namespace() {
   return 1
 }
 
+# Ensure RoleBindings exist that grant the tenant cloud-provider SA access
+# to NetworkFileSystem CRs (harvester-system) and Longhorn Volume status
+# (longhorn-system). Required so harvester-csi-driver on guest RKE2 clusters
+# can enable RWX support at startup. Without these, every RWX CreateVolume
+# returns `access mode MULTI_NODE_MULTI_WRITER is not supported`.
+#
+# Idempotent: kubectl apply is a no-op if the RoleBinding already matches.
+# Safe before the SA exists: RoleBinding does not validate subject existence.
+# Args: ns
+ensure_rwx_bindings() {
+  local ns="$1"
+  local sa_name="harvester-cloud-provider-${ns}"
+  local rb_name="${sa_name}-rwx"
+
+  for target_ns in harvester-system longhorn-system; do
+    kubectl create rolebinding "$rb_name" \
+      --clusterrole=harvester-cloud-provider-rwx \
+      --serviceaccount="${ns}:${sa_name}" \
+      -n "$target_ns" --dry-run=client -o yaml | kubectl apply -f -
+  done
+}
+
 # Build and write harvesterconfig-<name> to Rancher fleet-default.
 # Args: secret_name  cluster_name  vm_namespace
 write_harvesterconfig() {
@@ -299,6 +321,11 @@ EOF
 
   log "  [ns] SA ready: ${sa_name} in ${ns}"
 
+  # RoleBindings in shared system namespaces so harvester-csi-driver on guest
+  # clusters can enable RWX support. Failure propagates so the namespace stays
+  # unprocessed and the watch loop retries.
+  ensure_rwx_bindings "$ns" || return 1
+
   # Consumer VM-access kubeconfig — separate SA with broader permissions.
   # Explicit return propagates failure to the caller so the namespace is NOT
   # marked processed; the watch loop will retry on the next event.
@@ -348,6 +375,14 @@ on_deleted_namespace() {
     2>/dev/null && log "  [ns] deleted default RoleBinding for ${vm_sa_name}" || true
   kubectl delete rolebinding "${ns}-${vm_sa_name}-public-view" -n "harvester-public" \
     2>/dev/null && log "  [ns] deleted harvester-public RoleBinding for ${vm_sa_name}" || true
+
+  # Delete RWX RoleBindings from harvester-system and longhorn-system. Tolerate
+  # "not found" — they may already be gone or never existed for namespaces
+  # provisioned before this feature was added.
+  for target_ns in harvester-system longhorn-system; do
+    kubectl delete rolebinding "${sa_name}-rwx" -n "$target_ns" 2>/dev/null \
+      && log "  [ns] deleted ${sa_name}-rwx from ${target_ns}" || true
+  done
 }
 
 # ── Cluster watch handlers ─────────────────────────────────────────────────────
@@ -552,8 +587,17 @@ kubectl get namespaces -o json | jq -r '
   [[ "$role" == "infrastructure" ]] && continue
   sa_name="harvester-cloud-provider-${ns}"
   if kubectl get secret "${sa_name}-token" -n "$ns" &>/dev/null; then
-    # Cloud-provider credentials already exist. Check for the VM-access kubeconfig
-    # separately — may be absent on pods that ran before this feature was added.
+    # Cloud-provider credentials already exist. Always re-run ensure_rwx_bindings
+    # — idempotent, and the only way to backfill namespaces provisioned before
+    # this feature was added. On failure, skip marking as processed so the
+    # watch loop retries on the next event.
+    if ! ensure_rwx_bindings "$ns"; then
+      log "  WARN: RWX rolebinding backfill failed for ${ns} — will retry on next watch event"
+      continue
+    fi
+
+    # Check for the VM-access kubeconfig separately — may be absent on pods
+    # that ran before that feature was added.
     if kubectl get secret "harvester-vm-kubeconfig" -n "$ns" &>/dev/null; then
       log "INIT namespace: ${ns} — already provisioned, skipping"
       echo "$ns" >> "$PROCESSED_NS_FILE"


### PR DESCRIPTION
## Summary

- New shared ClusterRole `harvester-cloud-provider-rwx` granting read/write on `networkfilesystems.harvesterhci.io` and read on `volumes.longhorn.io`.
- Reconciler binds it per tenant via two RoleBindings (`harvester-system`, `longhorn-system`) using the existing idempotent `kubectl apply` pattern.
- Init pass backfills the bindings for already-provisioned tenant namespaces.
- `on_deleted_namespace` cleans them up.

Without this, recent builds of `rancher/harvester-csi-driver:v0.2.5` (observed `vendor_version: v0.2.5 (a4261da)`) probe `list networkfilesystems` at startup, hit Forbidden, log `"Failed to list NetworkFilesystems, skip RWX volume support"`, and only advertise `SINGLE_NODE_WRITER`. Every RWX `CreateVolume` then fails with `access mode MULTI_NODE_MULTI_WRITER is not supported` and PVCs stay Pending. The chart-managed `harvesterhci.io:cloudprovider` ClusterRole cannot be patched (Helm sync would revert), so the fix has to live in the reconciler.

Verified in lk-dev: new ClusterRole + per-tenant RoleBindings appear after `terraform apply`, reconciler backfills all existing namespaces on init pass, direct token API check returns HTTP 200 for both probes.

Closes #95

## Test plan

- [ ] `terraform plan` in consumer management layer shows: new ClusterRole, updated ConfigMap (reconcile.sh), Deployment depends_on update
- [ ] `terraform apply` succeeds
- [ ] `kubectl logs deploy/namespace-credential-provisioner` shows `INIT namespace: <ns>` lines and no `RWX rolebinding backfill failed` warnings
- [ ] `kubectl -n harvester-system get rolebinding` and `kubectl -n longhorn-system get rolebinding` list one `harvester-cloud-provider-<ns>-rwx` per tenant
- [ ] Direct API check with tenant SA token returns HTTP 200 for `list networkfilesystems` in `harvester-system` and `list volumes` in `longhorn-system`
- [ ] After bouncing `harvester-csi-driver` DS on a guest cluster, its startup log shows `Enabling volume access mode: MULTI_NODE_MULTI_WRITER`
- [ ] A previously-pending RWX PVC reaches `Bound`