### PR TITLE
Add Key Vault operator deployment module

### DIFF
--- a/modules/management/dc-controlplane-services/main.tf
+++ b/modules/management/dc-controlplane-services/main.tf
@@ -520,6 +520,166 @@ resource "kubernetes_service" "dc_api" {
   }
 }
 
+# ── cloud-ui Deployment + Service ─────────────────────────────────────────────
+# Same pattern as dc-api above: TF owns the shape (replicas, probes, security
+# context, volumes); CI owns the container image via `kubectl set image`.
+# The lifecycle ignore on image lets the two coexist without diff churn.
+#
+# cloud-ui is a static SPA (nginx-unprivileged) with no env-var or Secret
+# dependency, so no ConfigMap is wired up here.
+#
+# Gated on cloudui_image so consumers that haven't built a cloud-ui yet can
+# leave it unset and skip the Deployment + Service entirely. The Ingress
+# stays independent: it gates on cloudui_hostname only and is harmless when
+# the backend Service is missing (nginx returns 503 until the Service shows
+# up — either via TF on the next apply or via the CI workflow).
+resource "kubernetes_deployment" "cloud_ui" {
+  count = var.cloudui_image != "" ? 1 : 0
+
+  metadata {
+    name      = "cloud-ui"
+    namespace = kubernetes_namespace.dc_system.metadata[0].name
+    labels = {
+      app = "cloud-ui"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations,
+      spec[0].template[0].spec[0].container[0].image,
+    ]
+  }
+
+  spec {
+    replicas = var.cloudui_replicas
+
+    selector {
+      match_labels = {
+        app = "cloud-ui"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "cloud-ui"
+        }
+      }
+
+      spec {
+        # nginx-unprivileged runs as uid/gid 101 (nginx group).
+        security_context {
+          run_as_non_root = true
+          run_as_user     = 101
+          run_as_group    = 101
+        }
+
+        image_pull_secrets {
+          name = kubernetes_secret.ghcr_pull.metadata[0].name
+        }
+
+        container {
+          name              = "cloud-ui"
+          image             = var.cloudui_image
+          image_pull_policy = "Always"
+
+          port {
+            container_port = 8080
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+            read_only_root_filesystem  = true
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8080
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 15
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8080
+            }
+            initial_delay_seconds = 3
+            period_seconds        = 10
+          }
+
+          resources {
+            requests = {
+              cpu    = "50m"
+              memory = "64Mi"
+            }
+            limits = {
+              cpu    = "200m"
+              memory = "256Mi"
+            }
+          }
+
+          # nginx-unprivileged needs writable /tmp + two nginx dirs.
+          # tmpfs everything so the root FS stays read-only.
+          volume_mount {
+            name       = "tmp"
+            mount_path = "/tmp"
+          }
+          volume_mount {
+            name       = "nginx-cache"
+            mount_path = "/var/cache/nginx"
+          }
+          volume_mount {
+            name       = "nginx-run"
+            mount_path = "/var/run"
+          }
+        }
+
+        volume {
+          name = "tmp"
+          empty_dir {}
+        }
+        volume {
+          name = "nginx-cache"
+          empty_dir {}
+        }
+        volume {
+          name = "nginx-run"
+          empty_dir {}
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "cloud_ui" {
+  count = var.cloudui_image != "" ? 1 : 0
+
+  metadata {
+    name      = var.cloudui_service_name
+    namespace = kubernetes_namespace.dc_system.metadata[0].name
+    labels = {
+      app = "cloud-ui"
+    }
+  }
+  spec {
+    type = "ClusterIP"
+    selector = {
+      app = "cloud-ui"
+    }
+    port {
+      port        = var.cloudui_service_port
+      target_port = 8080
+    }
+  }
+}
+
 # ── TLS — self-signed certificate for the DC-API ingress ─────────────────────
 # Dev cluster, internal hostname, no public CA path available.
 # Valid for 1 year. Re-running apply after expiry regenerates it automatically.
@@ -537,10 +697,11 @@ resource "tls_self_signed_cert" "dc_api" {
     organization = "WSO2 LK Datacenter (dev)"
   }
 
-  dns_names = concat(
+  dns_names = distinct(compact(concat(
     [var.dcapi_hostname],
+    var.auto_include_cloudui_in_tls_sans && var.cloudui_hostname != "" ? [var.cloudui_hostname] : [],
     var.ingress_additional_dns_names,
-  )
+  )))
 
   validity_period_hours = 8760 # 1 year
 
@@ -626,6 +787,58 @@ resource "kubernetes_ingress_v1" "dc_api" {
               name = kubernetes_service.dc_api.metadata[0].name
               port {
                 number = 80
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── cloud-ui Ingress + TLS reuse ──────────────────────────────────────────────
+# The cloud-ui Deployment + Service are applied by the cloud-ui GitHub workflow
+# (not by this module). After a cluster rebuild that Ingress would be missing
+# until the next workflow run, leaving cloud-ui unreachable. Keeping the
+# Ingress here means routing is restored as part of the TF apply; the Service
+# the Ingress points at appears as soon as the workflow runs.
+#
+# The cert this Ingress references is the same dc-api self-signed cert — its
+# SAN list includes any wildcards passed via ingress_additional_dns_names, so
+# a single browser warning covers both hostnames.
+resource "kubernetes_ingress_v1" "cloud_ui" {
+  count = var.cloudui_hostname != "" ? 1 : 0
+
+  metadata {
+    name      = "cloud-ui"
+    namespace = kubernetes_namespace.dc_system.metadata[0].name
+    annotations = {
+      "nginx.ingress.kubernetes.io/proxy-read-timeout" = "3600"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout" = "3600"
+    }
+  }
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+  spec {
+    ingress_class_name = "nginx"
+
+    tls {
+      hosts       = [var.cloudui_hostname]
+      secret_name = kubernetes_secret_v1.dc_api_tls.metadata[0].name
+    }
+
+    rule {
+      host = var.cloudui_hostname
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = var.cloudui_service_name
+              port {
+                number = var.cloudui_service_port
               }
             }
           }

--- a/modules/management/dc-controlplane-services/variables.tf
+++ b/modules/management/dc-controlplane-services/variables.tf
@@ -57,8 +57,44 @@ variable "dcapi_hostname" {
 
 variable "ingress_additional_dns_names" {
   type        = list(string)
-  description = "Extra DNS names to add to the self-signed cert's SAN list (e.g. environment wildcards like *.dev.example.com). Empty by default — the cert only covers dcapi_hostname."
+  description = "Extra DNS names to add to the self-signed cert's SAN list (e.g. environment wildcards like *.dev.example.com). Empty by default — the cert only covers dcapi_hostname. Setting a wildcard here is what lets a single cert cover both dc-api and cloud-ui Ingresses without two browser warnings."
   default     = []
+}
+
+variable "cloudui_hostname" {
+  type        = string
+  description = "Public hostname for the cloud-ui ingress. When non-empty, this module creates an Ingress that routes the hostname to a Service named 'cloud-ui' in the dc-system namespace, AND — if cloudui_image is also set — the cloud-ui Deployment + Service themselves. The Ingress re-uses the dc-api self-signed cert via SAN; either set ingress_additional_dns_names to a wildcard that covers cloudui_hostname, or enable auto_include_cloudui_in_tls_sans to have the module add it explicitly. Set to empty string to opt out."
+  default     = ""
+}
+
+variable "auto_include_cloudui_in_tls_sans" {
+  type        = bool
+  description = "When true AND cloudui_hostname is non-empty, the dc-api self-signed cert's SAN list automatically includes cloudui_hostname. Defaults to false so existing deployments that already cover cloud-ui via ingress_additional_dns_names (e.g. a wildcard) don't regenerate their cert on apply. New consumers who don't want to manage SANs manually should set this true."
+  default     = false
+}
+
+variable "cloudui_service_name" {
+  type        = string
+  description = "Backend Service name the cloud-ui Ingress points at. Defaults to 'cloud-ui' — matching the cloud-ui workflow's Service manifest. Override only if the consumer renames the Service."
+  default     = "cloud-ui"
+}
+
+variable "cloudui_service_port" {
+  type        = number
+  description = "Backend Service port the cloud-ui Ingress points at."
+  default     = 80
+}
+
+variable "cloudui_image" {
+  type        = string
+  description = "Container image for the cloud-ui Deployment (e.g. registry/cloud-ui:sha). When empty, the Deployment + Service are skipped entirely — useful for environments that don't ship a cloud-ui. CI is expected to roll the image forward via `kubectl set image`; the Deployment's lifecycle ignores image changes so TF and CI don't fight."
+  default     = ""
+}
+
+variable "cloudui_replicas" {
+  type        = number
+  description = "Replica count for the cloud-ui Deployment."
+  default     = 1
 }
 
 variable "tenant_group_prefix" {

--- a/modules/management/dc-controlplane/main.tf
+++ b/modules/management/dc-controlplane/main.tf
@@ -31,21 +31,173 @@ resource "harvester_network" "mgmt" {
 
   lifecycle {
     ignore_changes = [labels]
+
+    precondition {
+      condition     = var.create_local_storage_class || var.node_image_name != ""
+      error_message = "node_image_name is required when create_local_storage_class is false. Pass a pre-existing image reference (typically the 00-bootstrap layer's vm_image_id output)."
+    }
   }
 
   depends_on = [module.project]
 }
 
+# ── VM root-disk StorageClass (Longhorn, 1 replica, strict-local) ────────────
+# Provisioned on the Harvester HOST cluster — that's where Longhorn actually
+# runs. The downstream control-plane VMs reference this SC by name in their
+# HarvesterConfig disk_info; Harvester then provisions each VM's root disk
+# as a single-replica volume pinned to the same host as the VM.
+#
+# Trade: losing the Harvester node hosting a VM loses that VM's root disk
+# (no replicated copy elsewhere). etcd quorum at the application layer is
+# what makes this acceptable for control-plane clusters — losing 1 of 3
+# VMs is survivable; 2 of 3 is not. With only 2 Harvester hosts available,
+# at-rest layout will be unavoidably 2 VMs on one host, 1 on the other.
+resource "kubernetes_storage_class_v1" "vm_local" {
+  count    = var.create_local_storage_class ? 1 : 0
+  provider = kubernetes.harvester
+
+  metadata {
+    name = var.local_storage_class_name
+  }
+
+  storage_provisioner    = "driver.longhorn.io"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "Immediate"
+  allow_volume_expansion = true
+
+  # dataLocality: Harvester's validator webhook rejects "strict-local"
+  # because it would forbid VM live-migration of any workload using this
+  # SC. "best-effort" tells Longhorn to TRY to co-locate the replica with
+  # the consumer, but allow migration when needed. Single-replica + best-
+  # effort gets us the no-network-replication fsync benefit (the actual
+  # bottleneck) without fighting Harvester's migration model.
+  parameters = {
+    numberOfReplicas    = "1"
+    dataLocality        = "best-effort"
+    fsType              = "ext4"
+    migratable          = "true"
+    staleReplicaTimeout = "30"
+  }
+}
+
+# Resolved SC name for the VM root disks. Empty string = let Harvester use
+# the host cluster's default StorageClass (the original module behaviour).
+locals {
+  vm_storage_class_name = (
+    var.vm_storage_class_override != "" ? var.vm_storage_class_override :
+    var.create_local_storage_class ? var.local_storage_class_name :
+    ""
+  )
+}
+
+# ── VirtualMachineImage on the local SC ──────────────────────────────────────
+# Harvester's VM provisioner ignores the storageClassName field passed via
+# HarvesterConfig.disk_info — it clones the boot disk from the source image's
+# PVC and the cloned PVC inherits the SOURCE image's StorageClass, not the
+# requested one. To actually land VM root disks on dcapi-controlplane-local
+# we have to give the source image itself that SC. So when the operator opts
+# into the local SC, the module also creates its own VirtualMachineImage in
+# the project namespace, downloaded from the same upstream URL, but with
+# storageClassName pinned. VMs cloned from this image inherit the local SC.
+resource "harvester_image" "dcapi_node" {
+  count = var.create_local_storage_class ? 1 : 0
+
+  name         = "dcapi-controlplane-ubuntu"
+  namespace    = var.project_name
+  display_name = var.node_image_display_name
+  source_type  = "download"
+  url          = var.node_image_url
+
+  storage_class_name = local.vm_storage_class_name
+
+  depends_on = [
+    module.project,
+    kubernetes_storage_class_v1.vm_local,
+  ]
+}
+
+# Resolved image reference passed to each machine_pool. When the module
+# created its own image, use that. Otherwise the operator must supply
+# node_image_name themselves (typically from a bootstrap layer's output).
+locals {
+  effective_image_name = (
+    var.create_local_storage_class && length(harvester_image.dcapi_node) > 0
+    ? "${var.project_name}/${harvester_image.dcapi_node[0].name}"
+    : var.node_image_name
+  )
+}
+
 # ── LoadBalancer IPPool ───────────────────────────────────────────────────────
+# Single ingress VIP for the dc-api ingress. The API VIP is NOT in this pool —
+# kube-vip claims it directly via ARP on the node side.
 resource "harvester_ippool" "lb" {
   name = "${var.cluster_name}-lb"
 
   range {
-    start   = var.lb_range_start
-    end     = var.lb_range_end
+    start   = var.ingress_vip
+    end     = var.ingress_vip
     subnet  = var.lb_subnet
     gateway = var.lb_gateway
   }
+}
+
+# ── kube-vip static-pod manifest ──────────────────────────────────────────────
+# Rendered once at the module level; the same manifest is shipped to every
+# server node via cloud-init write_files. Each kube-vip instance uses lease-
+# based leader election so only one node ARP-announces the API VIP at a time.
+locals {
+  kube_vip_manifest = templatefile("${path.module}/templates/kube-vip-rke2.yaml.tftpl", {
+    kube_vip_image = var.kube_vip_image
+    vip_interface  = var.node_interface_name
+    api_vip        = var.api_vip
+  })
+
+  # write_files YAML scalar block needs every line of the manifest indented by
+  # 6 spaces (4 for the list item's content + 2 for the parent key). Pre-indent
+  # once here so the template just interpolates the block.
+  kube_vip_manifest_indented = join("\n", [
+    for line in split("\n", local.kube_vip_manifest) : "      ${line}"
+  ])
+}
+
+# ── Per-node cloud-init ───────────────────────────────────────────────────────
+# One rendered cloud-init per node, with the node's static IP baked into the
+# bootcmd netplan block. Indexed so node_user_data[i] maps to node{i+1}.
+locals {
+  node_user_data = [
+    for idx, ip in var.node_ips : templatefile("${path.module}/templates/node-cloud-init.yaml.tftpl", {
+      interface_name             = var.node_interface_name
+      node_ip                    = ip
+      node_cidr_suffix           = var.node_mgmt_cidr_suffix
+      default_gateway            = var.node_default_gateway
+      dns_servers_json           = jsonencode(var.node_dns_servers)
+      ssh_user                   = var.ssh_user
+      node_password              = var.node_password
+      ntp_server                 = var.ntp_server
+      ssh_authorized_keys_json   = jsonencode(var.ssh_authorized_keys)
+      kube_vip_manifest_indented = local.kube_vip_manifest_indented
+    })
+  ]
+
+  # One pool per node, each with quantity=1. Pool naming is deterministic
+  # (node1/node2/...) so per-node operations don't shuffle between applies.
+  machine_pools = [
+    for idx, ip in var.node_ips : {
+      name               = "node${idx + 1}"
+      vm_namespace       = var.project_name
+      quantity           = 1
+      cpu_count          = var.node_cpu_count
+      memory_size        = var.node_memory_size
+      disk_size          = var.node_disk_size
+      image_name         = local.effective_image_name
+      networks           = ["${var.project_name}/${harvester_network.mgmt.name}"]
+      control_plane      = true
+      etcd               = true
+      worker             = true
+      user_data          = local.node_user_data[idx]
+      storage_class_name = local.vm_storage_class_name
+    }
+  ]
 }
 
 # ── RKE2 cluster ─────────────────────────────────────────────────────────────
@@ -53,8 +205,13 @@ resource "harvester_ippool" "lb" {
 # namespace-credential-provisioner creates automatically once the VM namespace
 # is assigned to a project (via module.project above).
 #
-# The default machine_global_config tolerates the multi-hundred-ms etcd fsync
-# latencies seen on Harvester/Longhorn-backed VM disks. Two adjustments:
+# Default machine_global_config tolerates the multi-hundred-ms etcd fsync
+# latencies seen on Harvester/Longhorn-backed VM disks. Three adjustments
+# vs. RKE2 defaults:
+#
+#   * tls-san: includes the API VIP (and any extra hostnames the operator
+#     passes) so the apiserver cert is valid for client connections through
+#     kube-vip's announced VIP.
 #
 #   * kube-apiserver: extend `etcd-healthcheck-timeout` from 2s → 10s so the
 #     readyz etcd probe absorbs WAL fsync spikes instead of marking the
@@ -68,10 +225,16 @@ resource "harvester_ippool" "lb" {
 # Note: the apiserver flag is `etcd-healthcheck-timeout` (one word).
 # `etcd-health-check-timeout` is a typo and the binary rejects it on startup.
 locals {
+  tls_san_entries = distinct(concat([var.api_vip], var.tls_san_extra))
+
   machine_global_config = var.machine_global_config != null ? var.machine_global_config : <<-YAML
     cni: cilium
     disable-kube-proxy: false
     etcd-expose-metrics: false
+    tls-san:
+    %{~for san in local.tls_san_entries~}
+      - ${san}
+    %{~endfor~}
     kube-apiserver-arg:
       - etcd-healthcheck-timeout=10s
     kube-controller-manager-arg:
@@ -97,11 +260,11 @@ module "cluster" {
 
   machine_global_config = local.machine_global_config
 
-  machine_pools = [
-    for pool in var.machine_pools : merge(pool, { vm_namespace = var.project_name })
-  ]
+  machine_pools = local.machine_pools
 
-  user_data         = var.user_data
+  # No module-level user_data — every pool carries its own (each baked with
+  # its node's static IP).
+  user_data         = ""
   manage_rke_config = var.manage_rke_config
 
   depends_on = [

--- a/modules/management/dc-controlplane/outputs.tf
+++ b/modules/management/dc-controlplane/outputs.tf
@@ -22,3 +22,18 @@ output "mgmt_network_name" {
   value       = "${var.project_name}/${harvester_network.mgmt.name}"
   description = "Fully-qualified Harvester NAD name (namespace/name) for the management network."
 }
+
+output "api_vip" {
+  value       = var.api_vip
+  description = "VIP served by kube-vip for the Kubernetes apiserver."
+}
+
+output "ingress_vip" {
+  value       = var.ingress_vip
+  description = "VIP allocated from the Harvester IPPool for the dc-api ingress LB."
+}
+
+output "node_ips" {
+  value       = var.node_ips
+  description = "Static management IPs of the control-plane nodes (index matches pool node{i+1})."
+}

--- a/modules/management/dc-controlplane/templates/kube-vip-rke2.yaml.tftpl
+++ b/modules/management/dc-controlplane/templates/kube-vip-rke2.yaml.tftpl
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  # Static pod, scheduled by kubelet from /var/lib/rancher/rke2/server/manifests/.
+  # Distinct from the kube-vip DaemonSet that harvester-cloud-provider installs
+  # for Service-type LoadBalancers (that one runs with cp_enable=false). This
+  # pod is dedicated to announcing the kube-apiserver VIP.
+  name: kube-vip-apiserver
+  namespace: kube-system
+spec:
+  containers:
+    - name: kube-vip
+      image: ${kube_vip_image}
+      imagePullPolicy: IfNotPresent
+      args:
+        - manager
+      env:
+        - name: vip_arp
+          value: "true"
+        - name: port
+          value: "6443"
+        - name: vip_interface
+          value: "${vip_interface}"
+        - name: vip_cidr
+          value: "32"
+        - name: cp_enable
+          value: "true"
+        - name: cp_namespace
+          value: kube-system
+        - name: vip_ddns
+          value: "false"
+        - name: svc_enable
+          value: "false"
+        - name: vip_leaderelection
+          value: "true"
+        - name: vip_leaseduration
+          value: "15"
+        - name: vip_renewdeadline
+          value: "10"
+        - name: vip_retryperiod
+          value: "2"
+        - name: address
+          value: "${api_vip}"
+      securityContext:
+        capabilities:
+          add:
+            - NET_ADMIN
+            - NET_RAW
+            - SYS_TIME
+      volumeMounts:
+        - mountPath: /etc/kubernetes/admin.conf
+          name: kubeconfig
+  hostNetwork: true
+  hostAliases:
+    - hostnames:
+        - kubernetes
+      ip: 127.0.0.1
+  volumes:
+    - hostPath:
+        path: /etc/rancher/rke2/rke2.yaml
+      name: kubeconfig

--- a/modules/management/dc-controlplane/templates/node-cloud-init.yaml.tftpl
+++ b/modules/management/dc-controlplane/templates/node-cloud-init.yaml.tftpl
@@ -1,0 +1,94 @@
+#cloud-config
+# Per-node cloud-init for HA RKE2 control-plane VM.
+#
+# bootcmd runs in cloud-init's "init" stage so the network is up BEFORE the
+# rancher-system-agent (baked into the image) starts pulling the RKE2 bundle.
+# The management NAD has no DHCP for VMs, so a static IP is mandatory.
+#
+# write_files deposits the kube-vip static-pod manifest into
+# /var/lib/rancher/rke2/server/manifests/ so RKE2 picks it up at bring-up.
+# All three server nodes deposit the same manifest; kube-vip's built-in
+# leader election ensures only one node ARP-announces the API VIP at a time.
+bootcmd:
+  - rm -f /etc/netplan/50-cloud-init.yaml
+  - |
+    cat > /etc/netplan/01-static-mgmt.yaml <<'NETPLAN_EOF'
+    network:
+      version: 2
+      ethernets:
+        ${interface_name}:
+          dhcp4: false
+          addresses:
+            - ${node_ip}/${node_cidr_suffix}
+          routes:
+            - to: default
+              via: ${default_gateway}
+          nameservers:
+            addresses: ${dns_servers_json}
+    NETPLAN_EOF
+  - chmod 600 /etc/netplan/01-static-mgmt.yaml
+  - netplan apply
+  - echo 'deb http://archive.ubuntu.com/ubuntu jammy main' > /etc/apt/sources.list.d/qga-only.list
+  - apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/qga-only.list -o Dir::Etc::sourceparts=- -o APT::List-Cleanup=0
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-guest-agent
+  - systemctl enable --now qemu-guest-agent
+  - rm -f /etc/apt/sources.list.d/qga-only.list
+  - mkdir -p /var/lib/rancher/rke2/server/manifests
+ssh_pwauth: True
+chpasswd:
+  expire: False
+  list:
+    - ${ssh_user}:${node_password}
+packages:
+  - qemu-guest-agent
+  - nfs-common
+  - net-tools
+  - ipvsadm
+write_files:
+  - path: /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+    content: |
+      network: {config: disabled}
+    owner: root:root
+    permissions: '0644'
+  - path: /etc/systemd/timesyncd.conf
+    content: |
+      [Time]
+      NTP=${ntp_server}
+    owner: root:root
+    permissions: '0644'
+  - path: /etc/sysctl.d/99-inotify.conf
+    content: |
+      fs.inotify.max_user_watches=524288
+      fs.inotify.max_user_instances=8192
+      fs.inotify.max_queued_events=65536
+    owner: root:root
+    permissions: '0644'
+  - path: /etc/modules-load.d/ipvs.conf
+    content: |
+      ip_vs
+      ip_vs_rr
+      ip_vs_wrr
+      ip_vs_sh
+      nf_conntrack
+    owner: root:root
+    permissions: '0644'
+  - path: /var/lib/rancher/rke2/server/manifests/kube-vip.yaml
+    owner: root:root
+    permissions: '0600'
+    content: |
+${kube_vip_manifest_indented}
+runcmd:
+  - - systemctl
+    - enable
+    - --now
+    - qemu-guest-agent.service
+  - modprobe ip_vs
+  - modprobe ip_vs_rr
+  - modprobe ip_vs_wrr
+  - modprobe ip_vs_sh
+  - modprobe nf_conntrack
+  - sysctl --system
+  - systemctl restart systemd-timesyncd
+  - timedatectl set-ntp false
+  - timedatectl set-ntp true
+ssh_authorized_keys: ${ssh_authorized_keys_json}

--- a/modules/management/dc-controlplane/variables.tf
+++ b/modules/management/dc-controlplane/variables.tf
@@ -30,54 +30,143 @@ variable "mgmt_cluster_network" {
   default     = "mgmt"
 }
 
-variable "lb_range_start" {
-  type        = string
-  description = "First IP in the LoadBalancer VIP range for the control-plane cluster."
+# ── Node count + per-node IPs ────────────────────────────────────────────────
+variable "node_count" {
+  type        = number
+  description = "Number of control-plane nodes. Must be 1, 3 or 5 to form an etcd quorum. 3 is the recommended HA default."
+  default     = 3
+
+  validation {
+    condition     = contains([1, 3, 5], var.node_count)
+    error_message = "node_count must be 1, 3 or 5 (etcd quorum requirement)."
+  }
 }
 
-variable "lb_range_end" {
-  type        = string
-  description = "Last IP in the LoadBalancer VIP range."
+variable "node_ips" {
+  type        = list(string)
+  description = "Per-node static management IPs. List length must equal node_count. Order is significant — index N maps to pool 'node{N+1}'."
+
+  validation {
+    condition     = length(var.node_ips) == length(distinct(var.node_ips))
+    error_message = "node_ips entries must be unique."
+  }
 }
 
+variable "node_mgmt_cidr_suffix" {
+  type        = number
+  description = "Prefix length for each node's static IP (e.g. 24 for /24)."
+  default     = 24
+}
+
+variable "node_default_gateway" {
+  type        = string
+  description = "Default gateway for the management network."
+}
+
+variable "node_dns_servers" {
+  type        = list(string)
+  description = "DNS servers written into each node's netplan."
+  default     = ["8.8.8.8", "1.1.1.1"]
+}
+
+variable "node_interface_name" {
+  type        = string
+  description = "Network interface name inside the VM that the static IP is pinned to. enp1s0 is the Harvester default for the first NIC."
+  default     = "enp1s0"
+}
+
+# ── Node sizing ──────────────────────────────────────────────────────────────
+variable "node_cpu_count" {
+  type        = string
+  description = "vCPU count per node."
+  default     = "4"
+}
+
+variable "node_memory_size" {
+  type        = string
+  description = "Memory in GiB per node (as a string, e.g. '8')."
+  default     = "8"
+}
+
+variable "node_disk_size" {
+  type        = number
+  description = "Root disk size in GiB per node."
+  default     = 40
+}
+
+variable "node_image_name" {
+  type        = string
+  description = "Harvester VM image reference ('namespace/image-id') to clone the VM root disks from. Required when create_local_storage_class is false (operator provides a pre-existing image). When create_local_storage_class is true the module creates its OWN image in the project namespace (with the local-fast SC baked in) and this variable is ignored — pass an empty string."
+  default     = ""
+}
+
+variable "node_image_url" {
+  type        = string
+  description = "Download URL for the cloud image the module bakes into its own VirtualMachineImage when create_local_storage_class is true. Defaults to the upstream Ubuntu 22.04 jammy cloud image. Ignored when create_local_storage_class is false."
+  default     = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+}
+
+variable "node_image_display_name" {
+  type        = string
+  description = "Friendly display name for the VirtualMachineImage when the module creates one. Ignored when create_local_storage_class is false."
+  default     = "DC-API Control-Plane Ubuntu 22.04"
+}
+
+# ── Cloud-init knobs ─────────────────────────────────────────────────────────
+variable "node_password" {
+  type        = string
+  sensitive   = true
+  description = "Password for the ssh_user account on every node."
+}
+
+variable "ssh_user" {
+  type        = string
+  description = "Linux user that cloud-init creates and that the node_password / ssh_authorized_keys apply to."
+  default     = "ubuntu"
+}
+
+variable "ssh_authorized_keys" {
+  type        = list(string)
+  description = "SSH public keys injected into ssh_user on every node."
+  default     = []
+}
+
+variable "ntp_server" {
+  type        = string
+  description = "NTP server written into /etc/systemd/timesyncd.conf on every node."
+  default     = "time.cloudflare.com"
+}
+
+# ── VIPs ─────────────────────────────────────────────────────────────────────
+variable "api_vip" {
+  type        = string
+  description = "Virtual IP for the Kubernetes API server. Served by kube-vip running as a static pod on each control-plane node (ARP mode, leader-elected). DigiOps must reserve this IP on the management VLAN out-of-band — it is NOT allocated from the Harvester IPPool."
+}
+
+variable "ingress_vip" {
+  type        = string
+  description = "Single VIP for Service type=LoadBalancer. Used by the dc-api ingress. Allocated from the Harvester IPPool created by this module."
+}
+
+# ── LoadBalancer IPPool ──────────────────────────────────────────────────────
 variable "lb_subnet" {
   type        = string
-  description = "Subnet CIDR containing the LoadBalancer VIP range."
+  description = "Subnet CIDR containing the ingress VIP."
 }
 
 variable "lb_gateway" {
   type        = string
-  description = "Default gateway for the LoadBalancer VIP subnet."
+  description = "Default gateway for the LB subnet."
 }
 
-variable "machine_pools" {
-  type = list(object({
-    name           = string
-    quantity       = number
-    cpu_count      = string
-    memory_size    = string
-    disk_size      = number
-    image_name     = string
-    networks       = list(string)
-    control_plane  = bool
-    etcd           = bool
-    worker         = bool
-    machine_labels = optional(map(string), {})
-    taints = optional(list(object({
-      key    = string
-      value  = string
-      effect = string
-    })), [])
-  }))
-  description = "Machine pool definitions. vm_namespace is set automatically to var.project_name."
-}
-
-variable "user_data" {
+# ── kube-vip ─────────────────────────────────────────────────────────────────
+variable "kube_vip_image" {
   type        = string
-  description = "Cloud-init user_data for cluster nodes."
-  sensitive   = true
+  description = "kube-vip container image used for the apiserver VIP static pod."
+  default     = "ghcr.io/kube-vip/kube-vip:v0.8.7"
 }
 
+# ── RKE2 machine config ──────────────────────────────────────────────────────
 variable "manage_rke_config" {
   type        = bool
   description = "When true, Terraform manages the full RKE2 machine configuration."
@@ -86,11 +175,66 @@ variable "manage_rke_config" {
 
 variable "machine_global_config" {
   type        = string
-  description = "Full machine_global_config YAML for the cluster. Defaults to a config with extended kube-apiserver etcd healthcheck timeout and extended kube-controller-manager / kube-scheduler leader-election timeouts, to tolerate higher disk I/O latency on Harvester/Longhorn-backed storage."
+  description = "Full machine_global_config YAML for the cluster. When null (the default), the module generates a config that: (a) sets cni=cilium, (b) adds the API VIP and ingress hostnames to tls-san so the apiserver cert is valid for client connections via the VIP, and (c) extends kube-apiserver etcd healthcheck + kube-controller-manager/kube-scheduler leader-election timeouts to tolerate Longhorn-backed disk fsync latency."
   default     = null
+}
+
+variable "tls_san_extra" {
+  type        = list(string)
+  description = "Extra hostnames/IPs to add to the apiserver tls-san list (e.g. an external DNS name fronting the API VIP). The API VIP itself is added automatically."
+  default     = []
 }
 
 variable "harvester_kubeconfig_path" {
   type        = string
   description = "Path to the Harvester kubeconfig file. Used to run the kubectl patch that sets the IPPool selector.scope after cluster creation."
+}
+
+# ── VM root-disk storage ─────────────────────────────────────────────────────
+# By default, this module creates a single-replica Longhorn StorageClass with
+# dataLocality=best-effort on the Harvester host cluster and points the
+# control-plane VM root disks at it. best-effort keeps a replica co-located
+# with the VM's node whenever possible (low fsync latency for etcd) but
+# permits Longhorn to migrate the volume to another node on host failure so
+# the VM can restart elsewhere. The fsync-latency drop versus the default
+# 2-replica SC is 5-10× — necessary for etcd quorum to bootstrap and stay
+# healthy on slow or overloaded host storage. The trade is reduced
+# per-disk redundancy (1 replica vs 2); etcd quorum at the application layer
+# is what compensates.
+#
+# For environments with fast underlying storage (good NVMe + spare IOPS),
+# set create_local_storage_class = false to fall back to the host cluster's
+# default StorageClass and recover full per-disk replication.
+#
+# In-cluster PVCs (e.g. dc-postgres) are unaffected — they continue to use
+# the downstream cluster's default StorageClass, which the Harvester CSI
+# driver translates to the host's default (replicated) SC.
+variable "create_local_storage_class" {
+  type        = bool
+  description = "When true, create a single-replica Longhorn StorageClass with dataLocality=best-effort on the Harvester host cluster for the control-plane VM root disks. Recommended for dev / slow-disk environments where etcd fsync latency is the bottleneck. Set false in production when host storage has adequate IOPS for the default 2-replica SC."
+  default     = true
+}
+
+variable "local_storage_class_name" {
+  type        = string
+  description = "Name of the single-replica, best-effort-local StorageClass created on the Harvester host cluster when create_local_storage_class = true."
+  default     = "dcapi-controlplane-local"
+}
+
+variable "vm_storage_class_override" {
+  type        = string
+  description = "Explicit StorageClass name for the control-plane VM root disks. Takes precedence over create_local_storage_class — use this to point at a pre-existing custom SC on the Harvester cluster. Empty string defers to the create_local_storage_class logic."
+  default     = ""
+}
+
+# Cross-variable consistency check: node_count and node_ips must agree, since
+# per-node cloud-init + machine pools are built from node_ips and a mismatch
+# would silently provision the wrong number of nodes. Uses a `check` block
+# (Terraform 1.5+) because the `validation` block didn't gain cross-variable
+# refs until Terraform 1.9 and required_version here is >= 1.7.
+check "node_count_matches_node_ips" {
+  assert {
+    condition     = length(var.node_ips) == var.node_count
+    error_message = "length(node_ips) (${length(var.node_ips)}) must equal node_count (${var.node_count}). The module derives both cloud-init and machine pools from node_ips; a mismatch would silently change the provisioned cluster size."
+  }
 }

--- a/modules/management/keyvault-operator/README.md
+++ b/modules/management/keyvault-operator/README.md
@@ -1,0 +1,110 @@
+# keyvault-operator
+
+Terraform module that deploys the
+[keyvault-operator](https://github.com/wso2/sovereign-cloud/tree/main/crds/keyvault)
+controller on a Kubernetes cluster. The operator watches the
+`KeyVaultBackend` and `KeyVaultInstance` CRDs (also installed by this
+module) and reconciles per-tenant OpenBao clusters, KV-v2 mounts, and
+AppRoles per their `spec`.
+
+## What this module manages
+
+| Kind                       | Scope        | Name                                       |
+|----------------------------|--------------|--------------------------------------------|
+| Namespace                  | cluster      | `var.namespace` (default `keyvault-system`) |
+| CustomResourceDefinition × 2 | cluster      | `keyvaultbackends`, `keyvaultinstances`    |
+| ServiceAccount             | namespaced   | `kvi-controller-manager`                   |
+| Role + RoleBinding         | namespaced   | leader-election                            |
+| ClusterRole + ClusterRoleBinding | cluster | manager (watches own CRDs, mutates StatefulSets in tenant namespaces) |
+| ClusterRole + ClusterRoleBinding | cluster | metrics-auth (TokenReview / SubjectAccessReview) |
+| ClusterRole                | cluster      | metrics-reader (anchor for Prometheus scrape SAs) |
+| ClusterRole × 6            | cluster      | stub admin/editor/viewer roles for kubectl users |
+| Service                    | namespaced   | metrics-service (ClusterIP `:8443`)        |
+| Deployment                 | namespaced   | manager (single replica, leader-elected)   |
+| Secret (optional)          | namespaced   | image-pull (when `image_pull_secret` set)  |
+
+## Provider config
+
+The module declares NO provider blocks. The caller layer supplies a
+`kubernetes` provider configured against the cluster where the operator
+should run. Typical pattern in a consumer:
+
+```hcl
+provider "kubernetes" {
+  alias       = "tenant_workload"
+  config_path = var.tenant_workload_kubeconfig
+}
+
+module "kvi" {
+  source    = "../../modules/management/keyvault-operator"
+  providers = { kubernetes = kubernetes.tenant_workload }
+  image     = "ghcr.io/<owner>/keyvault-operator:v0.0.2"
+  image_pull_secret = {
+    server   = "ghcr.io"
+    username = var.ghcr_user
+    password = var.ghcr_token
+  }
+}
+```
+
+## Inputs
+
+| Name                | Type    | Default              | Description |
+|---------------------|---------|----------------------|-------------|
+| `image`             | string  | (required)           | Full image ref incl. tag/digest |
+| `namespace`         | string  | `keyvault-system`    | Where the manager Deployment + RBAC live |
+| `name_prefix`       | string  | `kvi-`               | Prefix for every Kubernetes object name |
+| `replicas`          | number  | `1`                  | Manager replicas (leader-elected; >1 supported) |
+| `leader_elect`      | bool    | `true`               | Pass `--leader-elect` to the manager |
+| `image_pull_secret` | object  | `null`               | Docker-registry credentials for private images |
+| `resources`         | object  | kubebuilder defaults | Container resources.limits / .requests |
+| `common_labels`     | map     | `{}`                 | Extra labels on every created object |
+
+## Outputs
+
+| Name                  | Description                                        |
+|-----------------------|----------------------------------------------------|
+| `namespace`           | Resolved namespace name                            |
+| `deployment_name`     | Manager Deployment name (for kubectl rollout)      |
+| `service_account_name`| Manager SA name (for tenant-ns RoleBindings)       |
+| `metrics_service`     | `{namespace, name, port}` for Prometheus scrape    |
+| `crd_groups`          | `{group, plurals}` for CR creation                 |
+
+## Versioning
+
+The RBAC rules emitted by `kubernetes_cluster_role.manager` are a verbatim
+port of the operator's `+kubebuilder:rbac` markers at the time of writing.
+When bumping the operator image tag (`image` variable), confirm whether
+the operator's `config/rbac/role.yaml` shifted — if so, update the rules
+in `main.tf` to match before applying.
+
+The CRD YAML files under `crds/` are likewise pinned. Refresh them from
+the operator's `config/crd/bases/` when bumping the image tag.
+
+## Image-pull authentication
+
+When pulling from a private registry, supply `image_pull_secret`:
+
+```hcl
+image_pull_secret = {
+  server   = "ghcr.io"
+  username = "<gh-user-or-bot>"
+  password = "<personal-access-token-with-read:packages>"
+}
+```
+
+The module creates a `kubernetes.io/dockerconfigjson` Secret named
+`${name_prefix}image-pull` and references it in the manager Deployment's
+`imagePullSecrets`. For public images, leave `image_pull_secret = null`.
+
+## What this module does NOT do
+
+- No tenant-namespace creation. Tenant namespaces (where the
+  `KeyVaultBackend` CRs live) are created by the platform's API server
+  (dc-api) on tenant registration, not by this module.
+- No Prometheus ServiceMonitor / PodMonitor — left to the platform's
+  monitoring stack. The metrics Service is created so the scrape can
+  target it.
+- No NetworkPolicy. The manager calls the kube API server only;
+  consumers running a deny-all default policy should add an egress
+  allow rule to the apiserver themselves.

--- a/modules/management/keyvault-operator/crds/keyvaultbackends.yaml
+++ b/modules/management/keyvault-operator/crds/keyvaultbackends.yaml
@@ -1,0 +1,241 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: keyvaultbackends.keyvault.opencloud.wso2.com
+spec:
+  group: keyvault.opencloud.wso2.com
+  names:
+    kind: KeyVaultBackend
+    listKind: KeyVaultBackendList
+    plural: keyvaultbackends
+    shortNames:
+    - kvb
+    singular: keyvaultbackend
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint.address
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeyVaultBackend is a per-tenant OpenBao HA cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KeyVaultBackendSpec defines the desired state of a per-tenant OpenBao cluster.
+
+              Capacity fields are intentionally optional with controller-sane defaults:
+              the user-facing KeyVault API has no cap surface — Backend capacity is a
+              platform-operator concern, not a tenant one. dc-api creates Backends with
+              empty caps; admission fills the defaults here.
+            properties:
+              cpu:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 500m
+                description: CPU is the total CPU budget for the StatefulSet (divided
+                  across replicas).
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              engineConfig:
+                description: EngineConfig holds OpenBao-specific tuning.
+                properties:
+                  auditEnabled:
+                    default: true
+                    description: AuditEnabled toggles the file audit device. Default
+                      true.
+                    type: boolean
+                  auditLogPath:
+                    default: /openbao/audit/audit.log
+                    description: AuditLogPath is the file path inside each pod where
+                      audit writes.
+                    type: string
+                  haReplicas:
+                    default: 3
+                    description: HAReplicas is the number of pods in the Raft cluster.
+                      Must be odd. Default 3.
+                    maximum: 7
+                    minimum: 1
+                    type: integer
+                  storageClass:
+                    default: longhorn
+                    description: StorageClass is the Longhorn (or other) class for
+                      Raft PVCs. Default "longhorn".
+                    type: string
+                type: object
+              memoryGB:
+                default: 4
+                description: MemoryGB is the total memory budget for the StatefulSet
+                  (divided across replicas).
+                minimum: 1
+                type: integer
+              storageGB:
+                default: 10
+                description: StorageGB is the size of each replica's Raft PVC.
+                minimum: 1
+                type: integer
+            type: object
+          status:
+            description: KeyVaultBackendStatus defines the observed state of a Backend.
+            properties:
+              conditions:
+                description: Conditions follow standard Kubernetes status conventions.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              endpoint:
+                description: |-
+                  Endpoint is the in-cluster address of the active leader.
+                  Populated once the Raft cluster elects a leader.
+                properties:
+                  address:
+                    description: Address is the DNS name (e.g. openbao-active.dc-tenant-acme.svc.cluster.local).
+                    type: string
+                  port:
+                    description: Port is the OpenBao API port (8200 by default).
+                    type: integer
+                required:
+                - address
+                - port
+                type: object
+              keyMaterialRef:
+                description: |-
+                  KeyMaterialRef points at the Secret holding unseal keys + root token.
+                  Set once after init; subsequent reconciles never rewrite this.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              message:
+                description: Message is the human-readable explanation of the current
+                  phase.
+                type: string
+              phase:
+                description: Phase mirrors the managed-services contract enum.
+                enum:
+                - Pending
+                - Provisioning
+                - Ready
+                - Failed
+                - Terminating
+                type: string
+              resources:
+                description: Resources tracks every owned object for idempotent reconciliation.
+                items:
+                  description: ResourceRef identifies a Kubernetes object owned by
+                    this CR (for idempotency).
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/modules/management/keyvault-operator/crds/keyvaultinstances.yaml
+++ b/modules/management/keyvault-operator/crds/keyvaultinstances.yaml
@@ -1,0 +1,235 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: keyvaultinstances.keyvault.opencloud.wso2.com
+spec:
+  group: keyvault.opencloud.wso2.com
+  names:
+    kind: KeyVaultInstance
+    listKind: KeyVaultInstanceList
+    plural: keyvaultinstances
+    shortNames:
+    - kvi
+    singular: keyvaultinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.backendRef.name
+      name: Backend
+      type: string
+    - jsonPath: .status.mountPath
+      name: MountPath
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KeyVaultInstance is a user-facing key vault — a KV-v2 mount + AppRole
+          inside a Backend.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KeyVaultInstanceSpec defines the desired state of a user-facing Key Vault.
+
+              A KeyVaultInstance is a KV-v2 mount path inside a shared per-tenant
+              KeyVaultBackend plus an AppRole scoped to that mount. The user never sees
+              the Backend; they see independent KeyVaultInstance Resources at the
+              project URL.
+            properties:
+              backendRef:
+                description: |-
+                  BackendRef points at the KeyVaultBackend in dc-tenant-<slug>.
+                  dc-api sets this; users never specify it.
+                properties:
+                  name:
+                    description: Name of the KeyVaultBackend CR.
+                    type: string
+                  namespace:
+                    description: Namespace of the KeyVaultBackend CR (typically dc-tenant-<slug>).
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              softDeleteDays:
+                default: 30
+                description: |-
+                  SoftDeleteDays is honoured by OpenBao's KV-v2 metadata
+                  delete_version_after configuration. Default 30, min 7, max 90.
+                maximum: 90
+                minimum: 7
+                type: integer
+            required:
+            - backendRef
+            type: object
+          status:
+            description: KeyVaultInstanceStatus defines the observed state of a Key
+              Vault.
+            properties:
+              conditions:
+                description: Conditions follow standard Kubernetes status conventions.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              endpoint:
+                description: |-
+                  Endpoint.Address is the Backend's in-cluster address (consumed by dc-api's
+                  PrivateEndpoint handler to configure proxy upstreams).
+                  Endpoint.SecretRef points at the AppRole credential Secret in the same
+                  namespace as this CR.
+                properties:
+                  address:
+                    description: Address is the Backend's in-cluster address (NOT
+                      a customer-VPC IP).
+                    type: string
+                  port:
+                    description: Port is the OpenBao API port.
+                    type: integer
+                  secretRef:
+                    description: |-
+                      SecretRef points at the credentials Secret in the KeyVaultInstance's namespace.
+                      Data keys: role_id, secret_id, mount_path, backend_address, backend_port.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - address
+                - port
+                type: object
+              message:
+                description: Message is the human-readable explanation of the current
+                  phase.
+                type: string
+              mountPath:
+                description: |-
+                  MountPath inside the Backend (e.g. tenants/<tenant-uuid>/<resource-uuid>).
+                  Set once on first successful reconcile; immutable thereafter.
+                type: string
+              phase:
+                description: Phase mirrors the managed-services contract enum.
+                enum:
+                - Pending
+                - Provisioning
+                - Ready
+                - Failed
+                - Terminating
+                type: string
+              resources:
+                description: Resources tracks owned objects (the credentials Secret)
+                  for idempotency.
+                items:
+                  description: ResourceRef identifies a Kubernetes object owned by
+                    this CR (for idempotency).
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/modules/management/keyvault-operator/main.tf
+++ b/modules/management/keyvault-operator/main.tf
@@ -1,0 +1,464 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Key Vault Operator (KVI)
+#
+# Deploys the keyvault-operator manager onto a Kubernetes cluster. The operator
+# watches KeyVaultBackend and KeyVaultInstance custom resources and reconciles
+# OpenBao backends + KV-v2 mounts + AppRoles per the contract described at
+# https://github.com/wso2/open-cloud-datacenter/blob/main/modules/management/keyvault-operator/README.md
+#
+# Resources created:
+#   - Namespace (operator's own; CRDs are cluster-scoped)
+#   - 2x CustomResourceDefinition (KeyVaultBackend, KeyVaultInstance)
+#   - ServiceAccount for the manager
+#   - Leader-election Role + RoleBinding (namespaced)
+#   - manager ClusterRole + ClusterRoleBinding (watches own CRDs;
+#     creates/updates the StatefulSet + RBAC + Service that back each
+#     KeyVaultBackend)
+#   - metrics-auth ClusterRole + ClusterRoleBinding (TokenReview /
+#     SubjectAccessReview for the metrics endpoint)
+#   - metrics-reader ClusterRole (granted by the operator to anything
+#     scraping its /metrics endpoint, e.g. Prometheus)
+#   - 6x stub ClusterRoles for end-user kubectl access (admin/editor/viewer
+#     × backend/instance) — emitted by kubebuilder defaults, harmless;
+#     consumers can ignore them.
+#   - metrics Service (ClusterIP, port 8443)
+#   - manager Deployment
+#   - Optional image-pull Secret (when image_pull_secret is set)
+#
+# Provider config (kubernetes) is expected to live in the caller layer.
+# ─────────────────────────────────────────────────────────────────────────────
+
+locals {
+  manager_name        = "${var.name_prefix}controller-manager"
+  manager_role_name   = "${var.name_prefix}manager-role"
+  leader_role_name    = "${var.name_prefix}leader-election-role"
+  metrics_auth_name   = "${var.name_prefix}metrics-auth-role"
+  metrics_reader_name = "${var.name_prefix}metrics-reader"
+  metrics_svc_name    = "${var.name_prefix}controller-manager-metrics-service"
+  image_pull_secret   = var.image_pull_secret != null ? "${var.name_prefix}image-pull" : null
+
+  base_labels = merge(
+    {
+      "app.kubernetes.io/name"       = "keyvault-operator"
+      "app.kubernetes.io/managed-by" = "terraform"
+      "control-plane"                = "controller-manager"
+    },
+    var.common_labels,
+  )
+}
+
+# ── Namespace ────────────────────────────────────────────────────────────────
+
+resource "kubernetes_namespace" "operator" {
+  metadata {
+    name   = var.namespace
+    labels = local.base_labels
+  }
+}
+
+# ── CRDs (cluster-scoped; not bound to the namespace above) ──────────────────
+
+resource "kubernetes_manifest" "crd_backends" {
+  manifest = yamldecode(file("${path.module}/crds/keyvaultbackends.yaml"))
+}
+
+resource "kubernetes_manifest" "crd_instances" {
+  manifest = yamldecode(file("${path.module}/crds/keyvaultinstances.yaml"))
+}
+
+# ── ServiceAccount ───────────────────────────────────────────────────────────
+
+resource "kubernetes_service_account" "manager" {
+  metadata {
+    name      = local.manager_name
+    namespace = kubernetes_namespace.operator.metadata[0].name
+    labels    = local.base_labels
+  }
+}
+
+# ── Image-pull Secret (optional) ─────────────────────────────────────────────
+
+resource "kubernetes_secret" "image_pull" {
+  count = var.image_pull_secret != null ? 1 : 0
+
+  metadata {
+    name      = local.image_pull_secret
+    namespace = kubernetes_namespace.operator.metadata[0].name
+    labels    = local.base_labels
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        (var.image_pull_secret.server) = {
+          username = var.image_pull_secret.username
+          password = var.image_pull_secret.password
+          email    = var.image_pull_secret.email
+          auth     = base64encode("${var.image_pull_secret.username}:${var.image_pull_secret.password}")
+        }
+      }
+    })
+  }
+}
+
+# ── Leader-election Role + RoleBinding (namespaced) ──────────────────────────
+
+resource "kubernetes_role" "leader_election" {
+  metadata {
+    name      = local.leader_role_name
+    namespace = kubernetes_namespace.operator.metadata[0].name
+    labels    = local.base_labels
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = ["coordination.k8s.io"]
+    resources  = ["leases"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["events"]
+    verbs      = ["create", "patch"]
+  }
+}
+
+resource "kubernetes_role_binding" "leader_election" {
+  metadata {
+    name      = "${var.name_prefix}leader-election-rolebinding"
+    namespace = kubernetes_namespace.operator.metadata[0].name
+    labels    = local.base_labels
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.leader_election.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.manager.metadata[0].name
+    namespace = kubernetes_namespace.operator.metadata[0].name
+  }
+}
+
+# ── Manager ClusterRole + ClusterRoleBinding ─────────────────────────────────
+# These rules MUST stay in sync with the +kubebuilder:rbac markers in
+# crds/keyvault/internal/controller/*.go upstream. The operator's
+# `make manifests` regenerates them into the operator's own
+# config/rbac/role.yaml; the YAML below is a verbatim port from that file
+# at the time of writing. Bump along with operator version bumps.
+
+resource "kubernetes_cluster_role" "manager" {
+  metadata {
+    name   = local.manager_role_name
+    labels = local.base_labels
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "configmaps", "services", "serviceaccounts"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["get", "list", "watch", "create"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list", "watch", "update", "patch"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods/proxy"]
+    verbs      = ["get", "create", "update"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["persistentvolumeclaims"]
+    verbs      = ["get", "list", "watch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["events"]
+    verbs      = ["create", "patch"]
+  }
+  rule {
+    api_groups = ["apps"]
+    resources  = ["statefulsets"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["roles", "rolebindings"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = ["keyvault.opencloud.wso2.com"]
+    resources  = ["keyvaultbackends", "keyvaultinstances"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = ["keyvault.opencloud.wso2.com"]
+    resources  = ["keyvaultbackends/finalizers", "keyvaultinstances/finalizers"]
+    verbs      = ["update"]
+  }
+  rule {
+    api_groups = ["keyvault.opencloud.wso2.com"]
+    resources  = ["keyvaultbackends/status", "keyvaultinstances/status"]
+    verbs      = ["get", "update", "patch"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "manager" {
+  metadata {
+    name   = "${var.name_prefix}manager-rolebinding"
+    labels = local.base_labels
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.manager.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.manager.metadata[0].name
+    namespace = kubernetes_namespace.operator.metadata[0].name
+  }
+}
+
+# ── Metrics-auth ClusterRole + ClusterRoleBinding ────────────────────────────
+# Manager-side authentication of metrics-endpoint callers.
+
+resource "kubernetes_cluster_role" "metrics_auth" {
+  metadata {
+    name   = local.metrics_auth_name
+    labels = local.base_labels
+  }
+
+  rule {
+    api_groups = ["authentication.k8s.io"]
+    resources  = ["tokenreviews"]
+    verbs      = ["create"]
+  }
+  rule {
+    api_groups = ["authorization.k8s.io"]
+    resources  = ["subjectaccessreviews"]
+    verbs      = ["create"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "metrics_auth" {
+  metadata {
+    name   = "${var.name_prefix}metrics-auth-rolebinding"
+    labels = local.base_labels
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.metrics_auth.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.manager.metadata[0].name
+    namespace = kubernetes_namespace.operator.metadata[0].name
+  }
+}
+
+# ── Metrics-reader ClusterRole ───────────────────────────────────────────────
+# Granted by the operator to anything authorised to scrape /metrics
+# (e.g. a Prometheus scrape SA). Not bound to any subject by this module.
+
+resource "kubernetes_cluster_role" "metrics_reader" {
+  metadata {
+    name   = local.metrics_reader_name
+    labels = local.base_labels
+  }
+
+  rule {
+    non_resource_urls = ["/metrics"]
+    verbs             = ["get"]
+  }
+}
+
+# ── End-user-facing stub ClusterRoles (kubebuilder default scaffolding) ──────
+# These aren't bound by this module; they exist as standardised
+# aggregate-cluster-role anchor points so kubectl users with admin/editor/viewer
+# privileges on the CRs can be granted via a single rolebinding elsewhere.
+
+locals {
+  user_cr_specs = {
+    "${var.name_prefix}keyvaultbackend-admin-role"   = { plural = "keyvaultbackends", verbs = ["*"] }
+    "${var.name_prefix}keyvaultbackend-editor-role"  = { plural = "keyvaultbackends", verbs = ["get", "list", "watch", "create", "update", "patch", "delete"] }
+    "${var.name_prefix}keyvaultbackend-viewer-role"  = { plural = "keyvaultbackends", verbs = ["get", "list", "watch"] }
+    "${var.name_prefix}keyvaultinstance-admin-role"  = { plural = "keyvaultinstances", verbs = ["*"] }
+    "${var.name_prefix}keyvaultinstance-editor-role" = { plural = "keyvaultinstances", verbs = ["get", "list", "watch", "create", "update", "patch", "delete"] }
+    "${var.name_prefix}keyvaultinstance-viewer-role" = { plural = "keyvaultinstances", verbs = ["get", "list", "watch"] }
+  }
+}
+
+resource "kubernetes_cluster_role" "user_stubs" {
+  for_each = local.user_cr_specs
+
+  metadata {
+    name   = each.key
+    labels = local.base_labels
+  }
+
+  rule {
+    api_groups = ["keyvault.opencloud.wso2.com"]
+    resources  = [each.value.plural]
+    verbs      = each.value.verbs
+  }
+
+  rule {
+    api_groups = ["keyvault.opencloud.wso2.com"]
+    resources  = ["${each.value.plural}/status"]
+    verbs      = ["get"]
+  }
+}
+
+# ── Metrics Service ──────────────────────────────────────────────────────────
+
+resource "kubernetes_service" "metrics" {
+  metadata {
+    name      = local.metrics_svc_name
+    namespace = kubernetes_namespace.operator.metadata[0].name
+    labels    = local.base_labels
+  }
+
+  spec {
+    selector = {
+      "control-plane"          = "controller-manager"
+      "app.kubernetes.io/name" = "keyvault-operator"
+    }
+    port {
+      name        = "https"
+      port        = 8443
+      protocol    = "TCP"
+      target_port = "8443"
+    }
+  }
+}
+
+# ── Manager Deployment ───────────────────────────────────────────────────────
+
+resource "kubernetes_deployment" "manager" {
+  metadata {
+    name      = local.manager_name
+    namespace = kubernetes_namespace.operator.metadata[0].name
+    labels    = local.base_labels
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = {
+        "control-plane"          = "controller-manager"
+        "app.kubernetes.io/name" = "keyvault-operator"
+      }
+    }
+
+    template {
+      metadata {
+        labels = merge(local.base_labels, {
+          "control-plane"          = "controller-manager"
+          "app.kubernetes.io/name" = "keyvault-operator"
+        })
+        annotations = {
+          "kubectl.kubernetes.io/default-container" = "manager"
+        }
+      }
+
+      spec {
+        service_account_name             = kubernetes_service_account.manager.metadata[0].name
+        termination_grace_period_seconds = 10
+
+        security_context {
+          run_as_non_root = true
+          seccomp_profile {
+            type = "RuntimeDefault"
+          }
+        }
+
+        dynamic "image_pull_secrets" {
+          for_each = var.image_pull_secret != null ? [1] : []
+          content {
+            name = local.image_pull_secret
+          }
+        }
+
+        container {
+          name              = "manager"
+          image             = var.image
+          image_pull_policy = "IfNotPresent"
+
+          command = ["/manager"]
+          args = compact([
+            var.leader_elect ? "--leader-elect" : "",
+            "--health-probe-bind-address=:8081",
+          ])
+
+          port {
+            name           = "health"
+            container_port = 8081
+            protocol       = "TCP"
+          }
+
+          security_context {
+            read_only_root_filesystem  = true
+            allow_privilege_escalation = false
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8081
+            }
+            initial_delay_seconds = 15
+            period_seconds        = 20
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/readyz"
+              port = 8081
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
+
+          resources {
+            limits   = var.resources.limits
+            requests = var.resources.requests
+          }
+        }
+      }
+    }
+  }
+
+  # Make sure the CRDs exist before the manager starts watching them.
+  depends_on = [
+    kubernetes_manifest.crd_backends,
+    kubernetes_manifest.crd_instances,
+    kubernetes_cluster_role_binding.manager,
+    kubernetes_role_binding.leader_election,
+  ]
+}

--- a/modules/management/keyvault-operator/outputs.tf
+++ b/modules/management/keyvault-operator/outputs.tf
@@ -1,0 +1,31 @@
+output "namespace" {
+  description = "Kubernetes namespace where the operator's Deployment + RBAC live."
+  value       = kubernetes_namespace.operator.metadata[0].name
+}
+
+output "deployment_name" {
+  description = "Name of the operator manager Deployment. Useful for kubectl rollout commands."
+  value       = kubernetes_deployment.manager.metadata[0].name
+}
+
+output "service_account_name" {
+  description = "ServiceAccount the manager pod runs as. Useful for RoleBindings in tenant namespaces."
+  value       = kubernetes_service_account.manager.metadata[0].name
+}
+
+output "metrics_service" {
+  description = "ClusterIP Service exposing the manager's /metrics endpoint on :8443. Wire a Prometheus scrape job at <namespace>/<this-service-name>:8443/metrics."
+  value = {
+    namespace = kubernetes_namespace.operator.metadata[0].name
+    name      = kubernetes_service.metrics.metadata[0].name
+    port      = 8443
+  }
+}
+
+output "crd_groups" {
+  description = "CRD api group + plurals the operator owns. Consumers can use this to wait on the CRDs before creating CRs."
+  value = {
+    group   = "keyvault.opencloud.wso2.com"
+    plurals = ["keyvaultbackends", "keyvaultinstances"]
+  }
+}

--- a/modules/management/keyvault-operator/variables.tf
+++ b/modules/management/keyvault-operator/variables.tf
@@ -1,0 +1,64 @@
+variable "image" {
+  type        = string
+  description = "Full container image reference for the keyvault-operator manager binary, including tag or digest. Example: ghcr.io/<owner>/keyvault-operator:v0.0.2"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace where the operator's Deployment + RBAC live. CRDs are cluster-scoped and are NOT created in this namespace."
+  default     = "keyvault-system"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix applied to every Kubernetes object name (ServiceAccount, ClusterRole, Role, Deployment, Service). Matches the kvi- prefix the operator's kustomize-default emits."
+  default     = "kvi-"
+}
+
+variable "replicas" {
+  type        = number
+  description = "Number of operator manager replicas. Leader election is enabled, so only one is active at a time."
+  default     = 1
+}
+
+variable "leader_elect" {
+  type        = bool
+  description = "Whether the manager runs with --leader-elect. Required when replicas > 1; harmless when replicas = 1."
+  default     = true
+}
+
+variable "image_pull_secret" {
+  type = object({
+    server   = string
+    username = string
+    password = string
+    email    = optional(string, "noreply@example.com")
+  })
+  description = "Optional docker-registry credentials for pulling the operator image from a private registry. When null, the module skips creating an image-pull Secret and the cluster relies on node-level pull credentials. When set, the Deployment references a Secret named <name_prefix>image-pull."
+  default     = null
+  sensitive   = true
+}
+
+variable "resources" {
+  type = object({
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  description = "Compute resources for the manager container. Defaults match what the operator's kubebuilder-default scaffolding emits."
+  default = {
+    limits   = { cpu = "500m", memory = "128Mi" }
+    requests = { cpu = "10m", memory = "64Mi" }
+  }
+}
+
+variable "common_labels" {
+  type        = map(string)
+  description = "Labels merged into every object the module creates. Useful for tagging by environment, team, etc."
+  default     = {}
+}

--- a/modules/management/keyvault-operator/versions.tf
+++ b/modules/management/keyvault-operator/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.27.0"
+    }
+  }
+}

--- a/modules/workloads/k8s-cluster/main.tf
+++ b/modules/workloads/k8s-cluster/main.tf
@@ -106,7 +106,7 @@ resource "rancher2_machine_config_v2" "pool" {
     memory_size          = each.value.memory_size
     reserved_memory_size = "-1"
     ssh_user             = var.ssh_user
-    user_data = (var.user_data != null && var.user_data != "") ? var.user_data : (
+    user_data = (var.user_data != null && trimspace(var.user_data) != "") ? var.user_data : (
       (var.node_password != null || length(var.ssh_authorized_keys) > 0 || var.ntp_server != "" || (local._using_generated_user_data && each.value.storage_network != null)) ? templatefile(
         "${path.module}/templates/node-cloud-init.tpl",
         {
@@ -120,11 +120,19 @@ resource "rancher2_machine_config_v2" "pool" {
     )
 
     disk_info = jsonencode({
-      disks = [{
-        imageName = each.value.image_name
-        bootOrder = 1
-        size      = each.value.disk_size
-      }]
+      disks = [merge(
+        {
+          imageName = each.value.image_name
+          bootOrder = 1
+          size      = each.value.disk_size
+        },
+        # storageClassName is only emitted when the pool sets it. Omitting
+        # the key lets Harvester fall back to its default StorageClass —
+        # the original module behaviour.
+        try(each.value.storage_class_name, null) != null && trimspace(try(each.value.storage_class_name, "")) != "" ? {
+          storageClassName = each.value.storage_class_name
+        } : {}
+      )]
     })
 
     network_info = jsonencode({

--- a/modules/workloads/k8s-cluster/variables.tf
+++ b/modules/workloads/k8s-cluster/variables.tf
@@ -122,6 +122,20 @@ variable "machine_pools" {
       value  = string
       effect = string # NoSchedule | PreferNoSchedule | NoExecute
     })), [])
+    # Optional per-pool cloud-init override. When set and non-empty, takes
+    # precedence over the module-level user_data for VMs in this pool only.
+    # Required for HA control-plane setups where each node needs its own
+    # static IP pinned at boot time.
+    user_data = optional(string)
+    # Optional Kubernetes StorageClass for the VM root disk. When unset or
+    # empty, Harvester uses the host cluster's default StorageClass (typically
+    # harvester-longhorn-2r). Set this to an SC tuned for low fsync latency
+    # (numberOfReplicas=1, dataLocality=strict-local) for clusters whose
+    # bootstrap and steady-state are bottlenecked on replicated-write
+    # latency, e.g. control-plane clusters that run etcd on Longhorn-backed
+    # disks. The StorageClass must already exist on the Harvester host
+    # cluster — this module does NOT create it.
+    storage_class_name = optional(string)
   }))
   # Defaults to empty for brownfield callers (manage_rke_config = false).
   # A precondition on the cluster resource enforces at least one pool when


### PR DESCRIPTION
## Summary

New module at `modules/management/keyvault-operator/` that installs the
keyvault-operator controller (manages `KeyVaultBackend` +
`KeyVaultInstance` CRDs) onto a Kubernetes cluster.

Pattern follows `dc-webhook`: typed `kubernetes_*` resources for
everything that has a typed equivalent, `kubernetes_manifest` for the
two CRDs. Provider config lives in the calling layer.

## Module surface

| Inputs                | Outputs                |
|-----------------------|------------------------|
| `image` (required)    | `namespace`            |
| `namespace`           | `deployment_name`      |
| `name_prefix`         | `service_account_name` |
| `replicas`            | `metrics_service`      |
| `leader_elect`        | `crd_groups`           |
| `image_pull_secret`   |                        |
| `resources`           |                        |
| `common_labels`       |                        |

Created objects: Namespace, 2 CRDs, ServiceAccount, leader-election
Role+RoleBinding, manager ClusterRole+ClusterRoleBinding, metrics-auth
ClusterRole+ClusterRoleBinding, metrics-reader ClusterRole, 6 stub
user-facing ClusterRoles (kubebuilder default scaffolding), metrics
Service, manager Deployment, optional image-pull Secret.

## Test plan

- [x] `terraform fmt -recursive -check` clean
- [x] `terraform validate` clean (warnings about
  `kubernetes_namespace` → `kubernetes_namespace_v1` etc. match
  `dc-webhook`'s convention; pre-existing across OCD modules)
- [x] Operator manifests verified by direct `kubectl apply` of the
  operator's own kustomize output against a 3-node Harvester dev
  cluster — this module is a typed-resource port of that same shape.

## Notes for reviewers

- Manager ClusterRole rules are a verbatim port of the operator's
  `+kubebuilder:rbac` markers. When the operator image is bumped,
  re-check the controller source and re-render the operator's
  `config/rbac/role.yaml`; update this module's `main.tf` to match.
- CRD YAMLs under `crds/` are pinned. Refresh them from the operator's
  `config/crd/bases/` when bumping the image.
- No provider blocks in the module. Caller supplies a `kubernetes`
  provider configured against the target cluster.

## Base

This PR is **stacked on top of `feature/dc-controlplane-3node-ha`**
(PR #102). Merge that first; this one rebases onto main automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)