### PR TITLE
Onboard Rancher bot user module & Member roles for the K8s cluster module

### DIFF
--- a/modules/management/rancher-bot-user/main.tf
+++ b/modules/management/rancher-bot-user/main.tf
@@ -1,0 +1,95 @@
+resource "random_password" "this" {
+  count   = var.password == null ? 1 : 0
+  length  = 40
+  special = false
+  keepers = {
+    rotation_version = var.password_rotation_version
+  }
+}
+
+locals {
+  password = var.password != null ? var.password : random_password.this[0].result
+}
+
+resource "rancher2_user" "this" {
+  name                 = var.name
+  username             = var.name
+  password             = local.password
+  enabled              = true
+  must_change_password = false
+}
+
+# user-base  → login only (no resource access)
+# user       → Standard User: login + cloudcredentials + nodedrivers +
+#              harvesterconfigs + cluster provisioning (rancher2_cluster_v2)
+
+resource "rancher2_global_role_binding" "this" {
+  name           = "${var.name}-global"
+  global_role_id = var.can_provision_clusters ? "user" : "user-base"
+  user_id        = rancher2_user.this.id
+}
+
+resource "rancher2_cluster_role_template_binding" "this" {
+  for_each = toset(var.cluster_role_template_ids)
+
+  name             = substr(replace("${var.name}-${replace(each.value, "/[^a-z0-9-]/", "-")}", "/-{2,}/", "-"), 0, 63)
+  cluster_id       = var.cluster_id
+  role_template_id = each.value
+  user_id          = rancher2_user.this.id
+
+  depends_on = [rancher2_global_role_binding.this]
+}
+
+resource "rancher2_project_role_template_binding" "this" {
+  for_each = toset(var.project_role_template_ids)
+
+  name             = substr(replace("${var.name}-${replace(each.value, "/[^a-z0-9-]/", "-")}", "/-{2,}/", "-"), 0, 63)
+  project_id       = var.project_id
+  role_template_id = each.value
+  user_id          = rancher2_user.this.id
+
+  depends_on = [rancher2_global_role_binding.this]
+}
+
+# ── Shared image access ───────────────────────────────────────────────────────
+# Read-only binding to the shared images project so the bot can look up
+# VirtualMachineImages during VM and cluster provisioning. Enabled by default.
+# Change shared_image_project_name if your environment uses a different name.
+
+data "rancher2_project" "shared_images" {
+  count      = var.enable_shared_image_access ? 1 : 0
+  cluster_id = var.cluster_id
+  name       = var.shared_image_project_name
+}
+
+resource "rancher2_project_role_template_binding" "shared_image_access" {
+  count = var.enable_shared_image_access ? 1 : 0
+
+  name             = "${var.name}-shared-img"
+  project_id       = data.rancher2_project.shared_images[0].id
+  role_template_id = "read-only"
+  user_id          = rancher2_user.this.id
+
+  depends_on = [rancher2_global_role_binding.this]
+}
+
+# ── API token ─────────────────────────────────────────────────────────────────
+# NOTE: Do NOT set cluster_id — cluster-scoped tokens return 401 with the
+# Terraform provider (SUSE KB 000021440).
+# Rotate token:    bump token_rotation_version
+# Rotate password: bump password_rotation_version (recreates user + all bindings)
+
+resource "rancher2_custom_user_token" "this" {
+  username    = rancher2_user.this.username
+  password    = local.password
+  description = "${var.name} CI/CD pipeline token v${var.token_rotation_version}"
+  ttl         = var.token_ttl
+  renew       = true
+
+  depends_on = [
+    rancher2_global_role_binding.this,
+    rancher2_cluster_role_template_binding.this,
+    rancher2_project_role_template_binding.this,
+    rancher2_project_role_template_binding.shared_image_access,
+  ]
+}

--- a/modules/management/rancher-bot-user/outputs.tf
+++ b/modules/management/rancher-bot-user/outputs.tf
@@ -1,0 +1,15 @@
+output "user_id" {
+  value       = rancher2_user.this.id
+  description = "Rancher user ID for the bot (e.g. 'u-abc123'). Use to reference this identity in external rancher2_*_role_template_binding resources."
+}
+
+output "username" {
+  value       = rancher2_user.this.username
+  description = "Rancher username for the bot. Same as var.name."
+}
+
+output "token" {
+  value       = rancher2_custom_user_token.this.token
+  sensitive   = true
+  description = "Rancher API token for the bot user. Format: 'token-xxxxx:yyyyyy'. Use as token_key in the rancher2 provider block. Prefer retrieving via the kubernetes_secret stored in the tenant namespace rather than reading this output directly."
+}

--- a/modules/management/rancher-bot-user/variables.tf
+++ b/modules/management/rancher-bot-user/variables.tf
@@ -1,0 +1,81 @@
+variable "name" {
+  type        = string
+  description = "Bot user identifier used as the Rancher username and resource name prefix. Must be lowercase alphanumeric with hyphens, starting and ending with alphanumeric. Typically prefixed with the tenant project name by the caller (e.g. 'kasun-test-space-pipeline')."
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.name))
+    error_message = "name must be lowercase alphanumeric with hyphens, starting and ending with alphanumeric."
+  }
+}
+
+variable "password" {
+  type        = string
+  description = "Optional password for the bot user. When null (default), a 40-character random password is generated and stored only in Terraform state. The generated value is never surfaced as an output. Provide an explicit value only when the password is managed externally (e.g. pulled from Vault)."
+  default     = null
+  sensitive   = true
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "Rancher cluster ID of the target cluster (e.g. 'c-xxxxx'). Required for cluster-level role bindings."
+}
+
+variable "project_id" {
+  type        = string
+  description = "Rancher project ID in the format '<cluster_id>:<short_project_id>'. Required for project-level role bindings."
+}
+
+variable "cluster_role_template_ids" {
+  type        = list(string)
+  description = "Role template IDs to bind for this bot at the cluster level. Each entry creates one rancher2_cluster_role_template_binding. Use IDs from the cluster-roles module (e.g. vm_creator_role_id) or built-in IDs like 'cluster-member'."
+  default     = []
+}
+
+variable "project_role_template_ids" {
+  type        = list(string)
+  description = "Role template IDs to bind for this bot at the project level. Each entry creates one rancher2_project_role_template_binding. Use built-in IDs like 'project-member-restricted', 'project-member', or custom role IDs."
+  default     = []
+}
+
+variable "can_provision_clusters" {
+  type        = bool
+  description = "When true, creates a custom rancher2_global_role granting the additional verbs on provisioning.cattle.io/clusters that are missing from the Standard User role. Required to provision rancher2_cluster_v2 (RKE2) resources via this bot's API token. See runbooks/tenants/bot-user-service-principal-design.md for background."
+  default     = false
+}
+
+variable "token_ttl" {
+  type        = number
+  description = "Token TTL in seconds. Defaults to 7776000 (90 days), which matches the Rancher default auth-token-max-ttl-minutes ceiling. Combined with renew = true the token is automatically recreated on expiry. Set 0 only if your Rancher instance has no max-TTL configured."
+  default     = 7776000
+  validation {
+    condition     = var.token_ttl >= 0
+    error_message = "token_ttl must be a non-negative integer (seconds)."
+  }
+}
+
+variable "token_rotation_version" {
+  type        = number
+  description = "Increment to rotate the API token without touching the user or password. The version is embedded in the token description, triggering ForceNew recreation of only the rancher2_custom_user_token resource."
+  default     = 1
+}
+
+variable "password_rotation_version" {
+  type        = number
+  description = "Increment to generate a new random password. Cascades ForceNew through rancher2_user → all role bindings → token. Use only when the password itself may be compromised. Plan a short downtime window — the user is recreated and existing tokens are immediately invalidated."
+  default     = 1
+}
+
+variable "enable_shared_image_access" {
+  type        = bool
+  description = "When true (default), grants this bot user a read-only project role binding to the shared images project so VirtualMachineImage lookups succeed during cluster/VM provisioning. Set to false only for bots that never provision infrastructure."
+  default     = true
+}
+
+variable "shared_image_project_name" {
+  type        = string
+  description = "Name of the Rancher project that holds shared VM images. Looked up by name on the same cluster. Defaults to 'shared'. Change only if your environment uses a different project name for the image catalogue."
+  default     = "shared"
+  validation {
+    condition     = trimspace(var.shared_image_project_name) != ""
+    error_message = "shared_image_project_name must be a non-empty string."
+  }
+}

--- a/modules/management/rancher-bot-user/versions.tf
+++ b/modules/management/rancher-bot-user/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = "~> 13.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/tenancy/k8s-cluster/main.tf
+++ b/modules/tenancy/k8s-cluster/main.tf
@@ -369,3 +369,69 @@ resource "rancher2_cloud_credential" "harvester" {
     ignore_changes = [harvester_credential_config[0].kubeconfig_content]
   }
 }
+
+# ── Cluster membership ────────────────────────────────────────────────────────
+
+locals {
+  # Stable map key encodes which identity field is set so that switching identity
+  # type (e.g. email → user_id) produces a different key and triggers destroy+create
+  # rather than a silent in-place update with stale state.
+  _members = {
+    for m in var.cluster_members :
+    "${coalesce(
+      m.email != null ? "email:${m.email}" : null,
+      m.name != null ? "name:${m.type}:${m.name}" : null,
+      m.user_id != null ? "user_id:${m.user_id}" : null,
+      m.user_principal_id != null ? "user_principal_id:${m.user_principal_id}" : null,
+      m.group_principal_id != null ? "group_principal_id:${m.group_principal_id}" : null,
+    )}:${m.role}" => m
+  }
+}
+
+# Resolves email or name → full Rancher principal ID.
+# email entries always use type = "user"; name entries use the configured type.
+# Not created for user_id / user_principal_id / group_principal_id entries.
+data "rancher2_principal" "member" {
+  for_each = { for k, m in local._members : k => m if m.email != null || m.name != null }
+  name     = each.value.email != null ? each.value.email : each.value.name
+  type     = each.value.email != null ? "user" : each.value.type
+}
+
+resource "rancher2_cluster_role_template_binding" "member" {
+  for_each = local._members
+
+  name = substr(
+    replace(
+      replace(lower("${var.cluster_name}-${replace(each.key, ":", "-")}"), "/[^a-z0-9-]/", "-"),
+      "/-{2,}/", "-"
+    ),
+    0, 63
+  )
+
+  cluster_id       = rancher2_cluster_v2.this.cluster_v1_id
+  role_template_id = each.value.role
+
+  # user_principal_id covers:
+  #   - email lookup (data source result, always type = "user")
+  #   - name-based user lookup (data source result)
+  #   - explicit user_principal_id (e.g. "local://u-427g5iiyyg")
+  #   - bare user_id, wrapped to "local://<id>"
+  user_principal_id = (
+    each.value.user_principal_id != null ? each.value.user_principal_id :
+    each.value.user_id != null ? "local://${each.value.user_id}" :
+    each.value.email != null ? data.rancher2_principal.member[each.key].id :
+    each.value.name != null && each.value.type == "user" ? data.rancher2_principal.member[each.key].id :
+    null
+  )
+
+  # group_principal_id covers:
+  #   - explicit group_principal_id (e.g. "genericoidc_group://my-group")
+  #   - name-based group lookup (data source result)
+  group_principal_id = (
+    each.value.group_principal_id != null ? each.value.group_principal_id :
+    each.value.name != null && each.value.type == "group" ? data.rancher2_principal.member[each.key].id :
+    null
+  )
+
+  depends_on = [rancher2_cluster_v2.this]
+}

--- a/modules/tenancy/k8s-cluster/main.tf
+++ b/modules/tenancy/k8s-cluster/main.tf
@@ -54,6 +54,16 @@ EOF
   ) : ""
 
   effective_chart_values = var.chart_values != "" ? var.chart_values : local.default_chart_values
+
+  # Generated machine_global_config. ingress-controller is omitted when using
+  # the RKE2 default (ingress-nginx) to keep the config minimal.
+  _ingress_line = var.ingress_controller != "ingress-nginx" ? "\ningress-controller: ${var.ingress_controller}" : ""
+
+  default_machine_global_config = <<-YAML
+    cni: ${var.cni}
+    disable-kube-proxy: false
+    etcd-expose-metrics: false${local._ingress_line}
+  YAML
 }
 
 # Registry auth secrets — created only for configs that supply username/password.
@@ -195,11 +205,7 @@ resource "rancher2_cluster_v2" "this" {
   dynamic "rke_config" {
     for_each = var.manage_rke_config ? [1] : []
     content {
-      machine_global_config = var.machine_global_config != null ? var.machine_global_config : <<-YAML
-        cni: ${var.cni}
-        disable-kube-proxy: false
-        etcd-expose-metrics: false
-      YAML
+      machine_global_config = coalesce(var.machine_global_config, local.default_machine_global_config)
 
       dynamic "machine_selector_config" {
         for_each = var.enable_harvester_cloud_provider ? [1] : []

--- a/modules/tenancy/k8s-cluster/variables.tf
+++ b/modules/tenancy/k8s-cluster/variables.tf
@@ -323,3 +323,89 @@ variable "chart_values" {
   description = "Custom Helm chart values to pass to RKE2"
   default     = ""
 }
+
+# ── Cluster membership ────────────────────────────────────────────────────────
+# Optional list of users/groups to bind to this cluster after provisioning.
+# Defaults to [] — omitting it leaves no additional bindings and does not
+# affect any existing clusters.
+#
+# Identity fields (set exactly one per entry):
+#
+#   email              — User email address resolved via data "rancher2_principal"
+#                        with type = "user". Cleaner than name when you know the
+#                        identity is a user and have their email address.
+#                        Same caveat as name: unreliable if the account has never
+#                        logged in or if multiple Rancher accounts share the email.
+#                        Example: "dev@wso2.com"
+#
+#   name               — Generic display name / email resolved via data "rancher2_principal".
+#                        Use with type = "group" for group lookups.
+#                        Example: "platform-team"  (with type = "group")
+#
+#   user_id            — Bare Rancher user ID (no scheme prefix). Most reliable
+#                        for local users — immune to duplicate-account ambiguity.
+#                        Find it in Rancher UI → Users & Authentication → user row,
+#                        or from: rancher2_user.this.id
+#                        Example: "u-427g5iiyyg"
+#
+#   user_principal_id  — Full Rancher principal ID for a user account.
+#                        Local Rancher users:  "local://u-427g5iiyyg"
+#                        OIDC / SAML users:    "genericoidc_user://email@example.com"
+#
+#   group_principal_id — Full Rancher principal ID for a group.
+#                        OIDC / SAML groups:   "genericoidc_group://my-group-name"
+#                        AD groups:            "activedirectory_group://CN=my-group,DC=corp"
+#
+# role defaults to "cluster-member". Use "cluster-owner" to grant full
+# cluster admin. Any custom role template ID is also accepted.
+#
+# Examples:
+#   cluster_members = [
+#     # Email lookup — convenient when one Rancher account exists for the address
+#     { email = "dev@wso2.com" },
+#
+#     # Bare user ID — avoids lookup, immune to duplicate accounts
+#     { user_id = "u-427g5iiyyg", role = "cluster-owner" },
+#
+#     # Full user principal ID — local Rancher user
+#     { user_principal_id = "local://u-427g5iiyyg" },
+#
+#     # OIDC user by full principal ID
+#     { user_principal_id = "genericoidc_user://dev@wso2.com", role = "cluster-owner" },
+#
+#     # Group by full principal ID
+#     { group_principal_id = "genericoidc_group://platform-team", role = "cluster-owner" },
+#
+#     # Group name lookup
+#     { name = "platform-team", type = "group", role = "cluster-owner" },
+#   ]
+
+variable "cluster_members" {
+  type = list(object({
+    email              = optional(string)         # user email — resolved via data source (type = "user")
+    name               = optional(string)         # display name — resolved via data source, use with type
+    type               = optional(string, "user") # "user" or "group" — only meaningful with name
+    user_id            = optional(string)         # bare user ID, e.g. "u-427g5iiyyg"
+    user_principal_id  = optional(string)         # full user principal, e.g. "local://u-427g5iiyyg"
+    group_principal_id = optional(string)         # full group principal, e.g. "genericoidc_group://my-group"
+    role               = optional(string, "cluster-member")
+  }))
+  default     = []
+  description = "Optional cluster role bindings. Set exactly one of: email, name, user_id, user_principal_id, or group_principal_id. role defaults to cluster-member."
+
+  validation {
+    condition = alltrue([
+      for m in var.cluster_members :
+      length(compact([m.email, m.name, m.user_id, m.user_principal_id, m.group_principal_id])) == 1
+    ])
+    error_message = "Each cluster_members entry must set exactly one of: email, name, user_id, user_principal_id, or group_principal_id."
+  }
+
+  validation {
+    condition = alltrue([
+      for m in var.cluster_members :
+      m.name != null || m.type == "user"
+    ])
+    error_message = "type (\"user\" or \"group\") is only meaningful with name-based lookup. For email, user_id, user_principal_id, or group_principal_id entries, omit type or leave it as the default."
+  }
+}

--- a/modules/tenancy/k8s-cluster/variables.tf
+++ b/modules/tenancy/k8s-cluster/variables.tf
@@ -396,16 +396,19 @@ variable "cluster_members" {
   validation {
     condition = alltrue([
       for m in var.cluster_members :
-      length(compact([m.email, m.name, m.user_id, m.user_principal_id, m.group_principal_id])) == 1
+      length([
+        for v in [m.email, m.name, m.user_id, m.user_principal_id, m.group_principal_id] :
+        v if v != null && trimspace(v) != ""
+      ]) == 1
     ])
-    error_message = "Each cluster_members entry must set exactly one of: email, name, user_id, user_principal_id, or group_principal_id."
+    error_message = "Each cluster_members entry must set exactly one of: email, name, user_id, user_principal_id, or group_principal_id (non-empty, non-whitespace)."
   }
 
   validation {
     condition = alltrue([
       for m in var.cluster_members :
-      m.name != null || m.type == "user"
+      m.name == null ? m.type == "user" : contains(["user", "group"], m.type)
     ])
-    error_message = "type (\"user\" or \"group\") is only meaningful with name-based lookup. For email, user_id, user_principal_id, or group_principal_id entries, omit type or leave it as the default."
+    error_message = "When name is set, type must be \"user\" or \"group\". For email, user_id, user_principal_id, or group_principal_id entries, omit type (defaults to \"user\")."
   }
 }

--- a/modules/tenancy/k8s-cluster/variables.tf
+++ b/modules/tenancy/k8s-cluster/variables.tf
@@ -21,9 +21,20 @@ variable "cni" {
   default     = "cilium"
 }
 
+variable "ingress_controller" {
+  type        = string
+  description = "Ingress controller to use. Accepted values: ingress-nginx (RKE2 default), traefik, none. Ignored when machine_global_config is set explicitly."
+  default     = "ingress-nginx"
+
+  validation {
+    condition     = contains(["traefik", "ingress-nginx", "none"], var.ingress_controller)
+    error_message = "ingress_controller must be one of: traefik, ingress-nginx, none."
+  }
+}
+
 variable "machine_global_config" {
   type        = string
-  description = "Full machine_global_config YAML for the cluster. When null the module generates a default from the cni variable. Override to add extra args such as kube-proxy-arg."
+  description = "Full machine_global_config YAML for the cluster. When set, takes full precedence and ingress_controller is ignored. When null (default), the module generates a config from cni and ingress_controller."
   default     = null
 }
 

--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -314,3 +314,29 @@ resource "rancher2_project_role_template_binding" "shared_image_access" {
   user_principal_id  = each.value.user_principal_id
   user_id            = each.value.user_id
 }
+
+# ── CI/CD bot users ───────────────────────────────────────────────────────────
+# Optional per-tenant machine identities for Terraform/CI pipelines.
+# Only instantiated when bot_users is non-empty — all existing tenant spaces
+# that omit this variable are completely unaffected.
+# Uses only the unaliased rancher2 and random providers — no kubernetes needed.
+
+module "bot_user" {
+  for_each = { for b in var.bot_users : b.name => b }
+  source   = "../rancher-bot-user"
+
+  name                       = "${var.project_name}-${each.value.name}"
+  password                   = each.value.password
+  cluster_id                 = var.cluster_id
+  project_id                 = rancher2_project.this.id
+  cluster_role_template_ids  = each.value.cluster_role_template_ids
+  project_role_template_ids  = each.value.project_role_template_ids
+  can_provision_clusters     = each.value.can_provision_clusters
+  token_ttl                  = each.value.token_ttl
+  token_rotation_version     = each.value.token_rotation_version
+  password_rotation_version  = each.value.password_rotation_version
+  enable_shared_image_access = each.value.enable_shared_image_access
+  shared_image_project_name  = each.value.shared_image_project_name
+
+  depends_on = [rancher2_namespace.this]
+}

--- a/modules/tenancy/tenant-space/outputs.tf
+++ b/modules/tenancy/tenant-space/outputs.tf
@@ -43,3 +43,19 @@ output "vm_access_kubeconfig" {
   sensitive   = true
   description = "Namespace-scoped Harvester kubeconfig for the tenant team. Non-null when expose_vm_kubeconfig = true and the namespace-credential-provisioner has already created the secret. Hand to the tenant team once at onboarding. See examples/consumer-workloads in wso2-datacenter-project for usage."
 }
+
+output "bot_users" {
+  value = {
+    for name, mod in module.bot_user : name => {
+      user_id  = mod.user_id
+      username = mod.username
+    }
+  }
+  description = "Map of bot name → identity metadata (user_id, username) for each bot_users entry."
+}
+
+output "bot_user_tokens" {
+  value       = { for name, mod in module.bot_user : name => mod.token }
+  sensitive   = true
+  description = "Map of bot name → raw Rancher API token. Sensitive. Consumed by the caller to build a combined credentials output for tenant teams."
+}

--- a/modules/tenancy/tenant-space/variables.tf
+++ b/modules/tenancy/tenant-space/variables.tf
@@ -298,14 +298,14 @@ variable "vyos_api_key" {
 
 variable "bot_users" {
   type = list(object({
-    name                      = string
-    password                  = optional(string)
-    cluster_role_template_ids = optional(list(string), [])
-    project_role_template_ids = optional(list(string), [])
-    can_provision_clusters    = optional(bool, false)
-    token_ttl                 = optional(number, 7776000)
-    token_rotation_version    = optional(number, 1)
-    password_rotation_version = optional(number, 1)
+    name                       = string
+    password                   = optional(string)
+    cluster_role_template_ids  = optional(list(string), [])
+    project_role_template_ids  = optional(list(string), [])
+    can_provision_clusters     = optional(bool, false)
+    token_ttl                  = optional(number, 7776000)
+    token_rotation_version     = optional(number, 1)
+    password_rotation_version  = optional(number, 1)
     enable_shared_image_access = optional(bool, true)
     shared_image_project_name  = optional(string, "shared")
   }))

--- a/modules/tenancy/tenant-space/variables.tf
+++ b/modules/tenancy/tenant-space/variables.tf
@@ -274,6 +274,68 @@ variable "vyos_api_key" {
   default     = null
 }
 
+# ── CI/CD bot users — all optional ───────────────────────────────────────────
+# When bot_users is non-empty, one rancher-bot-user sub-module is instantiated
+# per entry. Each bot gets a dedicated Rancher local user, scoped RBAC
+# bindings, a rancher2_custom_user_token, and a kubernetes_secret in the
+# tenant namespace for pipeline token retrieval.
+#
+# All existing tenant spaces that omit bot_users are completely unaffected.
+#
+# Requires the kubernetes.harvester provider to be configured in the caller.
+# The token secret is named '<project_name>-<name>-rancher-token' and stored
+# in token_namespace (defaults to the first workload namespace).
+#
+# Example:
+#   bot_users = [
+#     {
+#       name                      = "pipeline"
+#       cluster_role_template_ids = [module.cluster_roles.vm_creator_role_id]
+#       project_role_template_ids = ["project-member-restricted"]
+#       can_provision_clusters    = true
+#     },
+#   ]
+
+variable "bot_users" {
+  type = list(object({
+    name                      = string
+    password                  = optional(string)
+    cluster_role_template_ids = optional(list(string), [])
+    project_role_template_ids = optional(list(string), [])
+    can_provision_clusters    = optional(bool, false)
+    token_ttl                 = optional(number, 7776000)
+    token_rotation_version    = optional(number, 1)
+    password_rotation_version = optional(number, 1)
+    enable_shared_image_access = optional(bool, true)
+    shared_image_project_name  = optional(string, "shared")
+  }))
+  description = <<-EOT
+    Optional list of CI/CD bot users to provision for this tenant space. Each entry
+    creates a Rancher local user, scoped RBAC bindings, an API token, and a
+    kubernetes_secret in the tenant namespace so pipelines can retrieve the token
+    via their namespace-scoped kubeconfig.
+
+    name                      - Bot username suffix. Prefixed with <project_name>- in all
+                                Rancher resource names. Must be lowercase alphanumeric with hyphens.
+    password                  - Optional explicit password. When null (default), a 40-char
+                                random password is generated and stored only in TF state.
+    cluster_role_template_ids - Role template IDs for cluster-level bindings (e.g. vm_creator).
+    project_role_template_ids - Role template IDs for project-level bindings (e.g. "project-member-restricted").
+    can_provision_clusters    - When true, adds a custom global role granting the verbs needed to
+                                provision rancher2_cluster_v2 resources (workaround for upstream 403 bug).
+    token_ttl                 - Token TTL in seconds. 0 = never expires.
+
+    Tokens are surfaced via the bot_user_tokens output (sensitive). The caller is responsible
+    for distributing them to tenant teams (e.g. via a combined credentials output).
+  EOT
+  default     = []
+
+  validation {
+    condition     = length(var.bot_users) == length(distinct([for b in var.bot_users : b.name]))
+    error_message = "Each bot_users entry must have a unique name within this tenant space."
+  }
+}
+
 # ── Storage network ───────────────────────────────────────────────────────────
 # Creates a harvester_network attached to a dedicated storage cluster network
 # (typically a separate physical NIC, e.g. enp2s0) rather than the VM network.

--- a/modules/tenancy/tenant-space/variables.tf
+++ b/modules/tenancy/tenant-space/variables.tf
@@ -277,14 +277,11 @@ variable "vyos_api_key" {
 # ── CI/CD bot users — all optional ───────────────────────────────────────────
 # When bot_users is non-empty, one rancher-bot-user sub-module is instantiated
 # per entry. Each bot gets a dedicated Rancher local user, scoped RBAC
-# bindings, a rancher2_custom_user_token, and a kubernetes_secret in the
-# tenant namespace for pipeline token retrieval.
+# bindings, and a rancher2_custom_user_token. No Kubernetes Secret is created
+# and no kubernetes provider is required — tokens are surfaced via the
+# bot_user_tokens sensitive output and distributed to tenant teams out-of-band.
 #
 # All existing tenant spaces that omit bot_users are completely unaffected.
-#
-# Requires the kubernetes.harvester provider to be configured in the caller.
-# The token secret is named '<project_name>-<name>-rancher-token' and stored
-# in token_namespace (defaults to the first workload namespace).
 #
 # Example:
 #   bot_users = [
@@ -311,9 +308,8 @@ variable "bot_users" {
   }))
   description = <<-EOT
     Optional list of CI/CD bot users to provision for this tenant space. Each entry
-    creates a Rancher local user, scoped RBAC bindings, an API token, and a
-    kubernetes_secret in the tenant namespace so pipelines can retrieve the token
-    via their namespace-scoped kubeconfig.
+    creates a Rancher local user, scoped RBAC bindings, and a rancher2_custom_user_token.
+    No Kubernetes Secret is created and no kubernetes provider is required.
 
     name                      - Bot username suffix. Prefixed with <project_name>- in all
                                 Rancher resource names. Must be lowercase alphanumeric with hyphens.
@@ -321,9 +317,12 @@ variable "bot_users" {
                                 random password is generated and stored only in TF state.
     cluster_role_template_ids - Role template IDs for cluster-level bindings (e.g. vm_creator).
     project_role_template_ids - Role template IDs for project-level bindings (e.g. "project-member-restricted").
-    can_provision_clusters    - When true, adds a custom global role granting the verbs needed to
-                                provision rancher2_cluster_v2 resources (workaround for upstream 403 bug).
-    token_ttl                 - Token TTL in seconds. 0 = never expires.
+    can_provision_clusters    - When true, assigns the Standard User global role ("user") which
+                                includes cloudcredentials, nodedrivers, harvesterconfigs, and
+                                cluster provisioning. When false, assigns "user-base" (login only).
+    token_ttl                 - Token TTL in seconds. Defaults to 7776000 (90 days), matching
+                                Rancher's auth-token-max-ttl-minutes ceiling. Avoid 0 — Rancher
+                                normalises it to the instance max, causing perpetual plan drift.
 
     Tokens are surfaced via the bot_user_tokens output (sensitive). The caller is responsible
     for distributing them to tenant teams (e.g. via a combined credentials output).

--- a/modules/tenancy/tenant-space/versions.tf
+++ b/modules/tenancy/tenant-space/versions.tf
@@ -14,5 +14,9 @@ terraform {
       version               = "~> 2.35"
       configuration_aliases = [kubernetes.harvester]
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

### New module: `rancher-bot-user`
Adds `modules/management/rancher-bot-user` — a self-contained machine identity for CI/CD pipelines.
Creates a local Rancher user, a global role binding (Standard User `user` or login-only `user-base`
depending on `can_provision_clusters`), optional cluster/project role bindings, shared image project
read-only access (enabled by default so VirtualMachineImage lookups succeed during provisioning),
and an API token surfaced as a sensitive output.

Key design decisions:
- `token_rotation_version`: increment to rotate the token only (ForceNew on description)
- `password_rotation_version`: increment to rotate password + cascade-recreate user and all bindings
- `token_ttl` defaults to `7776000` (90 days) to match Rancher's `auth-token-max-ttl-minutes` ceiling
  and avoid perpetual plan drift
- `enable_shared_image_access` (default `true`) grants read-only access to the shared images project
  so the bot can look up `VirtualMachineImages` during cluster/VM provisioning

### `tenant-space`: optional bot users
Adds an optional `bot_users` list variable to `modules/management/tenant-space`. Omitting it has
zero effect on existing tenant spaces. Each entry maps 1:1 to a `rancher-bot-user` module instance
named `<project_name>-<bot.name>`. Token and user metadata are surfaced via `bot_users` and
`bot_user_tokens` (sensitive) outputs.

### `k8s-cluster`: cluster membership bindings
Adds an optional `cluster_members` list variable to `modules/workloads/k8s-cluster` for granting
users or groups a role on the downstream cluster after provisioning. Supports five identity paths:

| Field | When to use |
|---|---|
| `email` | Email lookup via `data "rancher2_principal"` (type = user, implicit) |
| `name` + `type` | Generic name lookup — use `type = "group"` for group bindings |
| `user_id` | Bare Rancher user ID (e.g. `u-427g5iiyyg`) — immune to duplicate-account ambiguity |
| `user_principal_id` | Full principal ID (e.g. `local://u-427g5iiyyg`, `genericoidc_user://...`) |
| `group_principal_id` | Full group principal ID (e.g. `genericoidc_group://my-group`) |

Map keys encode the identity field type so switching from one path to another (e.g. `email` → `user_id`)
triggers destroy+recreate instead of a silent stale-state in-place update.


