### PR TITLE
Align openapi spec with handler 4xx responses

### DIFF
--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -169,6 +169,8 @@ paths:
                     $ref: "#/components/schemas/TenantCap"
                   available:
                     $ref: "#/components/schemas/TenantCap"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -196,6 +198,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -230,6 +234,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
         "500":
@@ -254,6 +260,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -298,7 +306,8 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
+                anyOf:
+                  - $ref: "#/components/schemas/Error"
                   - $ref: "#/components/schemas/QuotaExceededError"
                   - type: object
                     required: [error, message, requested, in_use]
@@ -331,6 +340,8 @@ paths:
       responses:
         "204":
           description: Project deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -1253,6 +1264,8 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/RoleAssignment"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -1377,6 +1390,8 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/ServiceAccount"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -2950,6 +2965,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
         "500":
@@ -2968,8 +2985,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/KeyVault"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -2997,6 +3018,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/KeyVault"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -3017,6 +3040,8 @@ paths:
       responses:
         "204":
           description: Key Vault deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -3062,6 +3087,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/KeyVaultCredentials"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -3135,6 +3162,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/KeyVaultCredentials"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -3223,6 +3252,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/PrivateEndpoint"
+        "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
@@ -3253,6 +3283,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PrivateEndpoint"
+        "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
@@ -3269,6 +3300,7 @@ paths:
       responses:
         "204":
           description: Endpoint deleted
+        "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }


### PR DESCRIPTION
## What

Make `dc-api/openapi.yaml` pass the Schemathesis contract test (`dc-api/test/contract`). The test reported **17 spec-vs-handler conformance failures**:

- **16× undocumented HTTP status code** — operations returned a 4xx the spec didn't declare.
- **1× response violates schema** — the `updateProjectQuota` 400 schema rejected the generic validation-error body.

## Changes

This is a **spec-only** change — no handler behaviour is modified. Each declaration was verified against the response the handler actually returns:

- **Add `400` (BadRequest)** to the 14 tenant-scoped operations that reject a malformed path parameter (e.g. a `tenant_id` that fails its pattern): `cap-usage`, `listProjects`, `getProject`, `deleteProject`, `listMembers`, `listServiceAccounts`, `listKeyVaults`, `getKeyVault`, `deleteKeyVault`, `getKeyVaultCredentials`, `rotateKeyVaultCredentials`, and the three KeyVault private-endpoint operations.
- **Add `404` (NotFound)** to `createProject`, `createKeyVault`, and `listKeyVaults`, which return `"tenant not found"`.
- **Widen the `updateProjectQuota` 400 schema** from `oneOf` to `anyOf` and add the generic `Error` shape, so the plain `{"error": "..."}` validation body validates alongside the quota-specific shapes.

## Verification

Run locally against the in-process dc-api (nopped backends), schemathesis
`4.4.4`:

```
✅ 32 passed
3039 generated, 3039 passed
--- PASS: TestSpec_Conformance
```

`npx @redocly/cli lint dc-api/openapi.yaml` → valid, no new warnings.

## Follow-up

Once this lands, `continue-on-error` can be removed from `.github/workflows/contract.yaml` and `contract` added to the `controlplane` branch-protection required checks. Kept out of this PR on purpose.
