### PR TITLE
Modularise dc-controlplane-services + add dc-webhook module

### DIFF
--- a/modules/management/dc-controlplane-services/main.tf
+++ b/modules/management/dc-controlplane-services/main.tf
@@ -386,6 +386,49 @@ resource "kubernetes_service" "dc_api" {
   }
 }
 
+# ── TLS — self-signed certificate for the DC-API ingress ─────────────────────
+# Dev cluster, internal hostname, no public CA path available.
+# Valid for 1 year. Re-running apply after expiry regenerates it automatically.
+
+resource "tls_private_key" "dc_api" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "tls_self_signed_cert" "dc_api" {
+  private_key_pem = tls_private_key.dc_api.private_key_pem
+
+  subject {
+    common_name  = var.dcapi_hostname
+    organization = "WSO2 LK Datacenter (dev)"
+  }
+
+  dns_names = [
+    var.dcapi_hostname,
+    "*.lk.internal.wso2.com",
+  ]
+
+  validity_period_hours = 8760 # 1 year
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "kubernetes_secret_v1" "dc_api_tls" {
+  metadata {
+    name      = "dc-api-tls"
+    namespace = kubernetes_namespace.dc_system.metadata[0].name
+  }
+  type = "kubernetes.io/tls"
+  data = {
+    "tls.crt" = tls_self_signed_cert.dc_api.cert_pem
+    "tls.key" = tls_private_key.dc_api.private_key_pem
+  }
+}
+
 # ── Ingress + LoadBalancer exposure ───────────────────────────────────────────
 
 # LoadBalancer service in kube-system that gives the rke2-ingress-nginx
@@ -432,6 +475,12 @@ resource "kubernetes_ingress_v1" "dc_api" {
   }
   spec {
     ingress_class_name = "nginx"
+
+    tls {
+      hosts       = [var.dcapi_hostname]
+      secret_name = kubernetes_secret_v1.dc_api_tls.metadata[0].name
+    }
+
     rule {
       host = var.dcapi_hostname
       http {

--- a/modules/management/dc-controlplane-services/main.tf
+++ b/modules/management/dc-controlplane-services/main.tf
@@ -74,12 +74,19 @@ resource "kubernetes_secret" "dc_api" {
   }
   data = {
     DCAPI_DB_URL                       = "postgres://dc_api:${random_password.postgres.result}@dc-postgres.dc-system:5432/dc_api?sslmode=disable"
-    DCAPI_OIDC_AUDIENCE                = var.oidc_audience
+    DCAPI_OIDC_AUDIENCE                = join(",", var.oidc_audience)
     DCAPI_HARVESTER_KUBECONFIG         = var.harvester_kubeconfig
     DCAPI_RANCHER_TOKEN                = var.rancher_token
     DCAPI_RANCHER_HARVESTER_CREDENTIAL = var.harvester_cloud_credential_id
     DCAPI_OPERATOR_SSH_KEY             = var.operator_ssh_key
     DCAPI_OPERATOR_PASSWORD            = var.operator_password
+    # F7 — BFF confidential OIDC client. Empty defaults so existing
+    # consumers that don't pass BFF inputs keep working with Bearer-only
+    # auth; dc-api checks bff_client_id at startup to decide whether to
+    # mount /v1/auth/*.
+    DCAPI_BFF_CLIENT_ID      = var.bff_client_id
+    DCAPI_BFF_CLIENT_SECRET  = var.bff_client_secret
+    DCAPI_BFF_SESSION_SECRET = var.bff_session_secret
   }
 }
 
@@ -134,6 +141,25 @@ resource "kubernetes_config_map" "dc_api_config" {
     DCAPI_ADMIN_GROUP         = var.admin_group
     DCAPI_LOG_LEVEL           = var.log_level
     DCAPI_LISTEN_ADDR         = ":8080"
+
+    # F15 — VPC external (SNAT) network config consumed by dc-api at startup
+    # to bootstrap the KubeOVN ProviderNetwork / Vlan / Subnet / NAD for
+    # tenant VPC outbound traffic.
+    DCAPI_VPC_EXTERNAL_BRIDGE       = var.vpc_external_bridge
+    DCAPI_VPC_EXTERNAL_CIDR         = var.vpc_external_cidr
+    DCAPI_VPC_EXTERNAL_GATEWAY      = var.vpc_external_gateway
+    DCAPI_VPC_EXTERNAL_RESERVED_IPS = var.vpc_external_reserved_ips
+    DCAPI_VPC_EXTERNAL_VLAN_ID      = tostring(var.vpc_external_vlan_id)
+
+    # F7 — BFF non-secret URL / cookie config. Sensitive client_id/secret
+    # /session-secret live in the dc-api-secrets Secret next to the other
+    # secrets. Empty values are safe defaults — dc-api gates BFF activation
+    # on bff_client_id being non-empty.
+    DCAPI_BFF_REDIRECT_URL         = var.bff_redirect_url
+    DCAPI_BFF_POST_LOGIN_REDIRECT  = var.bff_post_login_redirect
+    DCAPI_BFF_POST_LOGOUT_REDIRECT = var.bff_post_logout_redirect
+    DCAPI_BFF_COOKIE_DOMAIN        = var.bff_cookie_domain
+    DCAPI_BFF_COOKIE_SECURE        = tostring(var.bff_cookie_secure)
   }
 }
 
@@ -265,8 +291,19 @@ resource "kubernetes_deployment" "dc_api" {
     }
   }
 
+  # The container image is owned by CI (whatever build pipeline pushes
+  # dc-api images to your registry — typically a `kubectl set image
+  # deployment/dc-api dc-api=<registry>/dc-api:<sha>` on every commit).
+  # TF only seeds an initial value (var.dc_api_image) for the FIRST
+  # `terraform apply` against a brand new cluster — after that, CI
+  # rolls the image forward on every commit and TF must not fight it.
+  # Without ignore_changes on the container image, every `terraform
+  # plan` after a CI deploy would show a noisy revert.
   lifecycle {
-    ignore_changes = [metadata[0].annotations]
+    ignore_changes = [
+      metadata[0].annotations,
+      spec[0].template[0].spec[0].container[0].image,
+    ]
   }
 
   spec {
@@ -311,24 +348,121 @@ resource "kubernetes_deployment" "dc_api" {
             }
           }
 
-          dynamic "env" {
-            for_each = toset([
-              "DCAPI_DB_URL",
-              "DCAPI_OIDC_AUDIENCE",
-              "DCAPI_HARVESTER_KUBECONFIG",
-              "DCAPI_RANCHER_TOKEN",
-              "DCAPI_RANCHER_HARVESTER_CREDENTIAL",
-              "DCAPI_OPERATOR_SSH_KEY",
-              "DCAPI_OPERATOR_PASSWORD",
-            ])
-            content {
-              name = env.value
-              value_from {
-                secret_key_ref {
-                  name     = kubernetes_secret.dc_api.metadata[0].name
-                  key      = env.value
-                  optional = contains(["DCAPI_OPERATOR_SSH_KEY", "DCAPI_OPERATOR_PASSWORD"], env.value)
-                }
+          # Secret-backed env vars. Listed explicitly (instead of via dynamic
+          # for_each over a set) so the order in the k8s Deployment spec is
+          # stable and source-controlled. `toset` would alphabetise during
+          # iteration which causes a noisy positional diff on every plan
+          # against an existing deployment.
+          #
+          # Order matches the live deployment so existing clusters get a
+          # zero-diff plan after adopting this module:
+          #   1-3: BFF_* (always present in the Secret — empty defaults are
+          #               written when BFF isn't configured, so optional=false
+          #               is safe and dc-api gates BFF activation on
+          #               bff_client_id != "" at startup)
+          #   4:   DB_URL
+          #   5:   OIDC_AUDIENCE
+          #   6:   HARVESTER_KUBECONFIG
+          #   7:   RANCHER_TOKEN
+          #   8:   RANCHER_HARVESTER_CREDENTIAL
+          #   9-10: OPERATOR_* (optional — used only during cluster bootstrap)
+          env {
+            name = "DCAPI_BFF_CLIENT_ID"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_BFF_CLIENT_ID"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_BFF_CLIENT_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_BFF_CLIENT_SECRET"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_BFF_SESSION_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_BFF_SESSION_SECRET"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_DB_URL"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_DB_URL"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_OIDC_AUDIENCE"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_OIDC_AUDIENCE"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_HARVESTER_KUBECONFIG"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_HARVESTER_KUBECONFIG"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_RANCHER_TOKEN"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_RANCHER_TOKEN"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_RANCHER_HARVESTER_CREDENTIAL"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_RANCHER_HARVESTER_CREDENTIAL"
+                optional = false
+              }
+            }
+          }
+          env {
+            name = "DCAPI_OPERATOR_SSH_KEY"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_OPERATOR_SSH_KEY"
+                optional = true
+              }
+            }
+          }
+          env {
+            name = "DCAPI_OPERATOR_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.dc_api.metadata[0].name
+                key      = "DCAPI_OPERATOR_PASSWORD"
+                optional = true
               }
             }
           }
@@ -403,10 +537,10 @@ resource "tls_self_signed_cert" "dc_api" {
     organization = "WSO2 LK Datacenter (dev)"
   }
 
-  dns_names = [
-    var.dcapi_hostname,
-    "*.lk.internal.wso2.com",
-  ]
+  dns_names = concat(
+    [var.dcapi_hostname],
+    var.ingress_additional_dns_names,
+  )
 
   validity_period_hours = 8760 # 1 year
 
@@ -634,10 +768,22 @@ resource "null_resource" "arc_controller" {
     when        = destroy
     on_failure  = continue
     interpreter = ["/usr/bin/env", "bash", "-c"]
-    command     = <<-EOT
+    # lookup() with empty default so the provisioner survives the
+    # one-shot replacement of legacy null_resources whose trigger map
+    # didn't include kubeconfig_path (added in the workdir-randomization
+    # round). When the key is missing we skip the uninstall — the new
+    # null_resource that takes its place runs `helm upgrade --install`
+    # which is idempotent, so the helm release simply continues to
+    # exist with the same name and gets re-managed by the new resource.
+    command = <<-EOT
       set -eu
       if [[ -z "${self.triggers.namespace}" ]]; then exit 0; fi
-      export KUBECONFIG="${self.triggers.kubeconfig_path}"
+      KCP="${lookup(self.triggers, "kubeconfig_path", "")}"
+      if [[ -z "$KCP" ]]; then
+        echo "[arc_controller] skipping helm uninstall: legacy state has no kubeconfig_path trigger; the replacement resource will re-manage via helm upgrade --install"
+        exit 0
+      fi
+      export KUBECONFIG="$KCP"
       helm uninstall arc --namespace "${self.triggers.namespace}" --ignore-not-found || true
     EOT
   }
@@ -674,10 +820,18 @@ resource "null_resource" "dc_runner" {
     when        = destroy
     on_failure  = continue
     interpreter = ["/usr/bin/env", "bash", "-c"]
-    command     = <<-EOT
+    # See identical comment on null_resource.arc_controller's destroy
+    # provisioner — defensive lookup() for the one-shot replacement of
+    # legacy null_resources whose triggers predate kubeconfig_path.
+    command = <<-EOT
       set -eu
       if [[ -z "${self.triggers.namespace}" ]]; then exit 0; fi
-      export KUBECONFIG="${self.triggers.kubeconfig_path}"
+      KCP="${lookup(self.triggers, "kubeconfig_path", "")}"
+      if [[ -z "$KCP" ]]; then
+        echo "[dc_runner] skipping helm uninstall: legacy state has no kubeconfig_path trigger; the replacement resource will re-manage via helm upgrade --install"
+        exit 0
+      fi
+      export KUBECONFIG="$KCP"
       helm uninstall dc-runner --namespace "${self.triggers.namespace}" --ignore-not-found || true
     EOT
   }

--- a/modules/management/dc-controlplane-services/variables.tf
+++ b/modules/management/dc-controlplane-services/variables.tf
@@ -6,8 +6,13 @@ variable "oidc_issuer" {
 }
 
 variable "oidc_audience" {
-  type        = string
-  description = "OIDC client ID / audience for the DC-API application in Asgardeo. Passed to DC-API as DCAPI_OIDC_AUDIENCE."
+  type        = list(string)
+  description = "Every client ID dc-api should accept as a valid OIDC `aud` claim. dcctl, cloud-ui SPA, cloud-ui-bff confidential client, Rancher SSO client, and any other Asgardeo app whose tokens hit dc-api. Joined with commas at projection time and passed as DCAPI_OIDC_AUDIENCE."
+
+  validation {
+    condition     = length(var.oidc_audience) > 0
+    error_message = "oidc_audience must contain at least one client ID."
+  }
 }
 
 # ── Rancher ───────────────────────────────────────────────────────────────────
@@ -47,8 +52,13 @@ variable "dc_api_image" {
 
 variable "dcapi_hostname" {
   type        = string
-  description = "Public hostname for the DC-API ingress. Must resolve to the LoadBalancer IP (via /etc/hosts on dev machines or via internal DNS in production)."
-  default     = "dcapi.lk.internal.wso2.com"
+  description = "Public hostname for the DC-API ingress. Must resolve to the LoadBalancer IP (via /etc/hosts on dev machines or via internal/public DNS in production). Consumers should pick a per-environment hostname (e.g. dcapi.<env>.example.com) to keep environments routable independently."
+}
+
+variable "ingress_additional_dns_names" {
+  type        = list(string)
+  description = "Extra DNS names to add to the self-signed cert's SAN list (e.g. environment wildcards like *.dev.example.com). Empty by default — the cert only covers dcapi_hostname."
+  default     = []
 }
 
 variable "tenant_group_prefix" {
@@ -133,4 +143,90 @@ variable "helm_kubeconfig" {
   type        = string
   sensitive   = true
   description = "Full kubeconfig YAML pointing at the Rancher proxy URL with admin token. Used by null_resource local-exec to invoke helm CLI directly, bypassing the TF helm provider."
+}
+
+# ── F15: VPC external (SNAT) network ──────────────────────────────────────────
+# These get projected into the dc-api ConfigMap as DCAPI_VPC_EXTERNAL_* env
+# vars. dc-api reads them at startup to bootstrap the KubeOVN ProviderNetwork
+# / Vlan / Subnet / NetworkAttachmentDefinition that tenant VPCs SNAT through.
+
+variable "vpc_external_bridge" {
+  type        = string
+  description = "Host bridge name backing the external network (e.g. 'mgmt-br'). Matches Harvester's host NIC/bridge."
+}
+
+variable "vpc_external_cidr" {
+  type        = string
+  description = "CIDR of the external (management) network. dc-api places NAT gateway pod NICs and EIPs inside this CIDR."
+}
+
+variable "vpc_external_gateway" {
+  type        = string
+  description = "Upstream gateway IP for the external network."
+}
+
+variable "vpc_external_reserved_ips" {
+  type        = string
+  description = "Comma-separated IPs already in use on the external network. Listed so kube-ovn IPAM avoids them."
+}
+
+variable "vpc_external_vlan_id" {
+  type        = number
+  description = "VLAN tag for the external network. 0 = untagged."
+  default     = 0
+}
+
+# ── F7: BFF confidential OIDC client ──────────────────────────────────────────
+# Non-empty bff_client_id activates /v1/auth/{login,callback,logout,me} in
+# dc-api. Sensitive values land in the dc-api-secrets Secret; redirect / cookie
+# config lands in the dc-api-config ConfigMap.
+
+variable "bff_client_id" {
+  type        = string
+  description = "Asgardeo client ID for the BFF confidential OIDC client. Empty string disables BFF (dc-api falls back to Bearer-only auth). Projected as DCAPI_BFF_CLIENT_ID."
+  default     = ""
+}
+
+variable "bff_client_secret" {
+  type        = string
+  sensitive   = true
+  description = "Asgardeo client secret for the BFF client. Projected as DCAPI_BFF_CLIENT_SECRET."
+  default     = ""
+}
+
+variable "bff_session_secret" {
+  type        = string
+  sensitive   = true
+  description = "Base64-encoded 32-byte AES-256 key used by dc-api to seal BFF session cookies. Projected as DCAPI_BFF_SESSION_SECRET. Rotating this invalidates every active session."
+  default     = ""
+}
+
+variable "bff_redirect_url" {
+  type        = string
+  description = "Asgardeo redirect URI for the BFF authorization-code flow (must be whitelisted in the Asgardeo app). Projected as DCAPI_BFF_REDIRECT_URL."
+  default     = ""
+}
+
+variable "bff_post_login_redirect" {
+  type        = string
+  description = "URL dc-api 302s the browser to after a successful BFF login. Projected as DCAPI_BFF_POST_LOGIN_REDIRECT."
+  default     = ""
+}
+
+variable "bff_post_logout_redirect" {
+  type        = string
+  description = "URL dc-api 302s the browser to after BFF logout. Projected as DCAPI_BFF_POST_LOGOUT_REDIRECT."
+  default     = ""
+}
+
+variable "bff_cookie_domain" {
+  type        = string
+  description = "Cookie domain scope for BFF session cookies (e.g. '.lk-dev.internal.wso2.com'). Projected as DCAPI_BFF_COOKIE_DOMAIN."
+  default     = ""
+}
+
+variable "bff_cookie_secure" {
+  type        = bool
+  description = "Whether to set the Secure flag on the BFF session cookie. Should be true everywhere except localhost http://. Projected as DCAPI_BFF_COOKIE_SECURE."
+  default     = true
 }

--- a/modules/management/dc-controlplane-services/versions.tf
+++ b/modules/management/dc-controlplane-services/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
     # Used by the helm CLI bypass of the TF helm provider (see main.tf).
     local = {
       source  = "hashicorp/local"

--- a/modules/management/dc-webhook/README.md
+++ b/modules/management/dc-webhook/README.md
@@ -1,0 +1,73 @@
+# dc-webhook
+
+Deploys the DC-API mutating admission webhook onto a Harvester host cluster.
+The webhook intercepts KubeVirt VirtualMachine CREATE/UPDATE requests and
+injects MAC-pinning and KubeOVN annotations, which is required for L2
+return-path delivery when RKE2 node VMs live on KubeOVN overlay networks.
+
+## What this module creates
+
+- Self-signed CA + server TLS cert (hashicorp/tls) — stored in TF state, no
+  cert-manager required. Rotate by `terraform taint` + `apply`.
+- `kubernetes_namespace` — `dc-system` (configurable via `namespace`).
+- `kubernetes_secret` — TLS cert+key (`dc-api-webhook-tls`).
+- `kubernetes_secret` — Harvester kubeconfig (`dc-api-webhook-secrets`).
+- `kubernetes_secret` — GHCR image pull secret (`ghcr-pull-secret`).
+- `kubernetes_service_account` — `dc-api-webhook`.
+- `kubernetes_cluster_role` + `kubernetes_cluster_role_binding` — read-only
+  access to NetworkAttachmentDefinitions in any namespace.
+- `kubernetes_deployment` — 1 replica (configurable), port 9443 HTTPS.
+- `kubernetes_service` — ClusterIP, port 443 → 9443.
+- `kubernetes_manifest` — `MutatingWebhookConfiguration` named
+  `dc-api-ovn-mac-webhook`. The webhook handler's name uses
+  `var.webhook_domain` as its suffix so operators in shared clusters
+  don't collide.
+
+## Apply order
+
+Single-phase apply — no `-target` tricks needed. All resources are concrete
+Kubernetes objects; the cluster endpoint is known before apply.
+
+```bash
+./tf.sh apply --region <env> --layer dc-webhooks
+```
+
+## Updating the image tag
+
+```bash
+./tf.sh apply --region <env> --layer dc-webhooks \
+  -- -var='webhook_image=<registry>/<owner>/dc-api-webhook:<new-sha>'
+```
+
+Or update `webhook_image` in the layer's `terraform.tfvars` and re-apply.
+
+## TLS certificate rotation
+
+Certs are valid for 10 years (87600 hours) and stored in TF state. To force
+regeneration:
+
+```bash
+cd environments/<env>/02-dc-webhooks
+terraform taint 'module.dc_webhook.tls_private_key.ca'
+terraform taint 'module.dc_webhook.tls_self_signed_cert.ca'
+terraform taint 'module.dc_webhook.tls_private_key.server'
+./tf.sh apply --region <env> --layer dc-webhooks
+```
+
+A new CA and server cert will be generated, the TLS Secret will be updated, and
+the MutatingWebhookConfiguration's caBundle will be updated atomically. No
+manual kubectl steps needed.
+
+## Failure policy
+
+`failurePolicy: Ignore` — if the webhook pod is down, VM admission succeeds
+without annotation injection. OVN VMs without annotations will fall back to
+the pre-webhook behaviour (no MAC pinning). Not a security issue; just means
+OVN MAC alignment relies on kube-ovn's own defaults.
+
+## No namespaceSelector
+
+The webhook handler filters by NAD type internally (non-OVN NADs are no-ops).
+Adding a `namespaceSelector` would require labeling tenant namespaces from
+the dc-api Go code, coupling two repos unnecessarily. Add it later as a
+2-line TF change if namespace scoping is ever required.

--- a/modules/management/dc-webhook/main.tf
+++ b/modules/management/dc-webhook/main.tf
@@ -106,13 +106,21 @@ resource "kubernetes_secret" "tls" {
 # Webhook-specific env secrets: only the Harvester kubeconfig is sensitive at
 # runtime. Keeping it separate from the TLS secret so rotation of one doesn't
 # force a pod restart for the other.
+#
+# Note on the base64 dance: the consumer passes the kubeconfig pre-encoded
+# (`harvester_kubeconfig_b64`) so it can flow through TF remote_state /
+# outputs without literal YAML embedding. Terraform's `kubernetes_secret`
+# `data` field auto-base64-encodes whatever string it receives — so we
+# decode here first, otherwise the value in the live Secret ends up double-
+# encoded and the webhook pod reads back base64-of-base64 instead of the
+# raw kubeconfig.
 resource "kubernetes_secret" "webhook" {
   metadata {
     name      = "dc-api-webhook-secrets"
     namespace = kubernetes_namespace.webhook.metadata[0].name
   }
   data = {
-    DCWEBHOOK_KUBECONFIG = var.harvester_kubeconfig_b64
+    DCWEBHOOK_KUBECONFIG = base64decode(var.harvester_kubeconfig_b64)
   }
 }
 

--- a/modules/management/dc-webhook/main.tf
+++ b/modules/management/dc-webhook/main.tf
@@ -1,0 +1,393 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# DC-API Mutating Admission Webhook
+#
+# Deploys the dc-api-webhook binary onto a Harvester host cluster.
+# The webhook intercepts KubeVirt VirtualMachine CREATE/UPDATE requests and
+# injects MAC-pinning + KubeOVN annotations, which is the prerequisite for
+# L2 return-path delivery when RKE2 node VMs live on KubeOVN overlay networks.
+#
+# TLS: a self-signed CA + server cert are generated in TF state via the
+# hashicorp/tls provider. cert-manager is NOT required or used.
+#
+# No provider blocks here — all provider config lives in the calling layer.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── TLS: CA ──────────────────────────────────────────────────────────────────
+
+resource "tls_private_key" "ca" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "tls_self_signed_cert" "ca" {
+  private_key_pem = tls_private_key.ca.private_key_pem
+
+  subject {
+    common_name  = "dc-api-webhook-ca"
+    organization = "WSO2 DC"
+  }
+
+  # 10 years — rotated by replacing TF state, not by short-lived certs.
+  validity_period_hours = 87600
+  is_ca_certificate     = true
+
+  allowed_uses = [
+    "cert_signing",
+    "key_encipherment",
+    "digital_signature",
+  ]
+}
+
+# ── TLS: server cert ─────────────────────────────────────────────────────────
+
+resource "tls_private_key" "server" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "tls_cert_request" "server" {
+  private_key_pem = tls_private_key.server.private_key_pem
+
+  subject {
+    common_name  = "dc-api-webhook.${var.namespace}.svc"
+    organization = "WSO2 DC"
+  }
+
+  # The apiserver calls the webhook by Service DNS name; both short and FQDN
+  # forms must be in the SAN list.
+  dns_names = [
+    "dc-api-webhook",
+    "dc-api-webhook.${var.namespace}",
+    "dc-api-webhook.${var.namespace}.svc",
+    "dc-api-webhook.${var.namespace}.svc.cluster.local",
+  ]
+}
+
+resource "tls_locally_signed_cert" "server" {
+  cert_request_pem   = tls_cert_request.server.cert_request_pem
+  ca_private_key_pem = tls_private_key.ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
+
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+# ── Namespace ─────────────────────────────────────────────────────────────────
+
+resource "kubernetes_namespace" "webhook" {
+  metadata {
+    name = var.namespace
+  }
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+
+# TLS cert + key for the webhook HTTPS server. Mounted read-only at /tls.
+resource "kubernetes_secret" "tls" {
+  metadata {
+    name      = "dc-api-webhook-tls"
+    namespace = kubernetes_namespace.webhook.metadata[0].name
+  }
+  type = "kubernetes.io/tls"
+  data = {
+    "tls.crt" = tls_locally_signed_cert.server.cert_pem
+    "tls.key" = tls_private_key.server.private_key_pem
+  }
+}
+
+# Webhook-specific env secrets: only the Harvester kubeconfig is sensitive at
+# runtime. Keeping it separate from the TLS secret so rotation of one doesn't
+# force a pod restart for the other.
+resource "kubernetes_secret" "webhook" {
+  metadata {
+    name      = "dc-api-webhook-secrets"
+    namespace = kubernetes_namespace.webhook.metadata[0].name
+  }
+  data = {
+    DCWEBHOOK_KUBECONFIG = var.harvester_kubeconfig_b64
+  }
+}
+
+# GHCR image pull secret — same pattern as dc-controlplane-services.
+resource "kubernetes_secret" "ghcr_pull" {
+  metadata {
+    name      = "ghcr-pull-secret"
+    namespace = kubernetes_namespace.webhook.metadata[0].name
+  }
+  type = "kubernetes.io/dockerconfigjson"
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "ghcr.io" = {
+          username = var.ghcr_username
+          password = var.ghcr_pat
+          auth     = base64encode("${var.ghcr_username}:${var.ghcr_pat}")
+        }
+      }
+    })
+  }
+}
+
+# ── RBAC ──────────────────────────────────────────────────────────────────────
+
+resource "kubernetes_service_account" "webhook" {
+  metadata {
+    name      = "dc-api-webhook"
+    namespace = kubernetes_namespace.webhook.metadata[0].name
+  }
+}
+
+# ClusterRole: read NADs from any namespace (tenant namespaces are dc-<id>,
+# not predictable at deploy time, so ClusterRole is required).
+resource "kubernetes_cluster_role" "webhook" {
+  metadata {
+    name = "dc-api-webhook"
+  }
+
+  rule {
+    api_groups = ["k8s.cni.cncf.io"]
+    resources  = ["network-attachment-definitions"]
+    verbs      = ["get"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "webhook" {
+  metadata {
+    name = "dc-api-webhook"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.webhook.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.webhook.metadata[0].name
+    namespace = kubernetes_namespace.webhook.metadata[0].name
+  }
+}
+
+# ── Deployment + Service ──────────────────────────────────────────────────────
+
+resource "kubernetes_deployment" "webhook" {
+  metadata {
+    name      = "dc-api-webhook"
+    namespace = kubernetes_namespace.webhook.metadata[0].name
+    labels = {
+      app = "dc-api-webhook"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = {
+        app = "dc-api-webhook"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "dc-api-webhook"
+        }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account.webhook.metadata[0].name
+
+        security_context {
+          run_as_non_root = true
+          run_as_user     = 65532
+          seccomp_profile {
+            type = "RuntimeDefault"
+          }
+        }
+
+        image_pull_secrets {
+          name = kubernetes_secret.ghcr_pull.metadata[0].name
+        }
+
+        container {
+          name              = "webhook"
+          image             = var.webhook_image
+          image_pull_policy = "Always"
+
+          port {
+            name           = "https"
+            container_port = 9443
+          }
+
+          env {
+            name  = "DCWEBHOOK_LISTEN_ADDR"
+            value = ":9443"
+          }
+
+          env {
+            name  = "DCWEBHOOK_CERT_FILE"
+            value = "/tls/tls.crt"
+          }
+
+          env {
+            name  = "DCWEBHOOK_KEY_FILE"
+            value = "/tls/tls.key"
+          }
+
+          env {
+            name  = "DCWEBHOOK_LOG_LEVEL"
+            value = var.log_level
+          }
+
+          env {
+            name = "DCWEBHOOK_KUBECONFIG"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.webhook.metadata[0].name
+                key  = "DCWEBHOOK_KUBECONFIG"
+              }
+            }
+          }
+
+          volume_mount {
+            name       = "tls"
+            mount_path = "/tls"
+            read_only  = true
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/healthz"
+              port   = 9443
+              scheme = "HTTPS"
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
+
+          readiness_probe {
+            http_get {
+              path   = "/healthz"
+              port   = 9443
+              scheme = "HTTPS"
+            }
+            initial_delay_seconds = 2
+            period_seconds        = 5
+          }
+
+          resources {
+            requests = {
+              cpu    = "10m"
+              memory = "32Mi"
+            }
+            limits = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+            read_only_root_filesystem  = true
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+        }
+
+        volume {
+          name = "tls"
+          secret {
+            secret_name = kubernetes_secret.tls.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_secret.tls, kubernetes_secret.webhook]
+}
+
+resource "kubernetes_service" "webhook" {
+  metadata {
+    name      = "dc-api-webhook"
+    namespace = kubernetes_namespace.webhook.metadata[0].name
+  }
+
+  spec {
+    type = "ClusterIP"
+    selector = {
+      app = "dc-api-webhook"
+    }
+    port {
+      name        = "https"
+      port        = 443
+      target_port = 9443
+    }
+  }
+}
+
+# ── MutatingWebhookConfiguration ─────────────────────────────────────────────
+#
+# failurePolicy: Ignore is intentional. If the webhook is down, non-OVN VMs
+# must not be blocked. OVN VMs without the annotations will simply fail to get
+# the correct MAC allocation — the same outcome as before F14.
+#
+# No namespaceSelector: the handler filters internally by NAD type and no-ops
+# on non-OVN VMs regardless of namespace.
+
+resource "kubernetes_manifest" "mutating_webhook" {
+  manifest = {
+    apiVersion = "admissionregistration.k8s.io/v1"
+    kind       = "MutatingWebhookConfiguration"
+    metadata = {
+      name = "dc-api-ovn-mac-webhook"
+    }
+    webhooks = [
+      {
+        name                    = "virtualmachines.kubevirt.io.dc-api.${var.webhook_domain}"
+        admissionReviewVersions = ["v1"]
+        clientConfig = {
+          service = {
+            name      = kubernetes_service.webhook.metadata[0].name
+            namespace = kubernetes_namespace.webhook.metadata[0].name
+            path      = "/mutate"
+            port      = 443
+          }
+          # Base64-encoded CA cert that signed the server TLS cert.
+          # The apiserver uses this to verify the webhook's TLS handshake.
+          caBundle = base64encode(tls_self_signed_cert.ca.cert_pem)
+        }
+        rules = [
+          {
+            apiGroups   = ["kubevirt.io"]
+            apiVersions = ["v1"]
+            resources   = ["virtualmachines"]
+            operations  = ["CREATE", "UPDATE"]
+            scope       = "Namespaced"
+          }
+        ]
+        failurePolicy      = "Ignore"
+        sideEffects        = "None"
+        timeoutSeconds     = 5
+        reinvocationPolicy = "Never"
+      }
+    ]
+  }
+
+  depends_on = [kubernetes_service.webhook]
+}

--- a/modules/management/dc-webhook/outputs.tf
+++ b/modules/management/dc-webhook/outputs.tf
@@ -1,0 +1,14 @@
+output "service_fqdn" {
+  value       = "dc-api-webhook.${var.namespace}.svc"
+  description = "In-cluster DNS name used by the apiserver to call the webhook."
+}
+
+output "image_deployed" {
+  value       = var.webhook_image
+  description = "Container image reference that was deployed (for downstream audit/reference)."
+}
+
+output "webhook_configuration_name" {
+  value       = kubernetes_manifest.mutating_webhook.manifest.metadata.name
+  description = "Name of the MutatingWebhookConfiguration created on the cluster."
+}

--- a/modules/management/dc-webhook/variables.tf
+++ b/modules/management/dc-webhook/variables.tf
@@ -33,7 +33,7 @@ variable "log_level" {
 
 variable "webhook_domain" {
   type        = string
-  description = "Domain suffix used in the ValidatingWebhookConfiguration webhook names (convention: <handler>.<resource>.<group>.<domain>). Operators typically set this to their organization's DNS domain so webhook names don't collide with other operators in shared clusters."
+  description = "Domain suffix used in the MutatingWebhookConfiguration webhook names (convention: <handler>.<resource>.<group>.<domain>). Operators typically set this to their organization's DNS domain so webhook names don't collide with other operators in shared clusters."
   default     = "example.com"
 }
 

--- a/modules/management/dc-webhook/variables.tf
+++ b/modules/management/dc-webhook/variables.tf
@@ -1,0 +1,49 @@
+variable "webhook_image" {
+  type        = string
+  description = "Full container image reference for the dc-api-webhook (e.g. <registry>/<owner>/dc-api-webhook:<sha>)."
+}
+
+variable "harvester_kubeconfig_b64" {
+  type        = string
+  sensitive   = true
+  description = "Base64-encoded Harvester kubeconfig. The webhook uses this to resolve NetworkAttachmentDefinitions at admission time."
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace where the webhook runs."
+  default     = "dc-system"
+}
+
+variable "replicas" {
+  type        = number
+  description = "Number of webhook pod replicas."
+  default     = 1
+}
+
+variable "log_level" {
+  type        = string
+  description = "Webhook log level (debug | info | warn | error)."
+  default     = "info"
+  validation {
+    condition     = contains(["debug", "info", "warn", "error"], var.log_level)
+    error_message = "log_level must be one of: debug, info, warn, error."
+  }
+}
+
+variable "webhook_domain" {
+  type        = string
+  description = "Domain suffix used in the ValidatingWebhookConfiguration webhook names (convention: <handler>.<resource>.<group>.<domain>). Operators typically set this to their organization's DNS domain so webhook names don't collide with other operators in shared clusters."
+  default     = "example.com"
+}
+
+variable "ghcr_username" {
+  type        = string
+  description = "GitHub username (or org) that owns the webhook image on ghcr.io. Used as the imagePullSecrets auth subject."
+}
+
+variable "ghcr_pat" {
+  type        = string
+  sensitive   = true
+  description = "GitHub Personal Access Token with read:packages scope for pulling the webhook image from ghcr.io."
+}

--- a/modules/management/dc-webhook/versions.tf
+++ b/modules/management/dc-webhook/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      # See the layer's versions.tf for the 2.38 Resource Identity caveat.
+      version = "~> 2.30"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Consolidates the in-flight work on the `dc-controlplane-services` module
plus adds the new `dc-webhook` module so consumer environments can pass
parameters only — every per-environment knob now lives in module variables.

Six commits on top of `main`:

| # | Commit | What |
|---|---|---|
| 1 | `Bypass helm provider with helm CLI for ARC chart install` | Works around recurring `http: request body too large` from the TF helm provider via Rancher's proxy chain. Helm CLI invocation works against the same URL. |
| 2 | `Address CodeRabbit review on helm CLI bypass` | Review feedback on #1. |
| 3 | `Add TLS termination to dc-api ingress` | Self-signed cert (`hashicorp/tls`) + k8s Secret + ingress TLS block. |
| 4 | `Land BFF, VPC, hostname, env-order and lifecycle fixes` | 8 BFF variables, 5 VPC external network variables, `oidc_audience` → `list(string)`, `dcapi_hostname` made required with no env-internal default, deployment env-block dynamic-loop replaced with explicit ordered blocks (kills positional-swap diff), `container[0].image` added to `lifecycle.ignore_changes` (CI owns rollouts), helm-CLI destroy-provisioners hardened against legacy state via `lookup(self.triggers, "kubeconfig_path", "")`. |
| 5 | `Merge upstream/main into fix/dc-controlplane-services-helm-cli` | Routine catch-up merge; no logic conflicts beyond the three keep-HEAD blocks. |
| 6 | `Add dc-webhook module` | New module that deploys the dc-api mutating admission webhook (KubeVirt VM MAC pinning) on a Harvester host cluster. Self-signed TLS, namespace + RBAC + Deployment + Service + MutatingWebhookConfiguration. `webhook_domain` input (default `example.com`) controls the webhook handler name suffix so operators in shared clusters don't collide. |

## Why now

Several consumer environments had grown their own copy-paste of BFF /
VPC / hostname / cert-organisation wiring inside their per-env layers,
defeating the point of the OCD module split. Pulling those knobs back
into the module so the consumer layer becomes "module call + parameters"
only.

## Compatibility

* Existing consumers that don't pass the new BFF/VPC variables keep
  working — defaults are empty strings (BFF) or required (VPC, by
  design — VPC ingress bootstrap won't function without them).
* `oidc_audience` type change from `string` → `list(string)` IS a
  breaking change for any consumer passing a single string. Migration
  is one line: `oidc_audience = "abc"` → `oidc_audience = ["abc"]`.
* `dcapi_hostname` no longer has a default. Consumers must pick a
  hostname per environment (previously the module defaulted to
  `dcapi.lk.internal.wso2.com` which was env-vendor-specific).
* `ingress_additional_dns_names` added (default `[]`). Lets consumers
  append wildcard SANs without forking the module.

## Test plan

- [x] `terraform fmt -recursive modules/`
- [x] `terraform validate` clean on dc-controlplane-services and dc-webhook
- [x] `terraform plan` against a real dev environment shows zero
      noise after the env-order unroll + lifecycle.ignore_changes
- [x] `terraform apply` rolled cleanly on dev — TLS termination,
      helm-CLI workdir randomisation, BFF env wiring all landed
      without breaking existing pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)