### PR TITLE
Bind tenant SAs to harvesterhci.io:csi-driver for RWX

### DIFF
--- a/modules/management/namespace-credential-provisioner/README.md
+++ b/modules/management/namespace-credential-provisioner/README.md
@@ -15,18 +15,22 @@ For every namespace labelled as a tenant namespace, the provisioner creates:
 2. A long-lived SA token Secret
 3. `harvester-vm-kubeconfig` Secret in the namespace — a namespace-scoped kubeconfig
    consumers use to authenticate the `harvester` Terraform provider
-4. `harvester-cloud-provider-<ns>-rwx` RoleBindings in `harvester-system` and
-   `longhorn-system`, granting the tenant cloud-provider SA the permissions
-   harvester-csi-driver needs at startup to enable RWX support on guest clusters
-   (read/write `networkfilesystems.harvesterhci.io`, read `volumes.longhorn.io`).
-   Bound against the shared `harvester-cloud-provider-rwx` ClusterRole this
-   module also creates.
+4. `harvester-cloud-provider-<ns>-csi-driver` `ClusterRoleBinding`, mapping
+   the tenant cloud-provider SA to the chart-shipped `harvesterhci.io:csi-driver`
+   `ClusterRole`. Required so harvester-csi-driver on guest RKE2 clusters can
+   read `storageclasses`, read/write `networkfilesystems.harvesterhci.io`, and
+   read `volumes.longhorn.io` — without it, RWX provisioning silently fails
+   with `Failed to get NetworkFS …: not found` at mount time. This mirrors
+   what Rancher UI provisioning and the legacy
+   `workloads/harvester-cloud-credential` module create; the official
+   `generate_addon.sh` script leaves it out.
 
 On startup the provisioner backfills any existing namespaces that are missing the
-`harvester-vm-kubeconfig` Secret or the RWX RoleBindings (upgrade path).
+`harvester-vm-kubeconfig` Secret or the CSI ClusterRoleBinding (upgrade path).
 
 On namespace deletion it cleans up the cross-namespace `harvester-public` RoleBinding
-and the RWX RoleBindings in `harvester-system` / `longhorn-system`.
+and the per-tenant `…-csi-driver` ClusterRoleBinding (cluster-scoped, so namespace
+GC will not remove it).
 
 ## Why this matters
 

--- a/modules/management/namespace-credential-provisioner/main.tf
+++ b/modules/management/namespace-credential-provisioner/main.tf
@@ -46,8 +46,20 @@ resource "kubernetes_cluster_role_v1" "provisioner" {
     verbs      = ["get", "create", "patch", "update", "delete", "escalate"]
   }
 
-  # Needed to create RoleBindings that reference ClusterRoles. bind allows
-  # referencing a specific ClusterRole without holding all its permissions.
+  # Manage ClusterRoleBindings cluster-wide. Used to bind tenant cloud-provider
+  # ServiceAccounts to the chart-shipped `harvesterhci.io:csi-driver` ClusterRole
+  # — required for harvester-csi-driver on guest RKE2 clusters to enable RWX
+  # support. ClusterRoleBindings are cluster-scoped (not namespaced) so the
+  # `rolebindings` rule above does not cover them.
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["clusterrolebindings"]
+    verbs      = ["get", "create", "patch", "update", "delete"]
+  }
+
+  # Needed to create RoleBindings and ClusterRoleBindings that reference
+  # ClusterRoles. bind allows referencing a specific ClusterRole without
+  # holding all its permissions.
   rule {
     api_groups = ["rbac.authorization.k8s.io"]
     resources  = ["clusterroles"]
@@ -70,30 +82,6 @@ resource "kubernetes_cluster_role_binding_v1" "provisioner" {
     kind      = "ServiceAccount"
     name      = kubernetes_service_account_v1.provisioner.metadata[0].name
     namespace = var.namespace
-  }
-}
-
-# ── ClusterRole — RWX support for tenant cloud-provider SAs ───────────────────
-# Bound by the reconciler per-tenant into harvester-system and longhorn-system.
-# Required so harvester-csi-driver running on guest RKE2 clusters can probe
-# NetworkFileSystem / Longhorn Volume resources at startup; without these the
-# driver silently disables RWX support and every RWX CreateVolume returns
-# `access mode MULTI_NODE_MULTI_WRITER is not supported`.
-resource "kubernetes_cluster_role_v1" "cloud_provider_rwx" {
-  metadata {
-    name = "harvester-cloud-provider-rwx"
-  }
-
-  rule {
-    api_groups = ["harvesterhci.io"]
-    resources  = ["networkfilesystems"]
-    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
-  }
-
-  rule {
-    api_groups = ["longhorn.io"]
-    resources  = ["volumes"]
-    verbs      = ["get", "list", "watch"]
   }
 }
 
@@ -213,8 +201,5 @@ resource "kubernetes_deployment_v1" "provisioner" {
     }
   }
 
-  depends_on = [
-    kubernetes_cluster_role_binding_v1.provisioner,
-    kubernetes_cluster_role_v1.cloud_provider_rwx,
-  ]
+  depends_on = [kubernetes_cluster_role_binding_v1.provisioner]
 }

--- a/modules/management/namespace-credential-provisioner/scripts/reconcile.sh
+++ b/modules/management/namespace-credential-provisioner/scripts/reconcile.sh
@@ -78,26 +78,39 @@ is_system_namespace() {
   return 1
 }
 
-# Ensure RoleBindings exist that grant the tenant cloud-provider SA access
-# to NetworkFileSystem CRs (harvester-system) and Longhorn Volume status
-# (longhorn-system). Required so harvester-csi-driver on guest RKE2 clusters
-# can enable RWX support at startup. Without these, every RWX CreateVolume
-# returns `access mode MULTI_NODE_MULTI_WRITER is not supported`.
+# Ensure a ClusterRoleBinding exists granting the tenant cloud-provider SA the
+# RBAC that harvester-csi-driver on guest RKE2 clusters needs at runtime:
+# read/list/watch on storageclasses + volumeattachments, read/write on
+# networkfilesystems, and read on longhorn volumes. Bound against the
+# chart-shipped `harvesterhci.io:csi-driver` ClusterRole so we inherit any
+# future Harvester chart updates to that permission set automatically.
 #
-# Idempotent: kubectl apply is a no-op if the RoleBinding already matches.
-# Safe before the SA exists: RoleBinding does not validate subject existence.
+# Mirrors what Rancher UI provisioning and workloads/harvester-cloud-credential
+# create. Without it, harvester-csi-driver's startup probe falls through to
+# "Do no-op for non-LH RWX volume", returns success from ControllerPublish
+# without creating the NetworkFileSystem CR, and every RWX PVC ends up
+# unmountable with `Failed to get NetworkFS ...: not found`. This is the gap
+# that the official `generate_addon.sh` script (which only binds to
+# `harvesterhci.io:cloudprovider`) leaves behind.
+#
+# Short-circuits if the binding already exists — keeps the init pass quiet on
+# already-provisioned tenants and avoids spurious `configured` output from
+# kubectl apply's three-way merge over creationTimestamp normalization. Note
+# this means we do not reconcile drift in the binding's `subjects` field if
+# someone tampers with it out-of-band; the `roleRef` is immutable in any case.
 # Args: ns
-ensure_rwx_bindings() {
+ensure_csi_clusterrolebinding() {
   local ns="$1"
   local sa_name="harvester-cloud-provider-${ns}"
-  local rb_name="${sa_name}-rwx"
+  local crb_name="${sa_name}-csi-driver"
 
-  for target_ns in harvester-system longhorn-system; do
-    kubectl create rolebinding "$rb_name" \
-      --clusterrole=harvester-cloud-provider-rwx \
-      --serviceaccount="${ns}:${sa_name}" \
-      -n "$target_ns" --dry-run=client -o yaml | kubectl apply -f -
-  done
+  if kubectl get clusterrolebinding "$crb_name" &>/dev/null; then
+    return 0
+  fi
+
+  kubectl create clusterrolebinding "$crb_name" \
+    --clusterrole=harvesterhci.io:csi-driver \
+    --serviceaccount="${ns}:${sa_name}"
 }
 
 # Build and write harvesterconfig-<name> to Rancher fleet-default.
@@ -321,10 +334,11 @@ EOF
 
   log "  [ns] SA ready: ${sa_name} in ${ns}"
 
-  # RoleBindings in shared system namespaces so harvester-csi-driver on guest
-  # clusters can enable RWX support. Failure propagates so the namespace stays
-  # unprocessed and the watch loop retries.
-  ensure_rwx_bindings "$ns" || return 1
+  # ClusterRoleBinding so harvester-csi-driver on guest clusters can talk to
+  # storageclasses / networkfilesystems / longhorn volumes — required for RWX.
+  # Failure propagates so the namespace stays unprocessed and the watch loop
+  # retries.
+  ensure_csi_clusterrolebinding "$ns" || return 1
 
   # Consumer VM-access kubeconfig — separate SA with broader permissions.
   # Explicit return propagates failure to the caller so the namespace is NOT
@@ -376,13 +390,11 @@ on_deleted_namespace() {
   kubectl delete rolebinding "${ns}-${vm_sa_name}-public-view" -n "harvester-public" \
     2>/dev/null && log "  [ns] deleted harvester-public RoleBinding for ${vm_sa_name}" || true
 
-  # Delete RWX RoleBindings from harvester-system and longhorn-system. Tolerate
-  # "not found" — they may already be gone or never existed for namespaces
-  # provisioned before this feature was added.
-  for target_ns in harvester-system longhorn-system; do
-    kubectl delete rolebinding "${sa_name}-rwx" -n "$target_ns" 2>/dev/null \
-      && log "  [ns] deleted ${sa_name}-rwx from ${target_ns}" || true
-  done
+  # Delete the per-tenant ClusterRoleBinding to harvesterhci.io:csi-driver.
+  # ClusterRoleBindings are cluster-scoped, so namespace deletion will not
+  # garbage-collect them — we must remove explicitly. Tolerate "not found".
+  kubectl delete clusterrolebinding "${sa_name}-csi-driver" 2>/dev/null \
+    && log "  [ns] deleted clusterrolebinding ${sa_name}-csi-driver" || true
 }
 
 # ── Cluster watch handlers ─────────────────────────────────────────────────────
@@ -587,12 +599,12 @@ kubectl get namespaces -o json | jq -r '
   [[ "$role" == "infrastructure" ]] && continue
   sa_name="harvester-cloud-provider-${ns}"
   if kubectl get secret "${sa_name}-token" -n "$ns" &>/dev/null; then
-    # Cloud-provider credentials already exist. Always re-run ensure_rwx_bindings
-    # — idempotent, and the only way to backfill namespaces provisioned before
-    # this feature was added. On failure, skip marking as processed so the
-    # watch loop retries on the next event.
-    if ! ensure_rwx_bindings "$ns"; then
-      log "  WARN: RWX rolebinding backfill failed for ${ns} — will retry on next watch event"
+    # Cloud-provider credentials already exist. Always re-run the CSI driver
+    # ClusterRoleBinding ensure — idempotent, and the only way to backfill
+    # namespaces provisioned before this feature was added. On failure, skip
+    # marking as processed so the watch loop retries on the next event.
+    if ! ensure_csi_clusterrolebinding "$ns"; then
+      log "  WARN: CSI ClusterRoleBinding backfill failed for ${ns} — will retry on next watch event"
       continue
     fi
 


### PR DESCRIPTION
## Summary

- Drop the custom `harvester-cloud-provider-rwx` ClusterRole and two namespaced RoleBindings introduced in #96.
- Replace with a single per-tenant `ClusterRoleBinding/<sa-name>-csi-driver` mapping the tenant cloud-provider SA to the chart-shipped `harvesterhci.io:csi-driver` ClusterRole. Same pattern as Rancher UI provisioning and `workloads/harvester-cloud-credential`.
- Grant the NCP pod's own SA `clusterrolebindings` write so it can manage the new resource.
- Short-circuit the ensure helper when the binding already exists — quieter init-pass logs and fewer API calls.

## Why #96 wasn't enough

Verified on a `test-cluster` after #96 shipped: RWX PVCs reached `Bound` but pods failed with `Failed to get NetworkFS …: not found` at mount time. The harvester-csi-driver reads the host StorageClass (cluster-scoped) during `ControllerPublishVolume` to confirm a Longhorn-backed RWX volume. Namespaced RoleBindings cannot authorize cluster-scoped reads, so the read returned 403, the driver took the `"Do no-op for non-LH RWX volume"` branch, returned `{}` to Kubernetes without creating the `NetworkFileSystem` CR, and the mount failed forever.

The chart-shipped `harvesterhci.io:csi-driver` ClusterRole already covers storageclasses + volumeattachments + networkfilesystems (full) + longhorn volumes + csi-driver settings + volume snapshots. Binding to it pulls in everything the driver needs in one shot and inherits any future chart updates automatically.

## Test plan

- [x] Verified on a `test-cluster` (driver v0.2.8): with the new CRB applied + DS restart + PVC recycle, pod reached Running, NFS mounted, write/read worked end-to-end
- [x] Verified in lk-dev across all tenant namespaces (db-test + 30 others): init pass creates the CRB for each tenant, no permission errors after granting `clusterrolebindings` write to NCP
- [x] Namespace creation flow exercised — new tenant gets the CRB created on `ADDED namespace` event
- [x] Namespace deletion flow exercised — CRB explicitly removed (cluster-scoped, not GC'd by namespace deletion)

## Follow-ups (separate)

- Upstream PR against `harvester/cloud-provider-harvester` updating `generate_addon.sh` so the documented manual onboarding path doesn't omit this binding.
- Upstream PRs against `harvester/docs` for `cloud-provider.md` and `csi-driver.md` — the latter currently tells users to *create* a ClusterRole that already ships with the chart, and frames the requirement as a "for error-message visibility" prerequisite rather than the RWX-correctness one it actually is.

Closes #97