### PR TITLE
Fix dc-api contract conformance: JSON Content-Type on middleware errors

### DIFF
--- a/dc-api/internal/api/auth/handlers.go
+++ b/dc-api/internal/api/auth/handlers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/rs/zerolog"
+	"github.com/wso2/dc-api/internal/api/respond"
 	"golang.org/x/oauth2"
 )
 
@@ -239,12 +240,12 @@ func (s *Service) HandleMe(log zerolog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ck, err := r.Cookie(SessionCookieName)
 		if err != nil {
-			http.Error(w, "no session", http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "no session")
 			return
 		}
 		sess, err := s.codec.DecodeSession(ck.Value)
 		if err != nil {
-			http.Error(w, "session invalid", http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "session invalid")
 			return
 		}
 		// Treat past-expiry sessions as if the cookie wasn't there. Without
@@ -254,7 +255,7 @@ func (s *Service) HandleMe(log zerolog.Logger) http.HandlerFunc {
 		// AccessTokenFromCookieReq (used by the auth middleware) already
 		// applies the same check.
 		if sess.Expired() {
-			http.Error(w, "session expired", http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "session expired")
 			return
 		}
 		// We don't re-verify the access token's signature here — the auth
@@ -375,7 +376,7 @@ func (s *Service) resolveReturnTo(returnTo string) string {
 
 func (s *Service) error(w http.ResponseWriter, log zerolog.Logger, status int, msg string, err error) {
 	log.Warn().Err(err).Msg("auth: " + msg)
-	http.Error(w, msg, status)
+	respond.Error(w, status, msg)
 }
 
 // AccessTokenFromCookie decodes a sealed cookie value and returns the

--- a/dc-api/internal/api/middleware/auth.go
+++ b/dc-api/internal/api/middleware/auth.go
@@ -70,6 +70,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/wso2/dc-api/internal/api/respond"
 	"github.com/wso2/dc-api/internal/models"
 	"golang.org/x/oauth2"
 )
@@ -366,34 +367,33 @@ func (a *Auth) Validate(next http.Handler) http.Handler {
 				}
 			}
 			if err != nil {
-				http.Error(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
+				respond.Error(w, http.StatusUnauthorized, "Unauthorized: "+err.Error())
 				return
 			}
 		}
 
 		idToken, err := a.verifier.Verify(r.Context(), tokenStr)
 		if err != nil {
-			http.Error(w, "Unauthorized: invalid token", http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "Unauthorized: invalid token")
 			return
 		}
 
 		if !audienceMatches(idToken.Audience, a.audiences) {
-			http.Error(w, "Unauthorized: audience mismatch", http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "Unauthorized: audience mismatch")
 			return
 		}
 
 		var claims Claims
 		if err := idToken.Claims(&claims); err != nil {
-			http.Error(w, "Unauthorized: cannot parse claims", http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "Unauthorized: cannot parse claims")
 			return
 		}
 
 		ctx, ok := a.cfg.buildContext(r.Context(), claims, a.repo)
 		if !ok {
-			http.Error(w,
+			respond.Error(w, http.StatusForbidden,
 				fmt.Sprintf("Forbidden: user has no DC tenant group (expected group prefixed with %q or %q)",
-					a.cfg.TenantGroupPrefix, a.cfg.AdminGroup),
-				http.StatusForbidden)
+					a.cfg.TenantGroupPrefix, a.cfg.AdminGroup))
 			return
 		}
 
@@ -637,20 +637,19 @@ func (a *TestModeAuth) Validate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenStr, err := bearerToken(r)
 		if err != nil {
-			http.Error(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "Unauthorized: "+err.Error())
 			return
 		}
 		claims, err := verifyRS256JWT(tokenStr, a.pubKeys)
 		if err != nil {
-			http.Error(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "Unauthorized: "+err.Error())
 			return
 		}
 		ctx, ok := a.cfg.buildContext(r.Context(), *claims, a.repo)
 		if !ok {
-			http.Error(w,
+			respond.Error(w, http.StatusForbidden,
 				fmt.Sprintf("Forbidden: user has no DC tenant group (expected prefix %q or %q)",
-					a.cfg.TenantGroupPrefix, a.cfg.AdminGroup),
-				http.StatusForbidden)
+					a.cfg.TenantGroupPrefix, a.cfg.AdminGroup))
 			return
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/dc-api/internal/api/middleware/project_context.go
+++ b/dc-api/internal/api/middleware/project_context.go
@@ -31,6 +31,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/wso2/dc-api/internal/api/respond"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/rbac"
 )
@@ -52,14 +53,14 @@ func (p *ProjectContext) Validate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		urlProject := chi.URLParam(r, "project_id")
 		if urlProject == "" {
-			http.Error(w, "Bad Request: project_id required in URL", http.StatusBadRequest)
+			respond.Error(w, http.StatusBadRequest, "Bad Request: project_id required in URL")
 			return
 		}
 
 		// TenantContext must have run first.
 		tenantID, ok := TenantFromContext(r.Context())
 		if !ok {
-			http.Error(w, "Internal Server Error: no tenant in context", http.StatusInternalServerError)
+			respond.Error(w, http.StatusInternalServerError, "Internal Server Error: no tenant in context")
 			return
 		}
 
@@ -68,11 +69,11 @@ func (p *ProjectContext) Validate(next http.Handler) http.Handler {
 		if err != nil {
 			log.Error().Err(err).Str("tenant", tenantID).Str("project", urlProject).
 				Msg("project_context: project uuid lookup failed")
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			respond.Error(w, http.StatusInternalServerError, "Internal Server Error")
 			return
 		}
 		if projectUUID == uuid.Nil {
-			http.Error(w, "project not found", http.StatusNotFound)
+			respond.Error(w, http.StatusNotFound, "project not found")
 			return
 		}
 
@@ -91,7 +92,7 @@ func (p *ProjectContext) Validate(next http.Handler) http.Handler {
 
 		pType, pID, ok := PrincipalFromContext(r.Context())
 		if !ok {
-			http.Error(w, "Unauthorized: no principal in context", http.StatusUnauthorized)
+			respond.Error(w, http.StatusUnauthorized, "Unauthorized: no principal in context")
 			return
 		}
 
@@ -110,7 +111,7 @@ func (p *ProjectContext) Validate(next http.Handler) http.Handler {
 		if err := rbac.RequireRole(r.Context(), p.repo, pType, pID, false, chain, models.RoleViewer); err != nil {
 			// No matching assignment at project or tenant scope → 404 to avoid
 			// leaking project existence to callers with no access.
-			http.Error(w, "project not found", http.StatusNotFound)
+			respond.Error(w, http.StatusNotFound, "project not found")
 			return
 		}
 

--- a/dc-api/internal/api/respond/respond.go
+++ b/dc-api/internal/api/respond/respond.go
@@ -1,0 +1,43 @@
+// Package respond holds the response helpers shared across every HTTP
+// layer in dc-api — handlers, middleware, and the BFF session controller.
+//
+// Why a dedicated package: middleware short-circuits with auth /
+// project-context errors before the handler runs. Pre-respond, those
+// middleware paths called net/http.Error, which writes
+//
+//	Content-Type: text/plain; charset=utf-8
+//
+// while every other response body is JSON. The OpenAPI spec declares all
+// error responses as application/json, so schemathesis flagged every
+// middleware-short-circuited path as "Undocumented Content-Type" (26
+// findings on a single run). The handlers package had its own writeJSON
+// / writeError pair, but middleware can't import handlers without an
+// import cycle — hence this minimal third package both can use.
+package respond
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// JSON encodes v as JSON and writes it with the standard headers + the
+// given status code.
+//
+// Cache-Control: no-store on every response: dc-api's bodies reflect
+// dynamic state (resource phase, soft-delete toggles, quota counters)
+// and the browser-default cacheability of 200/301/404/410 has bitten us
+// before — a stale 410 surviving a KV secret restore. Cheaper to
+// blanket no-store than to whitelist per-route.
+func JSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// Error writes the canonical {"error": "..."} body with the given status.
+// Drop-in replacement for net/http.Error that keeps the Content-Type
+// declared by openapi.yaml.
+func Error(w http.ResponseWriter, status int, message string) {
+	JSON(w, status, map[string]string{"error": message})
+}

--- a/dc-api/test/contract/nop_providers.go
+++ b/dc-api/test/contract/nop_providers.go
@@ -44,6 +44,17 @@ func (nopCluster) CreateCluster(context.Context, string, string, models.ClusterS
 func (nopCluster) GetCluster(context.Context, string) (*models.Resource, error) { return nil, errNop }
 func (nopCluster) DeleteCluster(context.Context, string) error                  { return errNop }
 func (nopCluster) GetKubeconfig(context.Context, string) (string, error)        { return "", errNop }
+func (nopCluster) AddNodePool(context.Context, string, *models.NodePool, string, string, string, string) error {
+	return errNop
+}
+func (nopCluster) ScaleNodePool(context.Context, string, string, int) error { return errNop }
+func (nopCluster) UpdateNodePoolTaintsLabels(context.Context, string, string, []models.NodePoolTaint, map[string]string) error {
+	return errNop
+}
+func (nopCluster) RemoveNodePool(context.Context, string, string, string) error { return errNop }
+func (nopCluster) GetNodePoolStatuses(context.Context, string) (map[string]models.NodePoolStatus, error) {
+	return nil, errNop
+}
 
 // ── Network ─────────────────────────────────────────────────────────────────
 type nopNetwork struct{}


### PR DESCRIPTION
Closes the workflow-PR blocker (closed PR #111). Two real bugs:

## 1. `nopCluster` missing AKS-style node-pool methods (commit 1)

The contract test's `nopCluster` mock didn't implement `AddNodePool`, `ScaleNodePool`, `UpdateNodePoolTaintsLabels`, `RemoveNodePool`, or `GetNodePoolStatuses` — added in commit 6cfa274 to the `ClusterProvider` interface during the AKS-style multi-pool work but never propagated to the mock. The compile-time interface check (`var _ providers.ClusterProvider = nopCluster{}`) catches it; `go test ./test/contract/...` would fail to compile.

## 2. Middleware short-circuits returned `Content-Type: text/plain` (commit 2)

Schemathesis flagged 26 "Undocumented Content-Type" failures on the previous CI run. Root cause: `internal/api/middleware/auth.go`, `internal/api/middleware/project_context.go`, and `internal/api/auth/handlers.go` all used `net/http.Error`, which writes `text/plain; charset=utf-8`. Every handler error response goes through `handlers/writeError` → JSON, but middleware-short-circuited requests (auth failure, missing project context, expired session) skipped the handler entirely and got text/plain. OpenAPI declares all error responses as `application/json`.

**Fix:** new `internal/api/respond/` package with `JSON(...)` and `Error(...)` helpers, importable by both handlers AND middleware without an import cycle. All 18 `http.Error` sites in those three files now use `respond.Error`. Same status codes, same messages, same body shape as handlers' existing `writeError` (`{"error":"..."}`).

## Behaviour delta

| | Before | After |
|---|---|---|
| HTTP status code | unchanged | unchanged |
| Body text | `no session\n` (plain) | `{"error":"no session"}\n` |
| `Content-Type` | `text/plain; charset=utf-8` | `application/json` |
| `Cache-Control` | absent | `no-store` |

cloud-ui (openapi-fetch) and any other JSON-parsing client now actually works on these paths — was silently broken before.

## What's NOT included

The schemathesis run also reported **3 "Undocumented HTTP status code" failures**, separate from the Content-Type issue. Without CI on this PR (controlplane has no workflows yet — that's the next PR to land), I can't tell which 3. Will address in a follow-up commit once the workflows PR surfaces them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)