### PR TITLE
[Fix] Refresh tenant gate after first-tenant registration

### DIFF
--- a/cloud-ui/src/auth/RequireTenants.test.tsx
+++ b/cloud-ui/src/auth/RequireTenants.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FluentProvider } from '@fluentui/react-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import RequireTenants from './RequireTenants';
+import { AuthContext, type AuthContextValue, type AuthUser } from './context';
+import { ApiContext } from '../api/context';
+import type { ApiClient } from '../api/client';
+import { wso2LightTheme } from '../theme/themes';
+
+const ADMIN: AuthUser = {
+  sub: 'admin-sub',
+  expiresAt: '2099-01-01T00:00:00Z',
+  isAdmin: true,
+  tenants: [],
+};
+
+function authValue(user: AuthUser | null): AuthContextValue {
+  return { user, loading: false, login: () => {}, logout: async () => {} };
+}
+
+/**
+ * Fake API client whose GET('/v1/tenants') returns a fresh snapshot of
+ * whatever `tenants` holds at call time. Growing the backing array and then
+ * invalidating the query reproduces "a tenant was just registered" without
+ * touching the real BFF. The snapshot (slice) matters: a real API hands back
+ * a newly deserialized array each request, so react-query sees changed data
+ * and re-renders — returning the same mutated reference would defeat its
+ * structural sharing and mask the very transition under test.
+ */
+function makeFakeApi(tenants: unknown[]): ApiClient {
+  return {
+    GET: async (path: string) => {
+      if (path === '/v1/tenants') {
+        return { data: tenants.slice(), error: undefined, response: new Response() };
+      }
+      return { data: undefined, error: undefined, response: new Response() };
+    },
+  } as unknown as ApiClient;
+}
+
+function renderGate(client: ApiClient, queryClient: QueryClient) {
+  return render(
+    <FluentProvider theme={wso2LightTheme}>
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider value={authValue(ADMIN)}>
+          <ApiContext.Provider value={client}>
+            <MemoryRouter initialEntries={['/tenants/acme']}>
+              <Routes>
+                <Route element={<RequireTenants />}>
+                  <Route path="/tenants/:tenantId" element={<div>TENANT DASHBOARD</div>} />
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          </ApiContext.Provider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    </FluentProvider>
+  );
+}
+
+describe('RequireTenants gate', () => {
+  it('flips from the no-tenants screen to the Outlet when the tenants cache refreshes', async () => {
+    // Shared mutable backing store: starts empty (admin, zero tenants).
+    const tenants: unknown[] = [];
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    renderGate(makeFakeApi(tenants), queryClient);
+
+    // Empty → admin variant of NoTenantsPage, NOT the protected Outlet.
+    expect(await screen.findByText('No tenants registered yet')).toBeInTheDocument();
+    expect(screen.queryByText('TENANT DASHBOARD')).not.toBeInTheDocument();
+
+    // Simulate a successful registration: a tenant now exists and the dialog
+    // invalidates ['tenants'] — the same key this gate reads. No remount.
+    tenants.push({ id: 'acme', name: 'Acme', roles: ['owner'] });
+    await queryClient.invalidateQueries({ queryKey: ['tenants'] });
+
+    // Gate must flip empty → ready in place and resolve its Outlet, so the
+    // freshly registered tenant lands the user on the dashboard without a reload.
+    await waitFor(() => {
+      expect(screen.getByText('TENANT DASHBOARD')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('No tenants registered yet')).not.toBeInTheDocument();
+  });
+});

--- a/cloud-ui/src/auth/RequireTenants.tsx
+++ b/cloud-ui/src/auth/RequireTenants.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Spinner, Text, makeStyles, tokens } from '@fluentui/react-components';
-import { useEffect, useReducer, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Outlet } from 'react-router-dom';
-import { makeApiClient } from '../api/client';
+import { useApi } from '../api/useApi';
 import { useAuth } from './useAuth';
 import NoTenantsPage from '../pages/NoTenantsPage';
 
@@ -30,28 +30,6 @@ const useStyles = makeStyles({
   },
 });
 
-type GateState =
-  | { status: 'loading'; attempt: number }
-  | { status: 'error'; attempt: number }
-  | { status: 'empty'; attempt: number }
-  | { status: 'ready'; attempt: number };
-
-type GateAction =
-  | { type: 'retry' }
-  | { type: 'resolve'; tenantCount: number }
-  | { type: 'reject' };
-
-function gateReducer(state: GateState, action: GateAction): GateState {
-  switch (action.type) {
-    case 'retry':
-      return { status: 'loading', attempt: state.attempt + 1 };
-    case 'resolve':
-      return { status: action.tenantCount === 0 ? 'empty' : 'ready', attempt: state.attempt };
-    case 'reject':
-      return { status: 'error', attempt: state.attempt };
-  }
-}
-
 /**
  * Layout route that gates its children on the user having at least one
  * accessible tenant per GET /v1/tenants (DB-backed, not JWT-derived).
@@ -59,49 +37,34 @@ function gateReducer(state: GateState, action: GateAction): GateState {
  * Admins are NOT bypassed here — an admin with no tenants registered yet
  * should land on the admin variant of NoTenantsPage so they can create
  * the first tenant, not fall through to an empty TenantPickerPage.
+ *
+ * The tenant list is read through the shared react-query ['tenants'] cache —
+ * the same key TenantPickerPage and TenantSwitcher use. That coupling is
+ * deliberate: RegisterTenantDialog invalidates ['tenants'] after a successful
+ * create, which makes this gate refetch and flip empty → ready in place. So a
+ * freshly registered first tenant resolves its Outlet immediately, without the
+ * user having to reload the page.
  */
 export default function RequireTenants() {
   const styles = useStyles();
   const { user } = useAuth();
+  const api = useApi();
 
-  const [gate, dispatch] = useReducer(gateReducer, { status: 'loading', attempt: 0 });
-  const abortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    if (!user) return;
-
-    // Cancel any in-flight fetch from a previous render.
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    const client = makeApiClient();
-
-    void client
-      .GET('/v1/tenants', { signal: controller.signal } as Parameters<typeof client.GET>[1])
-      .then(({ data, response }) => {
-        if (controller.signal.aborted) return;
-        if (!response.ok) {
-          dispatch({ type: 'reject' });
-          return;
-        }
-        dispatch({ type: 'resolve', tenantCount: (data ?? []).length });
-      })
-      .catch(() => {
-        if (!controller.signal.aborted) dispatch({ type: 'reject' });
-      });
-
-    return () => {
-      controller.abort();
-    };
-    // gate.attempt drives re-fetches on retry; user drives re-fetches on login change.
-  }, [user, gate.attempt]);
+  const tenantsQuery = useQuery({
+    queryKey: ['tenants'],
+    enabled: Boolean(user),
+    queryFn: async () => {
+      const { data, error } = await api.GET('/v1/tenants');
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      return data ?? [];
+    },
+  });
 
   // RequireAuth above us already handles the loading/unauthenticated states;
   // we only render once user is non-null.
   if (!user) return null;
 
-  if (gate.status === 'loading') {
+  if (tenantsQuery.isLoading) {
     return (
       <div className={styles.loading}>
         <Spinner size="large" label="Loading tenants…" />
@@ -109,13 +72,13 @@ export default function RequireTenants() {
     );
   }
 
-  if (gate.status === 'error') {
+  if (tenantsQuery.isError) {
     return (
       <div className={styles.errorWrap}>
         <Card className={styles.errorCard}>
           <Text weight="semibold" size={500}>Could not load tenants</Text>
           <Text>There was a problem reaching the API. Check your connection and try again.</Text>
-          <Button appearance="primary" onClick={() => dispatch({ type: 'retry' })}>
+          <Button appearance="primary" onClick={() => void tenantsQuery.refetch()}>
             Retry
           </Button>
         </Card>
@@ -123,7 +86,7 @@ export default function RequireTenants() {
     );
   }
 
-  if (gate.status === 'empty') {
+  if ((tenantsQuery.data ?? []).length === 0) {
     // NoTenantsPage reads user.isAdmin internally and renders the correct variant.
     return <NoTenantsPage />;
   }


### PR DESCRIPTION
## Summary

When an admin signs in with no tenants registered yet, registering the first tenant succeeded but left the user on the no-tenants screen — the new tenant was only entered after a manual page reload. This makes that first-run onboarding land the admin directly in the newly created tenant, with no reload.

Closes #122

## Root cause

`RequireTenants` (the layout-route gate wired in `router.tsx`) kept its own tenant list in local component state, fetched once via a one-shot effect and disconnected from the shared react-query `['tenants']` cache that `TenantPickerPage` and `TenantSwitcher` already use. `RegisterTenantDialog` invalidates `['tenants']` after a successful create, but that invalidation had no effect on the gate, so it stayed in its `empty` branch and kept rendering `NoTenantsPage`, shadowing the routed `<Outlet />`. Only a full page reload remounted the gate and refetched.

## Fix

Read the gate's tenant list through the same `['tenants']` react-query key the rest of the app uses. The dialog's existing invalidation now makes the gate refetch and flip `empty → ready` in place, so the freshly registered tenant resolves its `Outlet` immediately. This also removes ~40 lines of bespoke `useReducer` / `useEffect` / abort state-machine code, unifying tenant fetching on one pattern.

## Testing

- `pnpm lint` — clean on the changed files
- `tsc -b` — clean
- `pnpm test` — 2/2 pass, including a new `RequireTenants.test.tsx` that drives the `empty → ready` transition purely from a `['tenants']` cache invalidation (no remount), proving the gate now advances without a reload.
- Manually verified locally: deleted the test tenant, re-registered as admin, and landed directly in the new tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
