### PR TITLE
Storage network  DHCP support,  Introduce ProjectMemberRestricted role,  Fix creating cluster when using Harvester cluster name instead of id.

### DIFF
--- a/modules/management/cluster-roles/main.tf
+++ b/modules/management/cluster-roles/main.tf
@@ -340,6 +340,162 @@ resource "rancher2_role_template" "cluster_contributor" {
   }
 }
 
+# ── Restricted project membership for Harvester VM tenants ───────────────────
+# Purpose: replace the built-in "project-member" role for tenants who provision
+# Harvester VMs. The built-in role inherits from the Kubernetes "edit"
+# ClusterRole which grants wildcard write access to all resources — including
+# harvesterhci.io/virtualmachineimages. Since Kubernetes RBAC is purely
+# additive (no deny verbs), there is no way to subtract image-write from an
+# inherited role. This custom role therefore does NOT inherit from "project-member"
+# or "edit"; instead it enumerates exactly the rules that Harvester VM tenants
+# need, with virtualmachineimages explicitly restricted to get/list/watch.
+#
+# Provides:
+#   - All explicit project-member rules (governance, UI, catalog, storage visibility)
+#   - Full Harvester VM lifecycle (create/start/stop/console/delete)
+#   - DataVolume (VM disk) management
+#   - SSH keypair management within the project
+#   - Cloud-init secrets and ConfigMaps
+#   - Read-only network attachment definitions (DC ops manages VLANs)
+#   - Read-only VM images (platform team manages the image catalogue)
+#
+# Does NOT provide:
+#   - virtualmachineimages create/update/delete/patch
+#   - Kubernetes pod/deployment/service creation (pure VM tenant use case)
+#   - Project membership management (project-member cannot manage its own members)
+resource "rancher2_role_template" "project_member_restricted" {
+  name        = "project-member-restricted"
+  description = "Project member role for Harvester VM tenants. Mirrors the built-in project-member capabilities with full VM lifecycle management added. VM image access is hard-restricted to read-only — tenants use images provisioned by the platform team and cannot create, upload, or delete them."
+  context     = "project"
+
+  # ── project-member explicit rules (excluding the 'edit' inheritance) ────────
+
+  rules {
+    api_groups = ["ui.cattle.io"]
+    resources  = ["navlinks"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["management.cattle.io"]
+    resources  = ["projectroletemplatebindings"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = [""]
+    resources  = ["namespaces"]
+    verbs      = ["create"]
+  }
+
+  rules {
+    api_groups = [""]
+    resources  = ["persistentvolumes"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["storageclasses"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["apiregistration.k8s.io"]
+    resources  = ["apiservices"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = [""]
+    resources  = ["persistentvolumeclaims"]
+    verbs      = ["*"]
+  }
+
+  rules {
+    api_groups = ["metrics.k8s.io"]
+    resources  = ["pods"]
+    verbs      = ["*"]
+  }
+
+  rules {
+    api_groups = ["management.cattle.io"]
+    resources  = ["clusterevents"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["catalog.cattle.io"]
+    resources  = ["clusterrepos", "operations", "releases", "apps"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups     = ["management.cattle.io"]
+    resources      = ["clusters"]
+    resource_names = ["local"]
+    verbs          = ["get"]
+  }
+
+  # ── Harvester VM lifecycle ─────────────────────────────────────────────────
+
+  rules {
+    api_groups = ["kubevirt.io"]
+    resources  = ["virtualmachines", "virtualmachineinstances", "virtualmachineinstancepresets", "virtualmachineinstancereplicasets"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rules {
+    api_groups = ["subresources.kubevirt.io"]
+    resources  = ["virtualmachines/start", "virtualmachines/stop", "virtualmachines/restart", "virtualmachines/migrate", "virtualmachineinstances/vnc", "virtualmachineinstances/console", "virtualmachineinstances/portforward", "virtualmachineinstances/pause", "virtualmachineinstances/unpause"]
+    verbs      = ["get", "update"]
+  }
+
+  rules {
+    api_groups = ["subresources.kubevirt.io"]
+    resources  = ["virtualmachineinstances/metrics"]
+    verbs      = ["get"]
+  }
+
+  rules {
+    api_groups = ["cdi.kubevirt.io"]
+    resources  = ["datavolumes"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  # VM images — READ ONLY. Tenants select from the platform-managed catalogue;
+  # create/update/delete/patch are intentionally absent.
+  rules {
+    api_groups = ["harvesterhci.io"]
+    resources  = ["virtualmachineimages"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["harvesterhci.io"]
+    resources  = ["keypairs"]
+    verbs      = ["get", "list", "watch", "create", "delete"]
+  }
+
+  rules {
+    api_groups = ["k8s.cni.cncf.io"]
+    resources  = ["network-attachment-definitions"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = [""]
+    resources  = ["secrets", "configmaps"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rules {
+    api_groups = [""]
+    resources  = ["services/proxy"]
+    verbs      = ["get"]
+  }
+}
+
 # Grants read-only visibility into VM status and metrics for the Harvester
 # dashboard. Intentionally excludes all mutating verbs (update, patch, delete)
 # and subresources that control VM power state (start, stop, restart, migrate).

--- a/modules/management/cluster-roles/outputs.tf
+++ b/modules/management/cluster-roles/outputs.tf
@@ -1,3 +1,8 @@
+output "project_member_restricted_role_id" {
+  value       = rancher2_role_template.project_member_restricted.id
+  description = "Role template ID for the project-member-restricted role. Replaces the built-in project-member for Harvester VM tenants. Grants full VM lifecycle management (create/start/stop/console/delete) with VM image access hard-restricted to read-only. Use in tenant-space group_role_bindings instead of the built-in 'project-member' or 'project-owner'."
+}
+
 output "project_contributor_role_id" {
   value       = rancher2_role_template.project_contributor.id
   description = "Role template ID for the project-contributor role. Grants namespace and member management within a project without the ability to change resource quotas or delete the project. Pass to tenant-space module's group_role_bindings for infrastructure operators and team leads."

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -4,9 +4,9 @@ locals {
   namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
   namespaces              = var.namespaces != null ? (var.create_default_namespace ? distinct(concat([var.project_name], var.namespaces)) : var.namespaces) : (var.create_default_namespace ? [var.project_name] : [])
 
-  # create_net_ns is true when explicitly requested OR when vlan_id has entries.
-  # Keeping backward compat: callers already using vlan_id still get the namespace.
-  create_net_ns     = var.create_network_namespace || (var.vlan_id != null && length(var.vlan_id) > 0)
+  # create_net_ns is true when explicitly requested, when any VLAN variable is set
+  # (all NADs live in the network namespace regardless of traffic type).
+  create_net_ns     = var.create_network_namespace || (var.vlan_id != null && length(var.vlan_id) > 0) || var.vm_network_vlan_id != null || var.storage_network_vlan_id != null
   network_namespace = local.create_net_ns ? coalesce(var.network_namespace_name, "${var.project_name}-net") : null
 
   # VyOS path: compute a deterministic /23 subnet from 10.0.0.0/8 using the VLAN
@@ -85,7 +85,8 @@ resource "rancher2_namespace" "this" {
   # quota would block VM creation when Rancher auto-applies a zero-limit
   # ResourceQuota to namespaces created via the API.
 
-  # field.cattle.io/projectId label is required for the harvester UI to show necessary quotas for the namespace
+  # field.cattle.io/projectId is required for the Harvester UI to show
+  # resource quota information correctly for namespaces in this project.
   labels = {
     "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
   }
@@ -106,7 +107,7 @@ resource "rancher2_namespace" "network" {
   project_id       = rancher2_project.this.id
   wait_for_cluster = false
 
-  # Set 0 limits so that no VMs can be provisioned in this namespace
+  # Zero-limit quota prevents any VMs from being created in the network namespace.
   resource_quota {
     limit {
       limits_cpu       = "0"
@@ -115,7 +116,6 @@ resource "rancher2_namespace" "network" {
     }
   }
 
-  # field.cattle.io/projectId label is required for the harvester UI to show necessary quotas for the namespace
   labels = {
     "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
     "platform.wso2.com/role"    = "network-namespace"
@@ -150,6 +150,40 @@ resource "harvester_network" "tenant" {
   # When VyOS is configured, wait for the vif/DHCP to be provisioned before
   # the network is visible to tenant VMs. for_each with empty set is a no-op.
   depends_on = [rancher2_namespace.network, module.vyos_tenant]
+}
+
+# ── VM network (simple path: vm_vlan_id) ──────────────────────────────────────
+# Created when vm_vlan_id is set. Attached to cluster_network_name (default 'vm-network').
+# Named <project_name>-vlan<id> by default. Always auto-routed.
+# For multi-VLAN or VyOS scenarios use the legacy vlan_id list below instead.
+
+resource "harvester_network" "vm" {
+  count                = var.vm_network_vlan_id != null ? 1 : 0
+  name                 = coalesce(var.vm_network_name, "${var.project_name}-vlan${var.vm_network_vlan_id}")
+  namespace            = rancher2_namespace.network[0].name
+  vlan_id              = var.vm_network_vlan_id
+  cluster_network_name = var.cluster_network_name
+  route_mode           = "auto"
+
+  depends_on = [rancher2_namespace.network]
+}
+
+# ── Storage network (only when storage_vlan_id is set) ────────────────────────
+# Attached to storage_cluster_network_name (default 'storage-network'), which maps
+# to the dedicated storage NIC (e.g. enp2s0) on the Harvester nodes.
+# Always auto-routed — the upstream switch advertises the storage gateway.
+# Route and DHCP settings for this interface are handled by VM cloud-init
+# (use-routes: false on enp2s0 ensures no default route is stolen from the VM NIC).
+
+resource "harvester_network" "storage" {
+  count                = var.storage_network_vlan_id != null ? 1 : 0
+  name                 = coalesce(var.storage_network_name, "${var.project_name}-strg-vlan${var.storage_network_vlan_id}")
+  namespace            = rancher2_namespace.network[0].name
+  vlan_id              = var.storage_network_vlan_id
+  cluster_network_name = var.storage_cluster_network_name
+  route_mode           = "auto"
+
+  depends_on = [rancher2_namespace.network]
 }
 
 # ── VyOS configuration (only when vyos_endpoint is also set) ──────────────────
@@ -221,4 +255,48 @@ resource "rancher2_project_role_template_binding" "this" {
   project_id         = rancher2_project.this.id
   role_template_id   = each.value.role_template_id
   group_principal_id = each.value.group_principal_id
+}
+
+# ── Shared image access ────────────────────────────────────────────────────────
+# Grants each unique group in group_role_bindings a read-only binding to the
+# shared images project. Using rancher2_project_role_template_binding (Rancher-
+# native) rather than kubernetes_role_binding_v1. Groups are deduplicated and
+# sorted so the idx-based key is stable across plan/apply runs.
+#
+# The shared project is discovered by name (shared_image_project_name, default
+# "shared") so callers do not need to pass a project ID. The data source is
+# guarded by both enable_shared_image_access AND the presence of at least one
+# group binding — this prevents a spurious lookup when the module itself IS the
+# shared space (no group_role_bindings configured) or when access is disabled.
+#
+# Callers should ensure the shared project exists before this module runs by
+# adding depends_on = [module.shared_space] at the module call site.
+
+locals {
+  # Sort unique group principals for a stable idx → group mapping.
+  _sorted_image_groups = var.enable_shared_image_access ? sort(distinct([
+    for b in var.group_role_bindings : b.group_principal_id
+  ])) : []
+
+  # Map: "<project_name>-img-<idx>" => group_principal_id
+  # e.g. "kasun-test-img-0" => "genericoidc_group://testgroup"
+  shared_image_bindings = {
+    for idx, group in local._sorted_image_groups :
+    "${var.project_name}-img-${idx}" => group
+  }
+}
+
+data "rancher2_project" "shared_images" {
+  count      = var.enable_shared_image_access && length(local._sorted_image_groups) > 0 ? 1 : 0
+  cluster_id = var.cluster_id
+  name       = var.shared_image_project_name
+}
+
+resource "rancher2_project_role_template_binding" "shared_image_access" {
+  for_each = local.shared_image_bindings
+
+  name               = each.key
+  project_id         = data.rancher2_project.shared_images[0].id
+  role_template_id   = "read-only"
+  group_principal_id = each.value
 }

--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -169,7 +169,7 @@ resource "harvester_network" "vm" {
 }
 
 # ── Storage network (only when storage_vlan_id is set) ────────────────────────
-# Attached to storage_cluster_network_name (default 'storage-network'), which maps
+# Attached to storage_cluster_network_name (default 'strg-network'), which maps
 # to the dedicated storage NIC (e.g. enp2s0) on the Harvester nodes.
 # Always auto-routed — the upstream switch advertises the storage gateway.
 # Route and DHCP settings for this interface are handled by VM cloud-init

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -95,6 +95,33 @@ variable "namespace_storage_limit" {
   }
 }
 
+# ── Simple VM / storage network (new approach) ───────────────────────────────
+# Pass a single VLAN ID for each traffic type. The module auto-creates the
+# harvester_network with a deterministic name and the correct cluster NIC.
+# Naming: vm → <project>-vlan<id>   storage → <project>-strg-vlan<id>
+# Use vm_vlan_id / storage_vlan_id for new tenants. The legacy vlan_id list
+# below remains for brownfield imports and multi-VLAN configurations.
+
+variable "vm_network_vlan_id" {
+  type        = number
+  description = "VLAN ID for the primary VM network. Creates a harvester_network named '<project_name>-vlan<id>' attached to cluster_network_name (default 'vm-network'). Always auto-routed. Use this instead of the legacy vlan_id list for simple single-VLAN tenants."
+  default     = null
+  validation {
+    condition     = var.vm_network_vlan_id == null || (var.vm_network_vlan_id >= 1 && var.vm_network_vlan_id <= 4094)
+    error_message = "vm_network_vlan_id must be null or a valid 802.1Q VLAN ID (1–4094)."
+  }
+}
+
+variable "vm_network_name" {
+  type        = string
+  description = "Override the harvester_network name for vm_network_vlan_id. Defaults to '<project_name>-vlan<id>'. Use when importing a brownfield VM network whose name differs from this convention."
+  default     = null
+  validation {
+    condition     = var.vm_network_name == null ? true : trimspace(var.vm_network_name) != ""
+    error_message = "vm_network_name must be null or a non-empty string."
+  }
+}
+
 # ── VyOS network integration — all optional ───────────────────────────────────
 # When vlan_id is set, the module additionally creates:
 #   - A "<project_name>-net" namespace in the project (network namespace)
@@ -170,6 +197,42 @@ variable "group_role_bindings" {
   default     = []
 }
 
+# ── Shared image access — all optional ───────────────────────────────────────
+# When enabled, each unique group in group_role_bindings receives a read-only
+# project-level binding to the shared images project. This uses Rancher-native
+# project role template bindings (not raw Kubernetes RoleBindings) and avoids
+# granting the tenant groups access to the images namespace via project-owner
+# or project-member, which would silently include all other namespaces.
+#
+# Backwards-compatible: defaults to false, so existing tenant spaces are
+# completely unaffected unless they explicitly opt in.
+
+variable "enable_shared_image_access" {
+  type        = bool
+  description = "When true (default), creates a Rancher read-only project role binding for each unique group in group_role_bindings to the shared images project. Set to false only for tenant spaces that should not see the shared image catalogue (e.g. the shared space itself)."
+  default     = true
+}
+
+variable "shared_image_project_name" {
+  type        = string
+  description = "Name of the Rancher project that holds shared VM images. The module looks this project up by name on the same cluster. Defaults to 'shared'. Only change if your environment uses a different project name for the image catalogue."
+  default     = "shared"
+  validation {
+    condition     = trimspace(var.shared_image_project_name) != ""
+    error_message = "shared_image_project_name must be a non-empty string."
+  }
+}
+
+variable "shared_image_namespace" {
+  type        = string
+  description = "Name of the namespace within the shared images project that holds VM images. Informational — used in resource naming only; access is granted at the project level. Defaults to 'images'."
+  default     = "images"
+  validation {
+    condition     = trimspace(var.shared_image_namespace) != ""
+    error_message = "shared_image_namespace must be a non-empty string."
+  }
+}
+
 variable "expose_vm_kubeconfig" {
   type        = bool
   description = "When true, reads the 'harvester-vm-kubeconfig' Secret created by the namespace-credential-provisioner and exposes it via the vm_access_kubeconfig output. Requires the kubernetes.harvester provider alias to be configured in the caller. The provisioner must have run before apply."
@@ -197,4 +260,40 @@ variable "vyos_api_key" {
   description = "VyOS HTTPS API key. Required when vlan_id is set."
   sensitive   = true
   default     = null
+}
+
+# ── Storage network ───────────────────────────────────────────────────────────
+# Creates a harvester_network attached to a dedicated storage cluster network
+# (typically a separate physical NIC, e.g. enp2s0) rather than the VM network.
+# Storage networks are always auto-routed — the upstream switch handles routing.
+# Separate from vlan_id so callers can use different cluster networks per traffic type.
+
+variable "storage_network_vlan_id" {
+  type        = number
+  description = "VLAN ID for the dedicated storage network. Creates a harvester_network named '<project_name>-strg-vlan<id>' attached to storage_cluster_network_name (default 'storage-network'). Storage is always auto-routed. When set, the network namespace is always created. Separate from vlan_id which targets cluster_network_name (default 'vm-network')."
+  default     = null
+  validation {
+    condition     = var.storage_network_vlan_id == null || (var.storage_network_vlan_id >= 1 && var.storage_network_vlan_id <= 4094)
+    error_message = "storage_network_vlan_id must be null or a valid 802.1Q VLAN ID (1–4094)."
+  }
+}
+
+variable "storage_cluster_network_name" {
+  type        = string
+  description = "Harvester cluster network for the storage VLAN. Should map to the dedicated storage NIC (e.g. enp2s0). Defaults to 'storage-network' — override only if your datacenter uses a different cluster network name for storage traffic."
+  default     = "storage-network"
+  validation {
+    condition     = trimspace(var.storage_cluster_network_name) != ""
+    error_message = "storage_cluster_network_name must be a non-empty string."
+  }
+}
+
+variable "storage_network_name" {
+  type        = string
+  description = "Override the harvester_network name for storage_network_vlan_id. Defaults to '<project_name>-strg-vlan<id>'. Use when importing a brownfield storage network whose name differs from this convention."
+  default     = null
+  validation {
+    condition     = var.storage_network_name == null ? true : trimspace(var.storage_network_name) != ""
+    error_message = "storage_network_name must be null or a non-empty string."
+  }
 }

--- a/modules/management/tenant-space/variables.tf
+++ b/modules/management/tenant-space/variables.tf
@@ -204,12 +204,13 @@ variable "group_role_bindings" {
 # granting the tenant groups access to the images namespace via project-owner
 # or project-member, which would silently include all other namespaces.
 #
-# Backwards-compatible: defaults to false, so existing tenant spaces are
-# completely unaffected unless they explicitly opt in.
+# Defaults to true so all tenant spaces get read-only image access out of the
+# box. Set to false only for spaces that should not see the shared catalogue
+# (e.g. the shared space itself).
 
 variable "enable_shared_image_access" {
   type        = bool
-  description = "When true (default), creates a Rancher read-only project role binding for each unique group in group_role_bindings to the shared images project. Set to false only for tenant spaces that should not see the shared image catalogue (e.g. the shared space itself)."
+  description = "When true, creates a read-only Rancher project role binding for each group in group_role_bindings to the shared images project. Set to false for tenant spaces that should not see the shared image catalogue (e.g. the shared space itself)."
   default     = true
 }
 
@@ -270,7 +271,7 @@ variable "vyos_api_key" {
 
 variable "storage_network_vlan_id" {
   type        = number
-  description = "VLAN ID for the dedicated storage network. Creates a harvester_network named '<project_name>-strg-vlan<id>' attached to storage_cluster_network_name (default 'storage-network'). Storage is always auto-routed. When set, the network namespace is always created. Separate from vlan_id which targets cluster_network_name (default 'vm-network')."
+  description = "VLAN ID for the dedicated storage network. Creates a harvester_network named '<project_name>-strg-vlan<id>' attached to storage_cluster_network_name (default 'strg-network'). Storage is always auto-routed. When set, the network namespace is always created. Separate from vlan_id which targets cluster_network_name (default 'vm-network')."
   default     = null
   validation {
     condition     = var.storage_network_vlan_id == null || (var.storage_network_vlan_id >= 1 && var.storage_network_vlan_id <= 4094)
@@ -280,8 +281,8 @@ variable "storage_network_vlan_id" {
 
 variable "storage_cluster_network_name" {
   type        = string
-  description = "Harvester cluster network for the storage VLAN. Should map to the dedicated storage NIC (e.g. enp2s0). Defaults to 'storage-network' — override only if your datacenter uses a different cluster network name for storage traffic."
-  default     = "storage-network"
+  description = "Harvester cluster network for the storage VLAN. Should map to the dedicated storage NIC (e.g. enp2s0). Defaults to 'strg-network' — override only if your datacenter uses a different cluster network name for storage traffic."
+  default     = "strg-network"
   validation {
     condition     = trimspace(var.storage_cluster_network_name) != ""
     error_message = "storage_cluster_network_name must be a non-empty string."

--- a/modules/workloads/k8s-cluster/main.tf
+++ b/modules/workloads/k8s-cluster/main.tf
@@ -15,15 +15,24 @@ terraform {
 locals {
   pools_by_name = { for p in var.machine_pools : p.name => p }
 
+  # Inject the storage interface netplan (enp2s0 / use-routes: false) when:
+  #   - at least one pool declares a storage_network, AND
+  #   - the caller is using generated user_data (not an explicit user_data string).
+  # Callers passing explicit user_data are responsible for the netplan themselves.
+  _using_generated_user_data = var.user_data == null || var.user_data == ""
+  _any_pool_has_storage      = anytrue([for p in var.machine_pools : p.storage_network != null])
+  _inject_storage_netplan    = local._any_pool_has_storage && local._using_generated_user_data
+
   # Generate node cloud-init from first-class variables when user_data is not provided.
   # user_data (non-empty string) takes full precedence — generation is skipped entirely.
-  _generated_node_user_data = (var.node_password != null || length(var.ssh_authorized_keys) > 0 || var.ntp_server != "") ? templatefile(
+  _generated_node_user_data = (var.node_password != null || length(var.ssh_authorized_keys) > 0 || var.ntp_server != "" || local._inject_storage_netplan) ? templatefile(
     "${path.module}/templates/node-cloud-init.tpl",
     {
-      ssh_user            = var.ssh_user
-      node_password       = var.node_password
-      ssh_authorized_keys = var.ssh_authorized_keys
-      ntp_server          = var.ntp_server
+      ssh_user               = var.ssh_user
+      node_password          = var.node_password
+      ssh_authorized_keys    = var.ssh_authorized_keys
+      ntp_server             = var.ntp_server
+      enable_storage_netplan = local._inject_storage_netplan
     }
   ) : ""
 
@@ -127,7 +136,11 @@ resource "rancher2_machine_config_v2" "pool" {
 
     network_info = jsonencode({
       interfaces = [
-        for net in each.value.networks : {
+        for net in compact(concat(
+          each.value.vm_network != null ? [each.value.vm_network] : [],
+          each.value.networks,
+          each.value.storage_network != null ? [each.value.storage_network] : []
+        )) : {
           networkName = net
           macAddress  = ""
         }

--- a/modules/workloads/k8s-cluster/main.tf
+++ b/modules/workloads/k8s-cluster/main.tf
@@ -312,7 +312,7 @@ data "rancher2_cluster" "harvester" {
 
 data "rancher2_cluster_v2" "harvester" {
   count = var.create_cloud_credential ? 1 : 0
-  name  = var.harvester_cluster_name != "" ? data.rancher2_cluster.harvester[0].name : var.harvester_cluster_id
+  name  = var.harvester_cluster_name != "" ? data.rancher2_cluster.harvester[0].id : var.harvester_cluster_id
 }
 
 data "http" "harvester_cloud_provider_kubeconfig" {

--- a/modules/workloads/k8s-cluster/main.tf
+++ b/modules/workloads/k8s-cluster/main.tf
@@ -15,28 +15,10 @@ terraform {
 locals {
   pools_by_name = { for p in var.machine_pools : p.name => p }
 
-  # Inject the storage interface netplan (enp2s0 / use-routes: false) when:
-  #   - at least one pool declares a storage_network, AND
-  #   - the caller is using generated user_data (not an explicit user_data string).
-  # Callers passing explicit user_data are responsible for the netplan themselves.
+  # user_data (non-empty string) takes full precedence over template generation.
+  # When not set, cloud-init is generated per-pool so enable_storage_netplan
+  # reflects only that pool's storage_network field (not a cluster-wide flag).
   _using_generated_user_data = var.user_data == null || var.user_data == ""
-  _any_pool_has_storage      = anytrue([for p in var.machine_pools : p.storage_network != null])
-  _inject_storage_netplan    = local._any_pool_has_storage && local._using_generated_user_data
-
-  # Generate node cloud-init from first-class variables when user_data is not provided.
-  # user_data (non-empty string) takes full precedence — generation is skipped entirely.
-  _generated_node_user_data = (var.node_password != null || length(var.ssh_authorized_keys) > 0 || var.ntp_server != "" || local._inject_storage_netplan) ? templatefile(
-    "${path.module}/templates/node-cloud-init.tpl",
-    {
-      ssh_user               = var.ssh_user
-      node_password          = var.node_password
-      ssh_authorized_keys    = var.ssh_authorized_keys
-      ntp_server             = var.ntp_server
-      enable_storage_netplan = local._inject_storage_netplan
-    }
-  ) : ""
-
-  effective_node_user_data = (var.user_data != null && var.user_data != "") ? var.user_data : local._generated_node_user_data
 
   harvester_kubeconfig = (var.create_cloud_credential && length(data.http.harvester_cloud_provider_kubeconfig) > 0) ? (
     data.http.harvester_cloud_provider_kubeconfig[0].status_code == 200 ? jsondecode(data.http.harvester_cloud_provider_kubeconfig[0].response_body) : null
@@ -124,7 +106,18 @@ resource "rancher2_machine_config_v2" "pool" {
     memory_size          = each.value.memory_size
     reserved_memory_size = "-1"
     ssh_user             = var.ssh_user
-    user_data            = local.effective_node_user_data
+    user_data = (var.user_data != null && var.user_data != "") ? var.user_data : (
+      (var.node_password != null || length(var.ssh_authorized_keys) > 0 || var.ntp_server != "" || (local._using_generated_user_data && each.value.storage_network != null)) ? templatefile(
+        "${path.module}/templates/node-cloud-init.tpl",
+        {
+          ssh_user               = var.ssh_user
+          node_password          = var.node_password
+          ssh_authorized_keys    = var.ssh_authorized_keys
+          ntp_server             = var.ntp_server
+          enable_storage_netplan = each.value.storage_network != null
+        }
+      ) : ""
+    )
 
     disk_info = jsonencode({
       disks = [{
@@ -140,7 +133,7 @@ resource "rancher2_machine_config_v2" "pool" {
           each.value.vm_network != null ? [each.value.vm_network] : [],
           each.value.networks,
           each.value.storage_network != null ? [each.value.storage_network] : []
-        )) : {
+          )) : {
           networkName = net
           macAddress  = ""
         }

--- a/modules/workloads/k8s-cluster/templates/node-cloud-init.tpl
+++ b/modules/workloads/k8s-cluster/templates/node-cloud-init.tpl
@@ -35,6 +35,19 @@ write_files:
       nf_conntrack
     owner: root:root
     permissions: '0644'
+%{~ if enable_storage_netplan }
+  - path: /etc/netplan/60-storage-network.yaml
+    owner: root:root
+    permissions: '0600'
+    content: |
+      network:
+        version: 2
+        ethernets:
+          enp2s0:
+            dhcp4: true
+            dhcp4-overrides:
+              use-routes: false
+%{~ endif }
 runcmd:
   - - systemctl
     - enable
@@ -49,6 +62,10 @@ runcmd:
   - systemctl restart systemd-timesyncd
   - timedatectl set-ntp false
   - timedatectl set-ntp true
+%{~ if enable_storage_netplan }
+  - netplan generate
+  - netplan apply
+%{~ endif }
 %{~ if length(ssh_authorized_keys) > 0 }
 ssh_authorized_keys:
 %{~ for key in ssh_authorized_keys }

--- a/modules/workloads/k8s-cluster/variables.tf
+++ b/modules/workloads/k8s-cluster/variables.tf
@@ -87,14 +87,28 @@ variable "registries" {
 # entries for larger ones.
 variable "machine_pools" {
   type = list(object({
-    name          = string
-    vm_namespace  = string
-    quantity      = number
-    cpu_count     = string       # string expected by Harvester API e.g. "4"
-    memory_size   = string       # GiB as string e.g. "12"
-    disk_size     = number       # GiB as integer
-    image_name    = string       # "namespace/image-id"
-    networks      = list(string) # ["ns/nad", "iaas/storage-network", ...]
+    name         = string
+    vm_namespace = string
+    quantity     = number
+    cpu_count    = string # string expected by Harvester API e.g. "4"
+    memory_size  = string # GiB as string e.g. "12"
+    disk_size    = number # GiB as integer
+    image_name   = string # "namespace/image-id"
+
+    # ── Network interfaces ────────────────────────────────────────────────────
+    # Simple path (new): declare vm_network and/or storage_network as single refs.
+    #   vm_network      → first interface (primary NIC, gets default route)
+    #   storage_network → last interface (storage NIC, use-routes: false via cloud-init)
+    #   networks        → any additional interfaces inserted between the two above
+    #
+    # Legacy path (backward compat): set networks with the full list in order.
+    #   networks = ["ns/vm-nad", "ns/storage-nad", ...]
+    #
+    # Final interface order: [vm_network, ...networks, storage_network]
+    vm_network      = optional(string)       # primary VM network ref e.g. "kasun-test-net/kasun-test-vlan601"
+    storage_network = optional(string)       # storage network ref   e.g. "kasun-test-net/kasun-test-strg-vlan698"
+    networks        = optional(list(string), []) # additional or legacy full network list
+
     control_plane = bool
     etcd          = bool
     worker        = bool

--- a/modules/workloads/k8s-cluster/variables.tf
+++ b/modules/workloads/k8s-cluster/variables.tf
@@ -105,8 +105,8 @@ variable "machine_pools" {
     #   networks = ["ns/vm-nad", "ns/storage-nad", ...]
     #
     # Final interface order: [vm_network, ...networks, storage_network]
-    vm_network      = optional(string)       # primary VM network ref e.g. "kasun-test-net/kasun-test-vlan601"
-    storage_network = optional(string)       # storage network ref   e.g. "kasun-test-net/kasun-test-strg-vlan698"
+    vm_network      = optional(string)           # primary VM network ref e.g. "kasun-test-net/kasun-test-vlan601"
+    storage_network = optional(string)           # storage network ref   e.g. "kasun-test-net/kasun-test-strg-vlan698"
     networks        = optional(list(string), []) # additional or legacy full network list
 
     control_plane = bool
@@ -147,6 +147,26 @@ variable "machine_pools" {
       ])
     ])
     error_message = "Each taint effect must be one of: NoSchedule, PreferNoSchedule, NoExecute."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.machine_pools : (
+        (p.vm_network == null || trimspace(p.vm_network) != "") &&
+        (p.storage_network == null || trimspace(p.storage_network) != "") &&
+        alltrue([for n in p.networks : trimspace(n) != ""]) &&
+        length(distinct(compact(concat(
+          p.vm_network != null ? [p.vm_network] : [],
+          p.networks,
+          p.storage_network != null ? [p.storage_network] : []
+          )))) == length(compact(concat(
+          p.vm_network != null ? [p.vm_network] : [],
+          p.networks,
+          p.storage_network != null ? [p.storage_network] : []
+        )))
+      )
+    ])
+    error_message = "Each pool's network refs must be non-empty strings with no duplicates across vm_network, networks, and storage_network."
   }
 }
 


### PR DESCRIPTION
## Summary

This PR introduces structured VM and storage network separation across the
tenant-space and k8s-cluster modules, eliminates manual cloud-init management
for storage NICs, and adds tenant-level image access control primitives.

### tenant-space module

- Added `vm_network_vlan_id` and `storage_network_vlan_id` as dedicated
  first-class variables. Each creates a correctly named NAD attached to the
  right cluster NIC (`vm-network` for VM traffic, `storage-network` for storage
  traffic) — previously both VLANs were attached to `vm-network`.
- Auto-naming convention: VM networks → `<project>-vlan<id>`, storage networks
  → `<project>-strg-vlan<id>`. No `vlan_network_names` map required for the
  new path.
- New outputs `vm_network_ref` and `storage_network_ref` expose the full
  `<namespace>/<name>` references for direct use in k8s-cluster machine pools.
- Added `enable_shared_image_access` variable (default `true`) that creates a
  read-only Rancher project role binding for each tenant group to the shared
  images project, giving all tenant spaces access to the platform image
  catalogue out of the box.
- Legacy `vlan_id` + `vlan_network_names` path is fully preserved — existing
  tenant spaces are unaffected.

### k8s-cluster module

- Machine pool objects now accept `vm_network` and `storage_network` as named
  optional fields. Interface ordering is enforced as
  `[vm_network, ...networks, storage_network]`, guaranteeing the storage NIC
  always lands on `enp2s0`.
- `networks` is now optional (default `[]`), supporting both the new structured
  path and the legacy full-list path.
- When `storage_network` is set on any pool and no explicit `user_data` is
  provided, the generated cloud-init automatically writes
  `/etc/netplan/60-storage-network.yaml` (DHCP with `use-routes: false`) and
  runs `netplan generate && netplan apply` via `runcmd`. No manual SSH or
  post-boot steps required.
- Removed top-level `storage_network_ref` variable (superseded by per-pool
  `storage_network` field).

### cluster-roles module

- Added `project-member-restricted` role template: mirrors all built-in
  `project-member` explicit rules plus full Harvester VM lifecycle management,
  with image access hard-restricted to read-only. Intended for tenant groups
  that should manage VMs but not upload or delete images.

