### PR TITLE
Allow same network multi attachments & use static principal+index key for role bindings

### DIFF
--- a/modules/management/tenant-space/main.tf
+++ b/modules/management/tenant-space/main.tf
@@ -251,8 +251,8 @@ locals {
 # than silently keeping stale state due to Computed field behaviour.
 resource "rancher2_project_role_template_binding" "this" {
   for_each = {
-    for b in var.group_role_bindings :
-    "${var.project_name}--${coalesce(b.group_principal_id, b.group_id, b.user_principal_id, b.user_id)}--${b.role_template_id}" => b
+    for idx, b in var.group_role_bindings :
+    "${var.project_name}--${coalesce(b.group_principal_id, b.group_id, b.user_principal_id, b.user_id)}--${idx}" => b
   }
 
   name               = substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63)

--- a/modules/workloads/k8s-cluster/variables.tf
+++ b/modules/workloads/k8s-cluster/variables.tf
@@ -154,19 +154,10 @@ variable "machine_pools" {
       for p in var.machine_pools : (
         (p.vm_network == null || trimspace(p.vm_network) != "") &&
         (p.storage_network == null || trimspace(p.storage_network) != "") &&
-        alltrue([for n in p.networks : trimspace(n) != ""]) &&
-        length(distinct(compact(concat(
-          p.vm_network != null ? [p.vm_network] : [],
-          p.networks,
-          p.storage_network != null ? [p.storage_network] : []
-          )))) == length(compact(concat(
-          p.vm_network != null ? [p.vm_network] : [],
-          p.networks,
-          p.storage_network != null ? [p.storage_network] : []
-        )))
+        alltrue([for n in p.networks : trimspace(n) != ""])
       )
     ])
-    error_message = "Each pool's network refs must be non-empty strings with no duplicates across vm_network, networks, and storage_network."
+    error_message = "Each pool's network refs (vm_network, storage_network, and entries in networks) must be non-empty strings."
   }
 }
 


### PR DESCRIPTION
## Summary

- Removed `role_template_id` from the `for_each` map key in `rancher2_project_role_template_binding`
- The key is now derived from the resolved principal value and list index (`<project>--<principal>--<idx>`), both of which are always known at plan time
- Previously, when `role_template_id` referenced a module output being created in the same apply (e.g. `module.cluster_roles.project_member_restricted_role_id`), Terraform raised an "Invalid for_each argument" error because the key could not be determined until apply
- Environments where the role template already existed in state were unaffected, masking the issue until a fresh environment was provisioned
- Removed the no-duplicates constraint from the `machine_pools` network ref validation
- Harvester legitimately supports provisioning multiple NICs attached to the same network (e.g. two interfaces both on `cloud-dp-net/vm-subnet-012` for bonding or multi-queue setups)
- The validation was introduced to catch empty string refs, which is still enforced — only the cross-field duplicate check has been removed
