### PR TITLE
[Feature]: Integrate DBaaS operator and Databases UI pages

### DIFF
--- a/cloud-ui/src/components/DatabaseCreateDrawer.tsx
+++ b/cloud-ui/src/components/DatabaseCreateDrawer.tsx
@@ -56,7 +56,9 @@ const INSTANCE_CLASSES = [
   'db.r5.large',
   'db.r5.xlarge',
   'db.r5.2xlarge',
-];
+] as const;
+
+type InstanceClass = typeof INSTANCE_CLASSES[number];
 
 export interface DatabaseCreated {
   id: string;
@@ -85,7 +87,7 @@ export default function DatabaseCreateDrawer({ open, onClose, onCreated }: Props
   // ── Form state ─────────────────────────────────────────────────────────────
 
   const [name, setName] = useState('');
-  const [instanceClass, setInstanceClass] = useState('db.t3.medium');
+  const [instanceClass, setInstanceClass] = useState<InstanceClass>('db.t3.medium');
   const [storageGb, setStorageGb] = useState(50);
 
   // ── Validation ─────────────────────────────────────────────────────────────
@@ -198,7 +200,7 @@ export default function DatabaseCreateDrawer({ open, onClose, onCreated }: Props
               <Dropdown
                 value={instanceClass}
                 selectedOptions={[instanceClass]}
-                onOptionSelect={(_, d) => setInstanceClass(d.optionValue ?? 'db.t3.medium')}
+                onOptionSelect={(_, d) => setInstanceClass((d.optionValue ?? 'db.t3.medium') as InstanceClass)}
               >
                 {INSTANCE_CLASSES.map((cls) => (
                   <Option key={cls} value={cls}>{cls}</Option>

--- a/cloud-ui/src/components/DatabaseCreateDrawer.tsx
+++ b/cloud-ui/src/components/DatabaseCreateDrawer.tsx
@@ -1,0 +1,289 @@
+import {
+  Body1,
+  Button,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerHeaderTitle,
+  Dropdown,
+  Field,
+  Input,
+  MessageBar,
+  MessageBarBody,
+  Option,
+  OverlayDrawer,
+  SpinButton,
+  Toast,
+  ToastTitle,
+  Toaster,
+  makeStyles,
+  tokens,
+  useId,
+  useToastController,
+} from '@fluentui/react-components';
+import { Dismiss24Regular } from '@fluentui/react-icons';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useApi } from '../api/useApi';
+import { useActiveProject } from '../hooks/useActiveProject';
+import { ReviewSummary } from './wizard/ReviewSummary';
+import { useWizard } from './wizard/CreateWizard';
+import type { ValidationIssue } from './wizard/CreateWizard';
+
+const useStyles = makeStyles({
+  drawer: { width: '480px' },
+  hint: { color: tokens.colorNeutralForeground3, fontSize: tokens.fontSizeBase200 },
+  body: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalL,
+  },
+  footer: { justifyContent: 'space-between' },
+});
+
+// RDS-style instance classes supported by the dbaas controller.
+const INSTANCE_CLASSES = [
+  'db.t3.micro',
+  'db.t3.small',
+  'db.t3.medium',
+  'db.t3.large',
+  'db.t3.xlarge',
+  'db.t3.2xlarge',
+  'db.m5.large',
+  'db.m5.xlarge',
+  'db.m5.2xlarge',
+  'db.r5.large',
+  'db.r5.xlarge',
+  'db.r5.2xlarge',
+];
+
+export interface DatabaseCreated {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (db: DatabaseCreated) => void;
+}
+
+const STEP_BASICS = 'basics';
+
+export default function DatabaseCreateDrawer({ open, onClose, onCreated }: Props) {
+  const styles = useStyles();
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const toasterId = useId('toaster');
+  const { dispatchToast } = useToastController(toasterId);
+  const { tenantId } = useParams<{ tenantId: string }>();
+  const { projectId } = useActiveProject();
+
+  const wizardResetRef = useRef<() => void>(() => undefined);
+
+  // ── Form state ─────────────────────────────────────────────────────────────
+
+  const [name, setName] = useState('');
+  const [instanceClass, setInstanceClass] = useState('db.t3.medium');
+  const [storageGb, setStorageGb] = useState(50);
+
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  const nameValid = /^[a-z0-9][a-z0-9-]{0,30}[a-z0-9]$/.test(name);
+  const storageValid = storageGb >= 1;
+
+  const validationIssues: ValidationIssue[] = [];
+  if (!nameValid)
+    validationIssues.push({ message: 'Database name is missing or invalid', targetStep: STEP_BASICS });
+  if (!storageValid)
+    validationIssues.push({ message: 'Storage must be at least 1 GB', targetStep: STEP_BASICS });
+
+  // ── Reset ──────────────────────────────────────────────────────────────────
+
+  const resetFormState = () => {
+    setName('');
+    setInstanceClass('db.t3.medium');
+    setStorageGb(50);
+  };
+
+  // ── Mutation ───────────────────────────────────────────────────────────────
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST(
+        '/v1/tenants/{tenant_id}/projects/{project_id}/databases',
+        {
+          params: { path: { tenant_id: tenantId!, project_id: projectId! } },
+          body: {
+            name,
+            engine: 'postgres',
+            instance_class: instanceClass,
+            allocated_storage_gb: storageGb,
+          },
+        },
+      );
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      return data!;
+    },
+    onSuccess: (db) => {
+      queryClient.invalidateQueries({ queryKey: ['databases', tenantId, projectId] });
+      onCreated({ id: db.id, name: db.name });
+      resetFormState();
+      wizardResetRef.current();
+      onClose();
+    },
+    onError: (e: Error) => {
+      dispatchToast(
+        <Toast><ToastTitle>Create failed: {e.message}</ToastTitle></Toast>,
+        { intent: 'error' },
+      );
+    },
+  });
+
+  // ── Review summary ─────────────────────────────────────────────────────────
+
+  const reviewSummaryContent = (
+    <>
+      <ReviewSummary
+        rows={[
+          { key: 'Name', value: name || '—' },
+          { key: 'Engine', value: 'PostgreSQL' },
+          { key: 'Instance class', value: instanceClass },
+          { key: 'Storage', value: `${storageGb} GB` },
+        ]}
+      />
+      <MessageBar intent="info">
+        <MessageBarBody>
+          After the database becomes <strong>Active</strong>, retrieve its master credentials
+          from the database detail page. The credentials are shown <em>once</em> — save them
+          immediately.
+        </MessageBarBody>
+      </MessageBar>
+    </>
+  );
+
+  // ── Wizard ─────────────────────────────────────────────────────────────────
+
+  const wizard = useWizard({
+    steps: [
+      {
+        id: STEP_BASICS,
+        title: 'Basics',
+        content: (
+          <>
+            <Body1 className={styles.hint}>
+              Creates a managed PostgreSQL database on a dedicated VM. Provisioning takes
+              2–5 minutes; the page refreshes automatically while the database is starting up.
+            </Body1>
+
+            <Field
+              label="Name"
+              required
+              hint="Lowercase + hyphens, 2–32 chars. Unique within the project."
+              validationState={name && !nameValid ? 'error' : 'none'}
+              validationMessage={
+                name && !nameValid ? 'Must match [a-z0-9][a-z0-9-]*[a-z0-9].' : undefined
+              }
+            >
+              <Input
+                value={name}
+                onChange={(_, d) => setName(d.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                placeholder="e.g. orders-db"
+                autoFocus
+              />
+            </Field>
+
+            <Field label="Instance class" required hint="Controls CPU and memory allocated to the database VM.">
+              <Dropdown
+                value={instanceClass}
+                selectedOptions={[instanceClass]}
+                onOptionSelect={(_, d) => setInstanceClass(d.optionValue ?? 'db.t3.medium')}
+              >
+                {INSTANCE_CLASSES.map((cls) => (
+                  <Option key={cls} value={cls}>{cls}</Option>
+                ))}
+              </Dropdown>
+            </Field>
+
+            <Field
+              label="Storage (GB)"
+              required
+              hint="Data volume size. Cannot be reduced after creation."
+              validationState={!storageValid ? 'error' : 'none'}
+              validationMessage={!storageValid ? 'Must be at least 1 GB.' : undefined}
+            >
+              <SpinButton
+                value={storageGb}
+                onChange={(_, d) => {
+                  if (typeof d.value === 'number') setStorageGb(d.value);
+                  else if (d.displayValue) {
+                    const n = parseInt(d.displayValue, 10);
+                    if (!Number.isNaN(n)) setStorageGb(n);
+                  }
+                }}
+                min={1}
+                max={16000}
+              />
+            </Field>
+          </>
+        ),
+      },
+    ],
+    issues: validationIssues,
+    reviewSummary: reviewSummaryContent,
+    onSubmit: () => createMutation.mutate(),
+    onCancel: () => onCloseInternal(),
+    submitLabel: 'Create database',
+    submitting: createMutation.isPending,
+    submitError: createMutation.isError ? (createMutation.error as Error).message : null,
+  });
+
+  useEffect(() => {
+    wizardResetRef.current = wizard.reset;
+  });
+
+  const onCloseInternal = () => {
+    if (createMutation.isPending) return;
+    resetFormState();
+    wizard.reset();
+    onClose();
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <OverlayDrawer
+      open={open}
+      onOpenChange={(_, d) => !d.open && onCloseInternal()}
+      position="end"
+      className={styles.drawer}
+    >
+      <Toaster toasterId={toasterId} />
+
+      <DrawerHeader>
+        <DrawerHeaderTitle
+          action={
+            <Button
+              appearance="subtle"
+              icon={<Dismiss24Regular />}
+              onClick={onCloseInternal}
+              aria-label="Close"
+            />
+          }
+        >
+          Create database
+        </DrawerHeaderTitle>
+        <wizard.TabList />
+      </DrawerHeader>
+
+      <DrawerBody className={styles.body}>
+        <wizard.StepContent />
+      </DrawerBody>
+
+      <DrawerFooter className={styles.footer}>
+        <wizard.Footer />
+      </DrawerFooter>
+    </OverlayDrawer>
+  );
+}

--- a/cloud-ui/src/layout/SideNav.tsx
+++ b/cloud-ui/src/layout/SideNav.tsx
@@ -3,6 +3,7 @@ import {
   Apps20Regular,
   Box20Regular,
   CloudCube20Regular,
+  Database20Regular,
   Globe20Regular,
   History20Regular,
   Image20Regular,
@@ -103,6 +104,12 @@ const projectGroups: { label: string; items: NavItem[] }[] = [
     items: [
       { label: 'Key vaults', to: 'keyvaults', icon: <LockClosed20Regular /> },
       { label: 'Service accounts', to: 'service-accounts', icon: <Box20Regular /> },
+    ],
+  },
+  {
+    label: 'Managed services',
+    items: [
+      { label: 'Databases', to: 'databases', icon: <Database20Regular /> },
     ],
   },
 ];

--- a/cloud-ui/src/pages/DatabaseDetailPage.tsx
+++ b/cloud-ui/src/pages/DatabaseDetailPage.tsx
@@ -1,0 +1,404 @@
+import {
+  Body1,
+  Button,
+  Card,
+  MessageBar,
+  MessageBarBody,
+  MessageBarTitle,
+  Spinner,
+  Subtitle1,
+  Title2,
+  Toast,
+  ToastTitle,
+  Toaster,
+  makeStyles,
+  shorthands,
+  tokens,
+  useId,
+  useToastController,
+} from '@fluentui/react-components';
+import {
+  ArrowLeft20Regular,
+  Delete20Regular,
+  Key20Regular,
+} from '@fluentui/react-icons';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useApi } from '../api/useApi';
+import { useActiveProject } from '../hooks/useActiveProject';
+import { useConfirmDialog } from '../components/useConfirmDialog';
+import SecretRevealBanner, { type Secret } from '../components/SecretRevealBanner';
+import StatusPill from '../components/StatusPill';
+import { fmtDate } from '../lib/date';
+
+interface Database {
+  id: string;
+  name: string;
+  engine: string;
+  engine_version?: string;
+  instance_class: string;
+  allocated_storage_gb: number;
+  network_mode: string;
+  status: string;
+  message?: string;
+  endpoint_address?: string;
+  endpoint_port?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface DatabaseCredentials {
+  username: string;
+  password: string;
+  ca_cert?: string;
+}
+
+const useStyles = makeStyles({
+  root: {
+    padding: tokens.spacingHorizontalXXL,
+    maxWidth: '900px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalL,
+  },
+  header: { display: 'flex', flexDirection: 'column', gap: tokens.spacingVerticalS },
+  backButton: { alignSelf: 'flex-start' },
+  cmdBar: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalS,
+    paddingTop: tokens.spacingVerticalS,
+    paddingBottom: tokens.spacingVerticalS,
+    ...shorthands.borderTop('1px', 'solid', tokens.colorNeutralStroke2),
+    ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStroke2),
+  },
+  card: { padding: tokens.spacingHorizontalXXL },
+  cardHeader: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalS,
+    paddingBottom: tokens.spacingVerticalM,
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: '180px 1fr',
+    rowGap: tokens.spacingVerticalM,
+    columnGap: tokens.spacingHorizontalL,
+  },
+  label: { color: tokens.colorNeutralForeground3, fontSize: tokens.fontSizeBase200 },
+  value: { fontSize: tokens.fontSizeBase300 },
+  mono: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    wordBreak: 'break-all',
+  },
+  loading: {
+    padding: tokens.spacingHorizontalXXL,
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  credsAction: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalM,
+    alignItems: 'center',
+  },
+});
+
+export default function DatabaseDetailPage() {
+  const styles = useStyles();
+  const api = useApi();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const toasterId = useId('toaster');
+  const { dispatchToast } = useToastController(toasterId);
+  const { tenantId, dbId } = useParams<{ tenantId: string; dbId: string }>();
+  const { projectId } = useActiveProject();
+  const confirmDialog = useConfirmDialog();
+
+  const [revealedSecrets, setRevealedSecrets] = useState<Secret[] | null>(null);
+  // Tracks whether credentials were already retrieved (410 Gone response).
+  const [credsAlreadyTaken, setCredsAlreadyTaken] = useState(false);
+
+  const dbQuery = useQuery({
+    queryKey: ['database', tenantId, projectId, dbId],
+    enabled: Boolean(tenantId) && Boolean(projectId) && Boolean(dbId),
+    queryFn: async () => {
+      const { data, error } = await api.GET(
+        '/v1/tenants/{tenant_id}/projects/{project_id}/databases/{id}',
+        { params: { path: { tenant_id: tenantId!, project_id: projectId!, id: dbId! } } },
+      );
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      return data as Database;
+    },
+    refetchInterval: (q) => {
+      const d = q.state.data as Database | undefined;
+      return d && (d.status === 'PENDING' || d.status === 'DELETING') ? 5_000 : false;
+    },
+  });
+
+  const credsMutation = useMutation({
+    mutationFn: async () => {
+      const { data, error, response } = await api.GET(
+        '/v1/tenants/{tenant_id}/projects/{project_id}/databases/{id}/credentials',
+        { params: { path: { tenant_id: tenantId!, project_id: projectId!, id: dbId! } } },
+      );
+      if (error) {
+        if (response?.status === 410) {
+          setCredsAlreadyTaken(true);
+          throw new Error(
+            'Credentials were already retrieved for this database and cannot be shown again.',
+          );
+        }
+        if (response?.status === 409) {
+          throw new Error('Database is not ready yet. Wait until status is Active.');
+        }
+        throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      }
+      return data as DatabaseCredentials;
+    },
+    onSuccess: (c) => {
+      const secrets: Secret[] = [
+        {
+          label: 'Username',
+          value: c.username,
+          filename: `${dbQuery.data?.name ?? 'database'}-username.txt`,
+        },
+        {
+          label: 'Password (sensitive)',
+          value: c.password,
+          filename: `${dbQuery.data?.name ?? 'database'}-password.txt`,
+        },
+      ];
+      if (c.ca_cert) {
+        secrets.push({
+          label: 'CA Certificate',
+          value: c.ca_cert,
+          filename: `${dbQuery.data?.name ?? 'database'}-ca.pem`,
+          multiline: true,
+        });
+      }
+      setRevealedSecrets(secrets);
+    },
+    onError: (e: Error) => {
+      dispatchToast(
+        <Toast><ToastTitle>{e.message}</ToastTitle></Toast>,
+        { intent: 'warning' },
+      );
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const { error } = await api.DELETE(
+        '/v1/tenants/{tenant_id}/projects/{project_id}/databases/{id}',
+        { params: { path: { tenant_id: tenantId!, project_id: projectId!, id: dbId! } } },
+      );
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+    },
+    onSuccess: () => {
+      dispatchToast(
+        <Toast><ToastTitle>Delete requested — database transitioning to DELETING</ToastTitle></Toast>,
+        { intent: 'success' },
+      );
+      queryClient.invalidateQueries({ queryKey: ['databases', tenantId, projectId] });
+      navigate(`/tenants/${tenantId}/projects/${projectId}/databases`);
+    },
+    onError: (e: Error) => {
+      dispatchToast(
+        <Toast><ToastTitle>Delete failed: {e.message}</ToastTitle></Toast>,
+        { intent: 'error' },
+      );
+    },
+  });
+
+  const onDelete = async () => {
+    const ok = await confirmDialog({
+      title: `Delete database "${dbQuery.data?.name}"?`,
+      body: 'The VM, data volumes, and credentials will be permanently destroyed. This cannot be undone.',
+      confirmLabel: 'Delete',
+      destructive: true,
+      typeToConfirm: dbQuery.data?.name,
+    });
+    if (!ok) return;
+    deleteMutation.mutate();
+  };
+
+  if (dbQuery.isLoading) {
+    return (
+      <div className={styles.root}>
+        <Toaster toasterId={toasterId} />
+        <div className={styles.loading}>
+          <Spinner label="Loading database…" />
+        </div>
+      </div>
+    );
+  }
+
+  if (dbQuery.isError || !dbQuery.data) {
+    return (
+      <div className={styles.root}>
+        <Toaster toasterId={toasterId} />
+        <Button
+          appearance="subtle"
+          icon={<ArrowLeft20Regular />}
+          onClick={() => navigate(`/tenants/${tenantId}/projects/${projectId}/databases`)}
+          className={styles.backButton}
+        >
+          Back to databases
+        </Button>
+        <MessageBar intent="error">
+          <MessageBarBody>
+            <MessageBarTitle>Failed to load database</MessageBarTitle>
+            {dbQuery.error instanceof Error ? dbQuery.error.message : 'Not found.'}
+          </MessageBarBody>
+        </MessageBar>
+      </div>
+    );
+  }
+
+  const db = dbQuery.data;
+  const isDeleting = db.status === 'DELETING' || deleteMutation.isPending;
+  const isActive = db.status === 'ACTIVE';
+
+  return (
+    <div className={styles.root}>
+      <Toaster toasterId={toasterId} />
+
+      <Button
+        appearance="subtle"
+        icon={<ArrowLeft20Regular />}
+        onClick={() => navigate(`/tenants/${tenantId}/projects/${projectId}/databases`)}
+        className={styles.backButton}
+      >
+        Back to databases
+      </Button>
+
+      <div className={styles.header}>
+        <Title2>{db.name}</Title2>
+        <Subtitle1 style={{ color: tokens.colorNeutralForeground3 }}>
+          <StatusPill status={db.status} />
+          {db.message && (
+            <span style={{ marginLeft: tokens.spacingHorizontalM }}>{db.message}</span>
+          )}
+        </Subtitle1>
+      </div>
+
+      <div className={styles.cmdBar}>
+        <Button
+          appearance="subtle"
+          icon={<Delete20Regular />}
+          onClick={onDelete}
+          disabled={isDeleting}
+        >
+          Delete
+        </Button>
+      </div>
+
+      {db.status === 'PENDING' && (
+        <MessageBar intent="info">
+          <MessageBarBody>
+            <MessageBarTitle>Provisioning</MessageBarTitle>
+            The dbaas controller is creating the PostgreSQL VM. This typically takes 2–5 minutes.
+            This page refreshes every 5 seconds.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {db.status === 'FAILED' && (
+        <MessageBar intent="error">
+          <MessageBarBody>
+            <MessageBarTitle>Provisioning failed</MessageBarTitle>
+            {db.message ?? 'The dbaas controller reported an error.'} Delete and recreate.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      <Card className={styles.card}>
+        <div className={styles.cardHeader}>
+          <Subtitle1>Details</Subtitle1>
+        </div>
+        <div className={styles.grid}>
+          <div className={styles.label}>Database ID</div>
+          <div className={`${styles.value} ${styles.mono}`}>{db.id}</div>
+          <div className={styles.label}>Tenant / Project</div>
+          <div className={styles.value}>{tenantId} / {projectId}</div>
+          <div className={styles.label}>Engine</div>
+          <div className={styles.value}>
+            {db.engine}{db.engine_version ? ` ${db.engine_version}` : ''}
+          </div>
+          <div className={styles.label}>Instance class</div>
+          <div className={styles.value}>{db.instance_class}</div>
+          <div className={styles.label}>Storage</div>
+          <div className={styles.value}>{db.allocated_storage_gb} GB</div>
+          <div className={styles.label}>Network mode</div>
+          <div className={styles.value}>{db.network_mode}</div>
+          <div className={styles.label}>Endpoint</div>
+          <div className={`${styles.value} ${styles.mono}`}>
+            {db.endpoint_address && db.endpoint_port
+              ? `${db.endpoint_address}:${db.endpoint_port}`
+              : '—'}
+          </div>
+          <div className={styles.label}>Created</div>
+          <div className={styles.value}>{fmtDate(db.created_at)}</div>
+          <div className={styles.label}>Updated</div>
+          <div className={styles.value}>{fmtDate(db.updated_at)}</div>
+        </div>
+      </Card>
+
+      <Card className={styles.card}>
+        <div className={styles.cardHeader}>
+          <Subtitle1>Master credentials</Subtitle1>
+          <Body1 style={{ color: tokens.colorNeutralForeground3 }}>
+            Username and password for the database master user.{' '}
+            <strong style={{ color: tokens.colorPaletteDarkOrangeForeground1, fontWeight: tokens.fontWeightBold }}>
+              Shown once
+            </strong>{' '}
+            — they are not stored after retrieval. Use them to seed your application's secret store.
+          </Body1>
+        </div>
+
+        {revealedSecrets && (
+          <div style={{ marginBottom: tokens.spacingVerticalL }}>
+            <SecretRevealBanner
+              title={`Credentials for ${db.name}`}
+              description="Save these values now — they will not be shown again."
+              secrets={revealedSecrets}
+              onDismiss={() => setRevealedSecrets(null)}
+              onCopy={(label) =>
+                dispatchToast(
+                  <Toast><ToastTitle>Copied {label}</ToastTitle></Toast>,
+                  { intent: 'success' },
+                )
+              }
+            />
+          </div>
+        )}
+
+        {credsAlreadyTaken && !revealedSecrets && (
+          <MessageBar intent="warning" style={{ marginBottom: tokens.spacingVerticalM }}>
+            <MessageBarBody>
+              Credentials were already retrieved for this database and cannot be shown again.
+              Delete and recreate the database if you need fresh credentials.
+            </MessageBarBody>
+          </MessageBar>
+        )}
+
+        <div className={styles.credsAction}>
+          <Button
+            appearance="primary"
+            icon={<Key20Regular />}
+            onClick={() => credsMutation.mutate()}
+            disabled={!isActive || credsMutation.isPending || credsAlreadyTaken}
+          >
+            {credsMutation.isPending ? 'Retrieving…' : 'Retrieve credentials'}
+          </Button>
+          {!isActive && !credsAlreadyTaken && (
+            <Body1 style={{ color: tokens.colorNeutralForeground3 }}>
+              Available once the database is Active.
+            </Body1>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/cloud-ui/src/pages/DatabasesListPage.tsx
+++ b/cloud-ui/src/pages/DatabasesListPage.tsx
@@ -1,0 +1,274 @@
+import {
+  Button,
+  Card,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Subtitle1,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Title2,
+  Toast,
+  ToastTitle,
+  Toaster,
+  makeStyles,
+  tokens,
+  useId,
+  useToastController,
+} from '@fluentui/react-components';
+import {
+  Add20Regular,
+  ArrowClockwise20Regular,
+  Database24Regular,
+  MoreHorizontal20Regular,
+} from '@fluentui/react-icons';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useApi } from '../api/useApi';
+import { useActiveProject } from '../hooks/useActiveProject';
+import { useConfirmDialog } from '../components/useConfirmDialog';
+import DatabaseCreateDrawer, { type DatabaseCreated } from '../components/DatabaseCreateDrawer';
+import StatusPill from '../components/StatusPill';
+import { EmptyState, ErrorState, LoadingState } from '../components/list/PageStates';
+import { useListPageStyles } from '../components/list/useListPageStyles';
+import { fmtDate } from '../lib/date';
+
+interface Database {
+  id: string;
+  name: string;
+  engine: string;
+  engine_version?: string;
+  instance_class: string;
+  allocated_storage_gb: number;
+  network_mode: string;
+  status: string;
+  endpoint_address?: string;
+  endpoint_port?: number;
+  created_at: string;
+}
+
+const usePageStyles = makeStyles({
+  nameLink: {
+    color: tokens.colorBrandForeground1,
+    textDecoration: 'none',
+    fontWeight: 600,
+    '&:hover': { textDecoration: 'underline' },
+  },
+});
+
+export default function DatabasesListPage() {
+  const styles = useListPageStyles();
+  const pageStyles = usePageStyles();
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const toasterId = useId('toaster');
+  const { dispatchToast } = useToastController(toasterId);
+  const { tenantId } = useParams<{ tenantId: string }>();
+  const { projectId } = useActiveProject();
+  const navigate = useNavigate();
+  const confirmDialog = useConfirmDialog();
+
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const dbsQuery = useQuery({
+    queryKey: ['databases', tenantId, projectId],
+    enabled: Boolean(tenantId) && Boolean(projectId),
+    queryFn: async () => {
+      const { data, error } = await api.GET(
+        '/v1/tenants/{tenant_id}/projects/{project_id}/databases',
+        { params: { path: { tenant_id: tenantId!, project_id: projectId! } } },
+      );
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      return (data ?? []) as Database[];
+    },
+    // Poll while any database is provisioning or being torn down.
+    refetchInterval: (query) => {
+      const data = query.state.data as Database[] | undefined;
+      return data?.some((db) => db.status === 'PENDING' || db.status === 'DELETING')
+        ? 5000
+        : false;
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await api.DELETE(
+        '/v1/tenants/{tenant_id}/projects/{project_id}/databases/{id}',
+        { params: { path: { tenant_id: tenantId!, project_id: projectId!, id } } },
+      );
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+    },
+    onSuccess: () => {
+      dispatchToast(
+        <Toast><ToastTitle>Database deletion started</ToastTitle></Toast>,
+        { intent: 'success' },
+      );
+      queryClient.invalidateQueries({ queryKey: ['databases', tenantId, projectId] });
+    },
+    onError: (e: Error) => {
+      dispatchToast(
+        <Toast><ToastTitle>Delete failed: {e.message}</ToastTitle></Toast>,
+        { intent: 'error' },
+      );
+    },
+  });
+
+  const onDelete = async (db: Database) => {
+    const ok = await confirmDialog({
+      title: `Delete database "${db.name}"?`,
+      body: 'The VM, data volumes, and credentials will be permanently destroyed. This cannot be undone.',
+      confirmLabel: 'Delete',
+      destructive: true,
+      typeToConfirm: db.name,
+    });
+    if (!ok) return;
+    deleteMutation.mutate(db.id);
+  };
+
+  const onCreated = (db: DatabaseCreated) => {
+    dispatchToast(
+      <Toast>
+        <ToastTitle>Database "{db.name}" created — provisioning in background…</ToastTitle>
+      </Toast>,
+      { intent: 'success' },
+    );
+    navigate(`${db.id}`);
+  };
+
+  const dbs = dbsQuery.data ?? [];
+  const count = dbs.length;
+
+  return (
+    <div className={styles.root}>
+      <Toaster toasterId={toasterId} />
+
+      <div className={styles.header}>
+        <Title2>Databases</Title2>
+        <Subtitle1 className={styles.subtitle}>
+          Managed PostgreSQL databases. Each database runs as a dedicated VM provisioned by the dbaas controller.
+        </Subtitle1>
+      </div>
+
+      <div className={styles.cmdBar}>
+        <Button
+          appearance="primary"
+          icon={<Add20Regular />}
+          onClick={() => setCreateOpen(true)}
+        >
+          Create database
+        </Button>
+        <Button
+          appearance="subtle"
+          icon={<ArrowClockwise20Regular />}
+          onClick={() => dbsQuery.refetch()}
+          disabled={dbsQuery.isFetching}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {dbsQuery.isLoading && <LoadingState label="Loading databases…" />}
+
+      {dbsQuery.isError && !dbsQuery.isLoading && (
+        <ErrorState
+          message={`Failed to load databases: ${(dbsQuery.error as Error).message}`}
+        />
+      )}
+
+      {!dbsQuery.isLoading && !dbsQuery.isError && count === 0 && (
+        <EmptyState
+          icon={<Database24Regular />}
+          title="No databases in this project yet"
+          description="A managed database gives your workloads a dedicated PostgreSQL instance. Credentials are provisioned by the controller and shown once on first retrieval."
+          action={
+            <Button
+              appearance="primary"
+              icon={<Add20Regular />}
+              onClick={() => setCreateOpen(true)}
+            >
+              Create database
+            </Button>
+          }
+        />
+      )}
+
+      {!dbsQuery.isLoading && !dbsQuery.isError && count > 0 && (
+        <Card className={styles.tableCard}>
+          <Table size="small" aria-label="Databases">
+            <TableHeader>
+              <TableRow>
+                <TableHeaderCell>Name</TableHeaderCell>
+                <TableHeaderCell>Status</TableHeaderCell>
+                <TableHeaderCell>Engine</TableHeaderCell>
+                <TableHeaderCell>Instance class</TableHeaderCell>
+                <TableHeaderCell>Storage</TableHeaderCell>
+                <TableHeaderCell>Endpoint</TableHeaderCell>
+                <TableHeaderCell>Created</TableHeaderCell>
+                <TableHeaderCell style={{ width: 40 }}></TableHeaderCell>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {dbs.map((db) => (
+                <TableRow key={db.id}>
+                  <TableCell>
+                    <Link to={`${db.id}`} className={pageStyles.nameLink}>
+                      {db.name}
+                    </Link>
+                    <div className={styles.tableMutedCell}>{db.id}</div>
+                  </TableCell>
+                  <TableCell><StatusPill status={db.status} /></TableCell>
+                  <TableCell className={styles.tableMutedCell}>
+                    {db.engine}{db.engine_version ? ` ${db.engine_version}` : ''}
+                  </TableCell>
+                  <TableCell className={styles.tableMutedCell}>{db.instance_class}</TableCell>
+                  <TableCell className={styles.tableMutedCell}>{db.allocated_storage_gb} GB</TableCell>
+                  <TableCell className={styles.tableMutedCell}>
+                    {db.endpoint_address && db.endpoint_port
+                      ? `${db.endpoint_address}:${db.endpoint_port}`
+                      : '—'}
+                  </TableCell>
+                  <TableCell className={styles.tableMutedCell}>{fmtDate(db.created_at)}</TableCell>
+                  <TableCell>
+                    <Menu>
+                      <MenuTrigger disableButtonEnhancement>
+                        <Button
+                          appearance="subtle"
+                          icon={<MoreHorizontal20Regular />}
+                          aria-label="Actions"
+                        />
+                      </MenuTrigger>
+                      <MenuPopover>
+                        <MenuList>
+                          <MenuItem onClick={() => navigate(`${db.id}`)}>Open</MenuItem>
+                          <MenuItem
+                            onClick={() => onDelete(db)}
+                            disabled={deleteMutation.isPending || db.status === 'DELETING'}
+                          >
+                            Delete
+                          </MenuItem>
+                        </MenuList>
+                      </MenuPopover>
+                    </Menu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
+      )}
+
+      <DatabaseCreateDrawer
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={onCreated}
+      />
+    </div>
+  );
+}

--- a/cloud-ui/src/router.tsx
+++ b/cloud-ui/src/router.tsx
@@ -14,6 +14,8 @@ import ClustersListPage from './pages/ClustersListPage';
 import ImagesPage from './pages/ImagesPage';
 import KeyVaultDetailPage from './pages/KeyVaultDetailPage';
 import KeyVaultsListPage from './pages/KeyVaultsListPage';
+import DatabaseDetailPage from './pages/DatabaseDetailPage';
+import DatabasesListPage from './pages/DatabasesListPage';
 import MembersPage from './pages/MembersPage';
 import ServiceAccountsPage from './pages/ServiceAccountsPage';
 import NSGDetailPage from './pages/NSGDetailPage';
@@ -65,6 +67,8 @@ export function buildRouter({ isDark, onToggleDark }: BuildRouterArgs) {
     { path: 'service-accounts', element: <ServiceAccountsPage /> },
     { path: 'keyvaults', element: <KeyVaultsListPage /> },
     { path: 'keyvaults/:kvId', element: <KeyVaultDetailPage /> },
+    { path: 'databases', element: <DatabasesListPage /> },
+    { path: 'databases/:dbId', element: <DatabaseDetailPage /> },
   ];
 
   const routes: RouteObject[] = [

--- a/dc-api/cmd/dc-api/main.go
+++ b/dc-api/cmd/dc-api/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/providers/common"
+	"github.com/wso2/dc-api/internal/providers/dbaas"
 	"github.com/wso2/dc-api/internal/providers/endpoints"
 	"github.com/wso2/dc-api/internal/providers/harvester"
 	"github.com/wso2/dc-api/internal/providers/kubeovn"
@@ -326,6 +327,7 @@ func main() {
 	var nsProvisioner providers.ProjectNamespaceProvisioner
 	var tenantNSProvisioner providers.TenantNamespaceProvisioner
 	var kviProvisioner providers.KVIProvisioner
+	var dbaasProvisioner providers.DatabaseProvisioner
 	if kvClient, ok := networkProvider.(*kubeovn.Client); ok {
 		endpointProvisioner = endpoints.NewKubeOVNProvisioner(kvClient.Dynamic(), endpoints.KubeOVNProvisionerOptions{
 			DNSForwarders: cfg.ParseDNSForwarders(),
@@ -336,6 +338,10 @@ func main() {
 		// REST config — same K8s API server, no point in two connection pools.
 		// The REST config is needed for the OpenBao pod-proxy path (secret CRUD).
 		kviProvisioner = kvi.NewClient(kvClient.Dynamic(), kvClient.RESTConfig())
+		// Task 1 — DBaaS adapter. Only needs the dynamic client; doesn't
+		// talk to the dbaas REST gateway, only the DBInstance CRD. Pre-req:
+		// dbaas controller + CRD installed on the same K8s API server.
+		dbaasProvisioner = dbaas.NewClient(kvClient.Dynamic())
 	}
 
 	// ── Router ────────────────────────────────────────────────────────────────
@@ -351,6 +357,8 @@ func main() {
 		NSProvisioner:       nsProvisioner,
 		TenantNSProvisioner: tenantNSProvisioner,
 		KVIProvisioner:      kviProvisioner,
+		DatabaseProvisioner: dbaasProvisioner,
+		DBaaSOSImage:        cfg.DBaaSOSImage,
 		BastionImage:        cfg.BastionImage,
 		BastionMgmtNAD:      cfg.BastionMgmtNAD,
 		InfraReservedNADs:   reservedNADs,

--- a/dc-api/internal/api/handlers/database.go
+++ b/dc-api/internal/api/handlers/database.go
@@ -1,0 +1,791 @@
+// Package handlers — database.go
+//
+// Task 1 v1: Database (DBaaS) HTTP handler. Mirrors the KVI managed-service
+// pattern (handlers/keyvault.go) — bespoke handler today, will collapse into
+// a managedservice.Register() call when the generic framework lands.
+//
+// Two operating modes:
+//
+//  1. Provisioner wired (production):
+//       POST   resolves the Multus NAD identity (VPC mode → subnet
+//              lookup; legacy mode → pass-through; omitted → project
+//              default), inserts a PENDING row, then creates a DBInstance
+//              CR. The dbaas controller provisions asynchronously; status
+//              flips to ACTIVE when status.phase=Ready.
+//       GET    overlays the live CR status onto the DB row so the caller
+//              sees fresh phase/endpoint/message without waiting for a
+//              reconciler tick.
+//       DELETE deletes the DBInstance CR (operator finalizer handles the
+//              VM/DataVolume/Secret cleanup async) and drops the DB row
+//              immediately.
+//
+//  2. Provisioner nil (tests / non-Kubernetes deployments):
+//       Synchronous DB-only CRUD with status=ACTIVE on create. Credentials
+//       endpoint returns 501. Integration tests that boot dc-api without
+//       a Kubernetes backend exercise this path.
+//
+// Tenant scoping is enforced via TenantFromContext (auth middleware) plus a
+// post-fetch tenant_uuid match (returns 404 on mismatch — don't leak
+// existence to non-owners). RBAC: all endpoints require role `member`.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/db"
+	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/providers"
+	"github.com/wso2/dc-api/internal/providers/common"
+)
+
+// DatabaseHandler handles /v1/tenants/{tid}/projects/{pid}/databases.
+type DatabaseHandler struct {
+	repo *db.Repository
+	// provisioner is optional. Nil falls back to DB-only synchronous CRUD
+	// (used by tests + dc-api deployments without a Kubernetes backend).
+	provisioner providers.DatabaseProvisioner
+	// osImage is the operator-configured Harvester VM image the controller
+	// boots database VMs from (DCAPI_DBAAS_OS_IMAGE). Stamped into every
+	// DBInstance CR. Empty leaves the controller's own default.
+	osImage string
+	log     zerolog.Logger
+}
+
+// NewDatabaseHandler constructs a DatabaseHandler. Pass nil for provisioner
+// to keep the DB-only fallback behaviour. osImage is the operator-configured
+// default OS image ("namespace/name"); empty defers to the controller default.
+func NewDatabaseHandler(repo *db.Repository, provisioner providers.DatabaseProvisioner, osImage string, log zerolog.Logger) *DatabaseHandler {
+	return &DatabaseHandler{repo: repo, provisioner: provisioner, osImage: osImage, log: log}
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+type createDatabaseRequest struct {
+	Name               string  `json:"name"`
+	Engine             string  `json:"engine,omitempty"`         // defaults to "postgres"
+	EngineVersion      string  `json:"engine_version,omitempty"` // informational in v1
+	InstanceClass      string  `json:"instance_class"`
+	AllocatedStorageGB int     `json:"allocated_storage_gb"`
+	Network            *netReq `json:"network,omitempty"` // omit → project default
+}
+
+// netReq is the discriminated network block on createDatabaseRequest.
+//
+//	{ "mode": "vpc",    "vnet_id": "...", "subnet_id": "..." }
+//	{ "mode": "legacy", "nad_ref": "namespace/name" }
+type netReq struct {
+	Mode     string `json:"mode"`
+	VNetID   string `json:"vnet_id,omitempty"`
+	SubnetID string `json:"subnet_id,omitempty"`
+	NadRef   string `json:"nad_ref,omitempty"`
+}
+
+type databaseResponse struct {
+	ID          string `json:"id"`
+	TenantID    string `json:"tenant_id"`
+	ProjectID   string `json:"project_id"`
+	Name        string `json:"name"`
+	Engine      string `json:"engine"`
+	EngineVersion      string `json:"engine_version,omitempty"`
+	InstanceClass      string `json:"instance_class"`
+	AllocatedStorageGB int    `json:"allocated_storage_gb"`
+
+	NetworkMode string `json:"network_mode"`
+	VNetID      string `json:"vnet_id,omitempty"`
+	SubnetID    string `json:"subnet_id,omitempty"`
+	NadRef      string `json:"nad_ref,omitempty"`
+
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+
+	EndpointAddress string `json:"endpoint_address,omitempty"`
+	EndpointPort    int    `json:"endpoint_port,omitempty"`
+
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type databaseCredentialsResponse struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	CACert   string `json:"ca_cert,omitempty"` // PEM
+}
+
+func databaseToResponse(d *models.Database) databaseResponse {
+	resp := databaseResponse{
+		ID:                 d.ID.String(),
+		TenantID:           d.TenantID,
+		ProjectID:          d.ProjectID,
+		Name:               d.Name,
+		Engine:             string(d.Engine),
+		EngineVersion:      d.EngineVersion,
+		InstanceClass:      d.InstanceClass,
+		AllocatedStorageGB: d.AllocatedStorageGB,
+		NetworkMode:        string(d.NetworkMode),
+		NadRef:             d.NadRef,
+		Status:             string(d.Status),
+		Message:            d.Message,
+		EndpointAddress:    d.EndpointAddress,
+		EndpointPort:       d.EndpointPort,
+		CreatedAt:          d.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:          d.UpdatedAt.Format(time.RFC3339),
+	}
+	if d.VNetID != nil {
+		resp.VNetID = d.VNetID.String()
+	}
+	if d.SubnetID != nil {
+		resp.SubnetID = d.SubnetID.String()
+	}
+	return resp
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+// Create handles POST /v1/tenants/{tid}/projects/{pid}/databases.
+//
+// In provisioner-wired mode: resolves NAD identity, inserts DB row in PENDING,
+// creates the DBInstance CR. Returns 201. The dbaas controller provisions
+// asynchronously.
+// In fallback mode: writes the row with status=ACTIVE synchronously.
+func (h *DatabaseHandler) Create(w http.ResponseWriter, r *http.Request) {
+	tenantID, ok := middleware.TenantFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant in context")
+		return
+	}
+	tenantUUID, ok := middleware.TenantUUIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant UUID in context")
+		return
+	}
+	if !requireTenantRole(w, r, h.repo, tenantID, models.RoleMember) {
+		return
+	}
+
+	var req createDatabaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	// ── Validate basic spec fields ─────────────────────────────────────
+	if err := validateResourceName(req.Name); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Engine == "" {
+		req.Engine = string(models.DatabaseEnginePostgres)
+	}
+	if req.Engine != string(models.DatabaseEnginePostgres) {
+		writeError(w, http.StatusBadRequest, "engine must be 'postgres' (v1)")
+		return
+	}
+	if req.InstanceClass == "" {
+		writeError(w, http.StatusBadRequest, "instance_class is required")
+		return
+	}
+	if !models.ValidDatabaseInstanceClass(req.InstanceClass) {
+		writeError(w, http.StatusBadRequest,
+			"instance_class '"+req.InstanceClass+"' is not a known size (see DatabaseInstanceClasses)")
+		return
+	}
+	if req.AllocatedStorageGB <= 0 {
+		writeError(w, http.StatusBadRequest, "allocated_storage_gb must be > 0")
+		return
+	}
+
+	projectID, projectUUID, ok := lookupProjectUUID(w, r)
+	if !ok {
+		return
+	}
+
+	// ── Resolve the network ────────────────────────────────────────────
+	networkMode, vnetID, subnetID, nadRef, networkRef, err := h.resolveNetwork(
+		r.Context(), req.Network, tenantUUID, projectUUID, tenantID, projectID,
+	)
+	if err != nil {
+		// resolveNetwork already wrote the response on auth/validation failures.
+		var herr *httpError
+		if errors.As(err, &herr) {
+			writeError(w, herr.status, herr.msg)
+			return
+		}
+		h.log.Error().Err(err).Str("tenant", tenantID).Msg("resolve database network")
+		writeError(w, http.StatusInternalServerError, "failed to resolve network")
+		return
+	}
+
+	// ── Initial status ──────────────────────────────────────────────────
+	initialStatus := models.StatusActive
+	if h.provisioner != nil {
+		initialStatus = models.StatusPending
+	}
+
+	row := &models.Database{
+		TenantID:           tenantID,
+		TenantUUID:         tenantUUID,
+		ProjectID:          projectID,
+		ProjectUUID:        projectUUID,
+		Name:               req.Name,
+		Engine:             models.DatabaseEnginePostgres,
+		EngineVersion:      req.EngineVersion,
+		InstanceClass:      req.InstanceClass,
+		AllocatedStorageGB: req.AllocatedStorageGB,
+		NetworkMode:        networkMode,
+		VNetID:             vnetID,
+		SubnetID:           subnetID,
+		NadRef:             nadRef,
+		Status:             initialStatus,
+	}
+
+	created, err := h.repo.CreateDatabase(r.Context(), row)
+	if err != nil {
+		if strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key") {
+			writeError(w, http.StatusConflict,
+				"a database named '"+req.Name+"' already exists in this project")
+			return
+		}
+		h.log.Error().Err(err).Str("tenant", tenantID).Msg("create database row")
+		writeError(w, http.StatusInternalServerError, "failed to create database")
+		return
+	}
+
+	// ── Drive the operator ─────────────────────────────────────────────
+	// Failures here don't roll back the DB row — they leave the row in
+	// PENDING with a diagnostic message the caller surfaces via GET. Same
+	// failure-mode KVI uses.
+	if h.provisioner != nil {
+		if err := h.driveProvisioner(r.Context(), created, networkRef); err != nil {
+			h.log.Warn().Err(err).
+				Str("tenant", tenantID).
+				Str("database_id", created.ID.String()).
+				Msg("DBInstance provisioning failed; row left in PENDING with error message")
+			created.Message = "provisioning failed: " + err.Error()
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, databaseToResponse(created))
+}
+
+// driveProvisioner builds the StandardLabels + CR-name and asks the adapter
+// to create the DBInstance CR.
+func (h *DatabaseHandler) driveProvisioner(
+	ctx context.Context,
+	d *models.Database,
+	networkRef providers.DatabaseNetworkRef,
+) error {
+	labels := common.StandardLabels(
+		d.TenantID, d.ProjectID, d.TenantUUID, d.ProjectUUID, d.ID,
+		"database", d.Name,
+	)
+	crName := common.NamespaceScopedName("db", d.ID)
+	ns := common.NamespaceForProject(d.TenantID, d.ProjectID)
+
+	return h.provisioner.CreateDatabaseInstance(ctx, providers.DatabaseInstanceCreateRequest{
+		Name:               crName,
+		Namespace:          ns,
+		Labels:             labels,
+		InstanceClass:      d.InstanceClass,
+		AllocatedStorageGB: d.AllocatedStorageGB,
+		EngineVersion:      d.EngineVersion,
+		OSImage:            h.osImage,
+		NetworkRef:         networkRef,
+	})
+}
+
+// Get handles GET /v1/.../databases/{id}.
+//
+// In provisioner-wired mode: overlays the live CR status onto the DB row
+// before returning.
+func (h *DatabaseHandler) Get(w http.ResponseWriter, r *http.Request) {
+	tenantID, ok := middleware.TenantFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant in context")
+		return
+	}
+	tenantUUID, ok := middleware.TenantUUIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant UUID in context")
+		return
+	}
+	if !requireTenantRole(w, r, h.repo, tenantID, models.RoleMember) {
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid database id")
+		return
+	}
+	d, err := h.repo.GetDatabase(r.Context(), id)
+	if errors.Is(err, db.ErrDatabaseNotFound) {
+		writeError(w, http.StatusNotFound, "database not found")
+		return
+	}
+	if err != nil {
+		h.log.Error().Err(err).Str("id", id.String()).Msg("get database")
+		writeError(w, http.StatusInternalServerError, "failed to fetch database")
+		return
+	}
+	if d.TenantUUID != tenantUUID {
+		// 404 not 403 — don't leak existence to non-owners.
+		writeError(w, http.StatusNotFound, "database not found")
+		return
+	}
+
+	resp := databaseToResponse(d)
+	h.overlayLiveStatus(r.Context(), d, &resp)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// List handles GET /v1/.../databases. Overlays the live CR status onto each
+// row so the list view shows the same Active/Pending/Failed phase as the
+// detail view. Costs one K8s GET per row — fine for the typical database
+// count per project (dozens at most). Move to a periodic DB-sync reconciler
+// if the count grows past that.
+func (h *DatabaseHandler) List(w http.ResponseWriter, r *http.Request) {
+	tenantID, ok := middleware.TenantFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant in context")
+		return
+	}
+	tenantUUID, ok := middleware.TenantUUIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant UUID in context")
+		return
+	}
+	if !requireTenantRole(w, r, h.repo, tenantID, models.RoleMember) {
+		return
+	}
+	_, projectUUID, ok := lookupProjectUUID(w, r)
+	if !ok {
+		return
+	}
+
+	rows, err := h.repo.ListDatabasesByProject(r.Context(), tenantUUID, projectUUID)
+	if err != nil {
+		h.log.Error().Err(err).Str("tenant", tenantID).Msg("list databases")
+		writeError(w, http.StatusInternalServerError, "failed to list databases")
+		return
+	}
+
+	out := make([]databaseResponse, 0, len(rows))
+	for _, d := range rows {
+		resp := databaseToResponse(d)
+		h.overlayLiveStatus(r.Context(), d, &resp)
+		out = append(out, resp)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Delete handles DELETE /v1/.../databases/{id}.
+//
+// In provisioner-wired mode: deletes the DBInstance CR (the controller's
+// finalizer handles VM/DataVolume/Secret teardown async) and drops the DB
+// row immediately.
+func (h *DatabaseHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	tenantID, ok := middleware.TenantFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant in context")
+		return
+	}
+	tenantUUID, ok := middleware.TenantUUIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant UUID in context")
+		return
+	}
+	if !requireTenantRole(w, r, h.repo, tenantID, models.RoleMember) {
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid database id")
+		return
+	}
+
+	// Tenant scope guard — fetch first so we don't delete another tenant's row.
+	d, err := h.repo.GetDatabase(r.Context(), id)
+	if errors.Is(err, db.ErrDatabaseNotFound) {
+		writeError(w, http.StatusNotFound, "database not found")
+		return
+	}
+	if err != nil {
+		h.log.Error().Err(err).Str("id", id.String()).Msg("get database for delete")
+		writeError(w, http.StatusInternalServerError, "failed to fetch database")
+		return
+	}
+	if d.TenantUUID != tenantUUID {
+		writeError(w, http.StatusNotFound, "database not found")
+		return
+	}
+
+	// Operator-side teardown. Idempotent on the adapter (NotFound → success).
+	if h.provisioner != nil {
+		ns := common.NamespaceForProject(d.TenantID, d.ProjectID)
+		crName := common.NamespaceScopedName("db", d.ID)
+		if err := h.provisioner.DeleteDatabaseInstance(r.Context(), ns, crName); err != nil {
+			h.log.Error().Err(err).
+				Str("database_id", d.ID.String()).
+				Msg("delete DBInstance CR")
+			writeError(w, http.StatusInternalServerError, "failed to delete database from operator")
+			return
+		}
+	}
+
+	if err := h.repo.DeleteDatabase(r.Context(), id); err != nil {
+		if errors.Is(err, db.ErrDatabaseNotFound) {
+			writeError(w, http.StatusNotFound, "database not found")
+			return
+		}
+		h.log.Error().Err(err).Str("id", id.String()).Msg("delete database row")
+		writeError(w, http.StatusInternalServerError, "failed to delete database")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Credentials handles GET /v1/.../databases/{id}/credentials.
+//
+// Shown-once semantics:
+//   - First call: returns username/password/ca_cert read from the operator's
+//     credentials Secret; stamps credentials_consumed_at = NOW() in the DB.
+//   - Subsequent calls: returns 410 Gone.
+//
+// Pre-conditions:
+//   - Provisioner must be wired (no creds without the operator). 501 otherwise.
+//   - The CR's status.phase must be Ready. 409 with a pointer to GET /{id}
+//     otherwise.
+func (h *DatabaseHandler) Credentials(w http.ResponseWriter, r *http.Request) {
+	tenantID, ok := middleware.TenantFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant in context")
+		return
+	}
+	tenantUUID, ok := middleware.TenantUUIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant UUID in context")
+		return
+	}
+	if !requireTenantRole(w, r, h.repo, tenantID, models.RoleMember) {
+		return
+	}
+	if h.provisioner == nil {
+		writeError(w, http.StatusNotImplemented,
+			"credentials endpoint requires the dbaas operator integration; not available on this dc-api deployment")
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid database id")
+		return
+	}
+	d, err := h.repo.GetDatabase(r.Context(), id)
+	if errors.Is(err, db.ErrDatabaseNotFound) {
+		writeError(w, http.StatusNotFound, "database not found")
+		return
+	}
+	if err != nil {
+		h.log.Error().Err(err).Str("id", id.String()).Msg("get database for credentials")
+		writeError(w, http.StatusInternalServerError, "failed to fetch database")
+		return
+	}
+	if d.TenantUUID != tenantUUID {
+		writeError(w, http.StatusNotFound, "database not found")
+		return
+	}
+	if d.CredentialsConsumedAt != nil {
+		writeError(w, http.StatusGone,
+			"credentials already retrieved at "+d.CredentialsConsumedAt.Format(time.RFC3339)+
+				" — they are shown only once; recreate the database or rotate via the operator if you need fresh ones")
+		return
+	}
+
+	// Read live CR status to find the credentials Secret name.
+	ns := common.NamespaceForProject(d.TenantID, d.ProjectID)
+	crName := common.NamespaceScopedName("db", d.ID)
+	st, err := h.provisioner.GetDatabaseInstance(r.Context(), ns, crName)
+	if err != nil {
+		h.log.Error().Err(err).Str("database_id", d.ID.String()).Msg("read DBInstance for credentials")
+		writeError(w, http.StatusInternalServerError, "failed to read database status")
+		return
+	}
+	if st == nil || st.Phase != "Ready" || st.SecretRefName == "" {
+		phase := "not yet provisioned"
+		if st != nil && st.Phase != "" {
+			phase = st.Phase
+		}
+		writeError(w, http.StatusConflict,
+			"database is not Ready yet (phase="+phase+
+				"); poll GET /v1/.../databases/"+d.ID.String()+" until status=ACTIVE before requesting credentials")
+		return
+	}
+
+	data, err := h.provisioner.GetDatabaseCredentialsSecret(r.Context(), ns, st.SecretRefName)
+	if err != nil {
+		h.log.Error().Err(err).
+			Str("database_id", d.ID.String()).
+			Str("secret", ns+"/"+st.SecretRefName).
+			Msg("read credentials secret")
+		writeError(w, http.StatusInternalServerError, "failed to read credentials secret")
+		return
+	}
+	if data == nil {
+		writeError(w, http.StatusConflict,
+			"credentials secret not yet written by the operator — try again shortly")
+		return
+	}
+
+	// Stamp consumed BEFORE returning. If two callers race, only one wins
+	// the UPDATE (WHERE credentials_consumed_at IS NULL); the other gets
+	// ErrCredentialsAlreadyConsumed → 410.
+	if err := h.repo.MarkDatabaseCredentialsConsumed(r.Context(), d.ID); err != nil {
+		if errors.Is(err, db.ErrCredentialsAlreadyConsumed) {
+			writeError(w, http.StatusGone,
+				"credentials already retrieved — they are shown only once; recreate the database or rotate via the operator if you need fresh ones")
+			return
+		}
+		h.log.Error().Err(err).Str("database_id", d.ID.String()).Msg("stamp credentials consumed")
+		writeError(w, http.StatusInternalServerError, "failed to record credentials consumption")
+		return
+	}
+
+	// dbaas controller writes admin_user/admin_password/ca_cert; map to the
+	// canonical username/password/ca_cert response shape.
+	writeJSON(w, http.StatusOK, databaseCredentialsResponse{
+		Username: string(data["admin_user"]),
+		Password: string(data["admin_password"]),
+		CACert:   string(data["ca_cert"]),
+	})
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// overlayLiveStatus mutates resp in place with the controller's live status.
+// No-op when the provisioner is nil. Errors are logged + swallowed so the
+// caller still gets a DB-only view rather than a 500.
+func (h *DatabaseHandler) overlayLiveStatus(ctx context.Context, d *models.Database, resp *databaseResponse) {
+	if h.provisioner == nil {
+		return
+	}
+	ns := common.NamespaceForProject(d.TenantID, d.ProjectID)
+	crName := common.NamespaceScopedName("db", d.ID)
+	st, err := h.provisioner.GetDatabaseInstance(ctx, ns, crName)
+	if err != nil {
+		h.log.Warn().Err(err).
+			Str("database_id", d.ID.String()).
+			Msg("read DBInstance CR status failed; returning DB-only view")
+		return
+	}
+	if st == nil {
+		return
+	}
+	if phase := mapDatabasePhaseToStatus(st.Phase); phase != "" {
+		resp.Status = phase
+	}
+	if st.Message != "" {
+		resp.Message = st.Message
+	}
+	if st.EndpointAddress != "" {
+		resp.EndpointAddress = st.EndpointAddress
+	}
+	if st.EndpointPort != 0 {
+		resp.EndpointPort = st.EndpointPort
+	}
+}
+
+// mapDatabasePhaseToStatus translates the framework-canonical phase enum
+// (already normalised by the adapter via mapRDSPhase) into dc-api's
+// ResourceStatus. Empty string when phase is unknown / unset (caller keeps
+// the DB-row status).
+func mapDatabasePhaseToStatus(phase string) string {
+	switch phase {
+	case "Pending", "Provisioning":
+		return string(models.StatusPending)
+	case "Ready":
+		return string(models.StatusActive)
+	case "Failed":
+		return string(models.StatusFailed)
+	case "Terminating":
+		return string(models.StatusDeleting)
+	}
+	return ""
+}
+
+// ── network resolution ────────────────────────────────────────────────────────
+
+// httpError carries an HTTP-mapped error from resolveNetwork back to Create.
+// Used instead of a plain error so the handler can preserve the status code
+// the resolver chose (400 for missing subnet, 409 for inactive subnet, ...).
+type httpError struct {
+	status int
+	msg    string
+}
+
+func (e *httpError) Error() string { return e.msg }
+
+// resolveNetwork turns the (optional) network block on the request into a
+// concrete NAD identity. Returns:
+//   - networkMode, vnetID, subnetID, nadRef → DB row values (some nil per mode)
+//   - networkRef → identity passed to the provisioner
+//
+// On user-input errors, returns an *httpError with the right HTTP status.
+func (h *DatabaseHandler) resolveNetwork(
+	ctx context.Context,
+	in *netReq,
+	tenantUUID, projectUUID uuid.UUID,
+	tenantID, projectID string,
+) (
+	mode models.DatabaseNetworkMode,
+	vnetID, subnetID *uuid.UUID,
+	nadRef string,
+	networkRef providers.DatabaseNetworkRef,
+	err error,
+) {
+	// Default path: caller omitted the network block → pick the project's
+	// first ACTIVE subnet in its first ACTIVE VPC. VPC mode.
+	if in == nil {
+		sub, derr := h.findProjectDefaultSubnet(ctx, tenantUUID, projectUUID)
+		if derr != nil {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{}, derr
+		}
+		vid := sub.VNetID
+		sid := sub.ID
+		return models.DatabaseNetworkModeVPC, &vid, &sid, "",
+			providers.DatabaseNetworkRef{
+				Namespace:   common.NamespaceForProject(tenantID, projectID),
+				Name:        sub.BackendUID,
+				DNSServerIP: h.vnetDNSServerIP(ctx, vid),
+			}, nil
+	}
+
+	switch in.Mode {
+	case "vpc":
+		if in.VNetID == "" || in.SubnetID == "" {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest, "network.mode='vpc' requires both vnet_id and subnet_id"}
+		}
+		vid, perr := uuid.Parse(in.VNetID)
+		if perr != nil {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest, "vnet_id is not a valid UUID"}
+		}
+		sid, perr := uuid.Parse(in.SubnetID)
+		if perr != nil {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest, "subnet_id is not a valid UUID"}
+		}
+
+		sub, gerr := h.repo.GetSubnet(ctx, sid)
+		if gerr != nil {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest, "subnet not found"}
+		}
+		// Scope checks: same tenant, same project, references the supplied vnet,
+		// and is ACTIVE.
+		if sub.TenantUUID != tenantUUID || sub.ProjectUUID != projectUUID {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest, "subnet not found in this project"}
+		}
+		if sub.VNetID != vid {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest, "subnet does not belong to the supplied vnet_id"}
+		}
+		if sub.Status != models.StatusActive {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusConflict,
+					"subnet is not ACTIVE (status=" + string(sub.Status) + ")"}
+		}
+		if sub.BackendUID == "" {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusConflict,
+					"subnet has not been provisioned by the network backend yet — try again shortly"}
+		}
+		return models.DatabaseNetworkModeVPC, &vid, &sid, "",
+			providers.DatabaseNetworkRef{
+				Namespace:   common.NamespaceForProject(tenantID, projectID),
+				Name:        sub.BackendUID,
+				DNSServerIP: h.vnetDNSServerIP(ctx, vid),
+			}, nil
+
+	case "legacy":
+		if in.NadRef == "" {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest, "network.mode='legacy' requires nad_ref"}
+		}
+		parts := strings.SplitN(in.NadRef, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", nil, nil, "", providers.DatabaseNetworkRef{},
+				&httpError{http.StatusBadRequest,
+					"nad_ref must be 'namespace/name' (got '" + in.NadRef + "')"}
+		}
+		return models.DatabaseNetworkModeLegacy, nil, nil, in.NadRef,
+			providers.DatabaseNetworkRef{Namespace: parts[0], Name: parts[1]}, nil
+
+	default:
+		return "", nil, nil, "", providers.DatabaseNetworkRef{},
+			&httpError{http.StatusBadRequest,
+				"network.mode must be 'vpc' or 'legacy' (got '" + in.Mode + "')"}
+	}
+}
+
+// vnetDNSServerIP returns the per-VPC CoreDNS address for a VNet (the F20
+// dns_server_ip), or "" when unset/unavailable. Best-effort: a lookup error is
+// logged and swallowed — the database is still created; if the per-VPC DNS is
+// genuinely missing the VM install would fail the same way regardless. Used to
+// populate the DBInstance's dnsServerIP so the VM resolves through a
+// VPC-reachable resolver (defeats the KubeVirt-on-OVN DHCP DNS race).
+func (h *DatabaseHandler) vnetDNSServerIP(ctx context.Context, vnetID uuid.UUID) string {
+	v, err := h.repo.GetVNetInternal(ctx, vnetID)
+	if err != nil {
+		h.log.Warn().Err(err).Str("vnet_id", vnetID.String()).
+			Msg("resolve vnet dns_server_ip failed; proceeding without VM dnsConfig")
+		return ""
+	}
+	return v.DNSServerIP
+}
+
+// findProjectDefaultSubnet returns the first ACTIVE subnet in the project's
+// first ACTIVE VPC. Returns *httpError 400 with a useful pointer when no
+// such subnet exists — the caller has to create a VPC + subnet first (or
+// explicitly pass network.mode='legacy' if their database should attach to
+// a pre-existing bridge NAD).
+func (h *DatabaseHandler) findProjectDefaultSubnet(
+	ctx context.Context,
+	tenantUUID, projectUUID uuid.UUID,
+) (*models.Subnet, error) {
+	vnets, err := h.repo.ListVNetsByProject(ctx, tenantUUID, projectUUID)
+	if err != nil {
+		return nil, fmt.Errorf("list project vnets: %w", err)
+	}
+	for _, v := range vnets {
+		if v.Status != models.StatusActive {
+			continue
+		}
+		subs, err := h.repo.ListSubnetsByVNet(ctx, v.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list subnets for vnet %s: %w", v.ID, err)
+		}
+		for _, s := range subs {
+			if s.Status == models.StatusActive && s.BackendUID != "" {
+				return s, nil
+			}
+		}
+	}
+	return nil, &httpError{http.StatusBadRequest,
+		"no default network available — this project has no ACTIVE VPC/subnet. " +
+			"Create one via POST /vnets and POST /vnets/{id}/subnets, or pass " +
+			"network.mode='legacy' with a nad_ref."}
+}

--- a/dc-api/internal/api/router.go
+++ b/dc-api/internal/api/router.go
@@ -69,6 +69,14 @@ type RouterDeps struct {
 	// KeyVaultInstance). Nil means dc-api falls back to the chunk-1+2
 	// behaviour (logical CRUD only; no backing OpenBao integration).
 	KVIProvisioner providers.KVIProvisioner
+	// DatabaseProvisioner drives the dbaas operator's DBInstance CRD
+	// (Task 1). Nil means dc-api falls back to DB-only synchronous CRUD —
+	// tests + no-K8s deployments.
+	DatabaseProvisioner providers.DatabaseProvisioner
+	// DBaaSOSImage is the operator-configured Harvester VM image
+	// ("namespace/name") database VMs boot from (DCAPI_DBAAS_OS_IMAGE).
+	// Empty defers to the controller's own default.
+	DBaaSOSImage string
 	// EndpointProvisioner is the generic Private Endpoint provisioner used by
 	// every M3 managed service (Key Vault today; Postgres / Valkey / Harbor
 	// later). Nil disables /v1/<service>/{id}/private-endpoints routes.
@@ -414,6 +422,16 @@ func NewRouter(deps RouterDeps) http.Handler {
 								r.Delete("/{ep_id}", kvEpHandler.Delete)
 							})
 						}
+					})
+
+					// ── Task 1 — DBaaS Databases ────────────────────────────
+					dbHandler := handlers.NewDatabaseHandler(deps.Repo, deps.DatabaseProvisioner, deps.DBaaSOSImage, deps.Log)
+					r.Route("/databases", func(r chi.Router) {
+						r.Post("/", dbHandler.Create)                     // POST   .../databases
+						r.Get("/", dbHandler.List)                        // GET    .../databases
+						r.Get("/{id}", dbHandler.Get)                     // GET    .../databases/{id}
+						r.Delete("/{id}", dbHandler.Delete)               // DELETE .../databases/{id}
+						r.Get("/{id}/credentials", dbHandler.Credentials) // GET    .../databases/{id}/credentials (shown-once)
 					})
 				})
 			})

--- a/dc-api/internal/config/config.go
+++ b/dc-api/internal/config/config.go
@@ -129,6 +129,13 @@ type Config struct {
 	// from workstations via VPN.
 	BastionMgmtNAD string `envconfig:"BASTION_MGMT_NAD" default:"iaas/vm-network-001"`
 
+	// ── Task 1 DBaaS ─────────────────────────────────────────────────────────
+	// DBaaSOSImage is the Harvester VirtualMachineImage (`namespace/resource-name`)
+	// the dbaas controller boots database VMs from. dc-api stamps this into every
+	// DBInstance CR's spec.osImage. Empty leaves the controller's own default,
+	// which may not match a given cluster's image catalog. Set per-environment.
+	DBaaSOSImage string `envconfig:"DBAAS_OS_IMAGE" default:"rancher-infra/ubuntu-22-04"`
+
 	// ── F21 infra-reserved NADs ─────────────────────────────────────────────
 	// Comma-separated list of `namespace/nad-name` references that tenant
 	// VMs MUST NOT attach to (the legacy `network_name` path). These are

--- a/dc-api/internal/db/database.go
+++ b/dc-api/internal/db/database.go
@@ -1,0 +1,250 @@
+// Package db — database.go
+//
+// Repository methods for Task 1 (DBaaS). All SQL touching the `databases`
+// table lives here — handlers call these methods, never pool.Query directly
+// (repository pattern; see dc-api/CLAUDE.md §"Design Patterns").
+//
+// Mirrors the shape of db/keyvault.go: one row per managed Database, scoped
+// by (tenant_uuid, project_uuid). Status updates and shown-once credential
+// consumption follow the same race-safe pattern KVI uses.
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/wso2/dc-api/internal/models"
+)
+
+// ErrDatabaseNotFound is returned by GetDatabase/DeleteDatabase when the
+// requested row does not exist (or is invisible to the caller's tenant
+// after the handler's scope check). Handlers map directly to 404.
+var ErrDatabaseNotFound = errors.New("database not found")
+
+// CreateDatabase inserts a new Database row. Caller fills in spec fields;
+// id/created_at/updated_at are populated via RETURNING. Unique constraint
+// violations (same name within a project) surface as Postgres SQLSTATE
+// 23505; handlers map that to 409 Conflict.
+func (r *Repository) CreateDatabase(ctx context.Context, d *models.Database) (*models.Database, error) {
+	const q = `
+		INSERT INTO databases (
+			tenant_id, tenant_uuid, project_id, project_uuid,
+			name, engine, engine_version, instance_class, allocated_storage_gb,
+			network_mode, vnet_id, subnet_id, nad_ref,
+			status, message
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6, $7, $8, $9,
+			$10, $11, $12, $13,
+			$14, $15
+		)
+		RETURNING id, created_at, updated_at`
+
+	if err := r.pool.QueryRow(ctx, q,
+		d.TenantID, d.TenantUUID, d.ProjectID, d.ProjectUUID,
+		d.Name, string(d.Engine), nilIfEmpty(d.EngineVersion), d.InstanceClass, d.AllocatedStorageGB,
+		string(d.NetworkMode), d.VNetID, d.SubnetID, nilIfEmpty(d.NadRef),
+		string(d.Status), nilIfEmpty(d.Message),
+	).Scan(&d.ID, &d.CreatedAt, &d.UpdatedAt); err != nil {
+		return nil, fmt.Errorf("db create database: %w", err)
+	}
+	return d, nil
+}
+
+// GetDatabase fetches a Database by ID. Returns ErrDatabaseNotFound on
+// missing rows so handlers can map directly to 404 without string-matching
+// pgx errors.
+func (r *Repository) GetDatabase(ctx context.Context, id uuid.UUID) (*models.Database, error) {
+	const q = `
+		SELECT id, tenant_id, tenant_uuid, project_id, project_uuid,
+		       name, engine, engine_version, instance_class, allocated_storage_gb,
+		       network_mode, vnet_id, subnet_id, nad_ref,
+		       status, message,
+		       endpoint_address, endpoint_port,
+		       credentials_consumed_at, created_at, updated_at
+		FROM   databases
+		WHERE  id = $1`
+
+	d := &models.Database{}
+	var engine, networkMode, status string
+	var engineVersion, nadRef, message, endpointAddress *string
+	var endpointPort *int
+	err := r.pool.QueryRow(ctx, q, id).Scan(
+		&d.ID, &d.TenantID, &d.TenantUUID, &d.ProjectID, &d.ProjectUUID,
+		&d.Name, &engine, &engineVersion, &d.InstanceClass, &d.AllocatedStorageGB,
+		&networkMode, &d.VNetID, &d.SubnetID, &nadRef,
+		&status, &message,
+		&endpointAddress, &endpointPort,
+		&d.CredentialsConsumedAt, &d.CreatedAt, &d.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrDatabaseNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db get database: %w", err)
+	}
+
+	d.Engine = models.DatabaseEngine(engine)
+	d.NetworkMode = models.DatabaseNetworkMode(networkMode)
+	d.Status = models.ResourceStatus(status)
+	if engineVersion != nil {
+		d.EngineVersion = *engineVersion
+	}
+	if nadRef != nil {
+		d.NadRef = *nadRef
+	}
+	if message != nil {
+		d.Message = *message
+	}
+	if endpointAddress != nil {
+		d.EndpointAddress = *endpointAddress
+	}
+	if endpointPort != nil {
+		d.EndpointPort = *endpointPort
+	}
+	return d, nil
+}
+
+// ListDatabasesByProject returns every Database in the given project,
+// newest first. Filter is on (tenant_uuid, project_uuid) — the immutable
+// UUIDs, not the slugs (Phase 6a / M2.5 pattern).
+func (r *Repository) ListDatabasesByProject(ctx context.Context, tenantUUID, projectUUID uuid.UUID) ([]*models.Database, error) {
+	const q = `
+		SELECT id, tenant_id, tenant_uuid, project_id, project_uuid,
+		       name, engine, engine_version, instance_class, allocated_storage_gb,
+		       network_mode, vnet_id, subnet_id, nad_ref,
+		       status, message,
+		       endpoint_address, endpoint_port,
+		       credentials_consumed_at, created_at, updated_at
+		FROM   databases
+		WHERE  tenant_uuid = $1 AND project_uuid = $2
+		ORDER  BY created_at DESC`
+
+	rows, err := r.pool.Query(ctx, q, tenantUUID, projectUUID)
+	if err != nil {
+		return nil, fmt.Errorf("db list databases by project: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*models.Database, 0)
+	for rows.Next() {
+		d := &models.Database{}
+		var engine, networkMode, status string
+		var engineVersion, nadRef, message, endpointAddress *string
+		var endpointPort *int
+		if err := rows.Scan(
+			&d.ID, &d.TenantID, &d.TenantUUID, &d.ProjectID, &d.ProjectUUID,
+			&d.Name, &engine, &engineVersion, &d.InstanceClass, &d.AllocatedStorageGB,
+			&networkMode, &d.VNetID, &d.SubnetID, &nadRef,
+			&status, &message,
+			&endpointAddress, &endpointPort,
+			&d.CredentialsConsumedAt, &d.CreatedAt, &d.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("db scan database: %w", err)
+		}
+		d.Engine = models.DatabaseEngine(engine)
+		d.NetworkMode = models.DatabaseNetworkMode(networkMode)
+		d.Status = models.ResourceStatus(status)
+		if engineVersion != nil {
+			d.EngineVersion = *engineVersion
+		}
+		if nadRef != nil {
+			d.NadRef = *nadRef
+		}
+		if message != nil {
+			d.Message = *message
+		}
+		if endpointAddress != nil {
+			d.EndpointAddress = *endpointAddress
+		}
+		if endpointPort != nil {
+			d.EndpointPort = *endpointPort
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// DeleteDatabase removes a Database row by ID. The dbaas controller's
+// finalizer handles the VM/Secret/PVC teardown; once we delete the CR (in
+// the handler/adapter) we can hard-delete the row immediately. Returns
+// ErrDatabaseNotFound if the row was already gone.
+func (r *Repository) DeleteDatabase(ctx context.Context, id uuid.UUID) error {
+	const q = `DELETE FROM databases WHERE id = $1`
+	tag, err := r.pool.Exec(ctx, q, id)
+	if err != nil {
+		return fmt.Errorf("db delete database: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDatabaseNotFound
+	}
+	return nil
+}
+
+// UpdateDatabaseStatus writes the latest controller-reported state to the
+// row. Called from the GET handler (status overlay) and (later) the
+// reconciler. endpointAddress/endpointPort may be empty/0 until the
+// controller reaches DatabaseReady.
+func (r *Repository) UpdateDatabaseStatus(
+	ctx context.Context,
+	id uuid.UUID,
+	status models.ResourceStatus,
+	message, endpointAddress string,
+	endpointPort int,
+) error {
+	const q = `
+		UPDATE databases
+		SET    status            = $2,
+		       message           = $3,
+		       endpoint_address  = $4,
+		       endpoint_port     = $5
+		WHERE  id = $1`
+	_, err := r.pool.Exec(ctx, q, id,
+		string(status),
+		nilIfEmpty(message),
+		nilIfEmpty(endpointAddress),
+		nilIfZeroInt(endpointPort),
+	)
+	if err != nil {
+		return fmt.Errorf("db update database status: %w", err)
+	}
+	return nil
+}
+
+// MarkDatabaseCredentialsConsumed stamps credentials_consumed_at = NOW()
+// on the row, but only if it is still NULL. Returns the shared
+// ErrCredentialsAlreadyConsumed (defined alongside the KeyVault repo) when
+// the row had already been marked — the handler maps to 410 Gone.
+//
+// The IS NULL predicate is the race guard: if two callers race
+// GET /credentials, only one wins the UPDATE; the other sees zero rows
+// affected and gets ErrCredentialsAlreadyConsumed.
+func (r *Repository) MarkDatabaseCredentialsConsumed(ctx context.Context, id uuid.UUID) error {
+	const q = `
+		UPDATE databases
+		SET    credentials_consumed_at = NOW()
+		WHERE  id = $1 AND credentials_consumed_at IS NULL`
+	tag, err := r.pool.Exec(ctx, q, id)
+	if err != nil {
+		return fmt.Errorf("db mark database credentials consumed: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrCredentialsAlreadyConsumed
+	}
+	return nil
+}
+
+// nilIfZeroInt returns nil for 0, otherwise a pointer to v. Used to keep
+// endpoint_port NULL in the DB until the controller reports a real port
+// (rather than storing 0, which would round-trip back as a non-empty value
+// in JSON responses).
+func nilIfZeroInt(v int) *int {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}

--- a/dc-api/internal/db/schema.sql
+++ b/dc-api/internal/db/schema.sql
@@ -794,3 +794,80 @@ DROP TRIGGER IF EXISTS cluster_node_pools_updated_at ON cluster_node_pools;
 CREATE TRIGGER cluster_node_pools_updated_at
     BEFORE UPDATE ON cluster_node_pools
     FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+-- ─────────────────────────── Task 1 — DBaaS (Databases) ─────────────────────
+-- One row per managed Database. 1:1 model — each row maps to exactly one
+-- DBInstance CR (group dbaas.opencloud.wso2.com/v1alpha1) in the project
+-- namespace, which the dbaas controller provisions as a KubeVirt VM running
+-- PostgreSQL. No DatabaseBackend CRD — databases don't share infrastructure
+-- (different from key_vaults, which has a per-tenant OpenBao Backend).
+--
+-- Network mode is per-instance:
+--   'vpc'    → vnet_id + subnet_id must be set; the dbaas controller attaches
+--              the VM to the KubeOVN-managed NAD at
+--              (project-ns, subnets.backend_uid)
+--   'legacy' → nad_ref must be set ('<namespace>/<nad-name>' of a pre-existing
+--              Multus NAD on a VLAN bridge); used by lk prod today
+--
+-- engine is postgres-only in v1. Task 2 extends this to 'mysql', 'mssql' via
+-- DROP CONSTRAINT / ADD CONSTRAINT on databases_engine_check.
+--
+-- credentials_consumed_at follows the shown-once pattern from key_vaults:
+-- NULL = creds not yet retrieved; timestamp = consumed, GET .../credentials
+-- returns 410 Gone on subsequent calls.
+
+CREATE TABLE IF NOT EXISTS databases (
+    id                      UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id               TEXT            NOT NULL,
+    tenant_uuid             UUID            NOT NULL,
+    project_id              TEXT            NOT NULL,
+    project_uuid            UUID            NOT NULL REFERENCES projects(project_uuid) ON DELETE RESTRICT,
+
+    name                    TEXT            NOT NULL,
+    engine                  TEXT            NOT NULL DEFAULT 'postgres'
+        CONSTRAINT databases_engine_check CHECK (engine IN ('postgres')),
+    engine_version          TEXT,
+    instance_class          TEXT            NOT NULL,
+    allocated_storage_gb    INTEGER         NOT NULL CHECK (allocated_storage_gb > 0),
+
+    -- Network selection. Exactly one mode's fields must be populated.
+    network_mode            TEXT            NOT NULL CHECK (network_mode IN ('vpc', 'legacy')),
+    vnet_id                 UUID,
+    subnet_id               UUID,
+    nad_ref                 TEXT,
+
+    status                  resource_status NOT NULL DEFAULT 'PENDING',
+    message                 TEXT,
+
+    -- Endpoint cache, populated from the live CR status once the controller
+    -- has assigned the Multus IP and PostgreSQL is accepting connections.
+    endpoint_address        TEXT,
+    endpoint_port           INTEGER,
+
+    credentials_consumed_at TIMESTAMPTZ,
+
+    created_at              TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    UNIQUE (project_uuid, name),
+
+    -- Defense-in-depth: handler validates first, but if anything bypasses it
+    -- the row still can't be wedged into an invalid network state.
+    CONSTRAINT databases_network_fields_check CHECK (
+        (network_mode = 'vpc'
+            AND vnet_id IS NOT NULL AND subnet_id IS NOT NULL
+            AND nad_ref IS NULL)
+        OR
+        (network_mode = 'legacy'
+            AND nad_ref IS NOT NULL
+            AND vnet_id IS NULL AND subnet_id IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_databases_tenant_uuid  ON databases (tenant_uuid);
+CREATE INDEX IF NOT EXISTS idx_databases_project_uuid ON databases (project_uuid);
+
+DROP TRIGGER IF EXISTS databases_updated_at ON databases;
+CREATE TRIGGER databases_updated_at
+    BEFORE UPDATE ON databases
+    FOR EACH ROW EXECUTE FUNCTION touch_updated_at();

--- a/dc-api/internal/models/database.go
+++ b/dc-api/internal/models/database.go
@@ -1,0 +1,118 @@
+// Package models — database.go
+//
+// Task 1 v1: Database (DBaaS) domain types. A Database is a project-scoped
+// managed PostgreSQL instance backed by the dbaas controller (one Resource =
+// one KubeVirt VM, 1:1 model — no shared Backend).
+//
+// The dbaas controller is the operator at github.com/wso2/open-cloud-datacenter
+// (the dbaas/ active fork during development). dc-api creates DBInstance CRs
+// of group dbaas.opencloud.wso2.com/v1alpha1 and watches their status —
+// it never imports the operator's Go types directly.
+//
+// Forward-compat reservations (accepted on POST today, behaviour deferred):
+//   - EngineVersion: stored but not acted on by the controller until the
+//     multi-version work in Task 2 lands.
+//   - Backups, BYOK, SSL toggling: Task 2 scope.
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DatabaseEngine is the family of DB engines the platform supports.
+// v1 is Postgres-only; Task 2 adds MySQL/MSSQL.
+type DatabaseEngine string
+
+const (
+	DatabaseEnginePostgres DatabaseEngine = "postgres"
+)
+
+// DatabaseNetworkMode tells dc-api how to resolve the controller's
+// spec.networkRef. The choice is per-instance, not per-tenant — a project
+// can have some Databases on KubeOVN VPCs and others on legacy bridge NADs.
+type DatabaseNetworkMode string
+
+const (
+	// DatabaseNetworkModeVPC resolves to a KubeOVN-managed NAD via
+	// (VNetID, SubnetID). The NAD already exists — KubeOVN provisions it at
+	// subnet create time. dc-api looks up the subnet row and derives the NAD
+	// identity as (project-namespace, subnet.BackendUID).
+	DatabaseNetworkModeVPC DatabaseNetworkMode = "vpc"
+	// DatabaseNetworkModeLegacy passes the caller-supplied NadRef ("ns/name")
+	// straight through to the controller. Used today by lk prod where VMs
+	// attach to a pre-provisioned Multus bridge NAD on a VLAN.
+	DatabaseNetworkModeLegacy DatabaseNetworkMode = "legacy"
+)
+
+// Database is the persisted dc-api record. Mirrors the databases table.
+// dbaas controller-side state (VM phase, endpoint IP allocated by Multus,
+// credentials secret name) lives on the DBInstance CR; the handler overlays
+// it onto the response on GET.
+type Database struct {
+	ID          uuid.UUID `json:"id"`
+	TenantID    string    `json:"tenant_id"`
+	TenantUUID  uuid.UUID `json:"tenant_uuid"`
+	ProjectID   string    `json:"project_id"`
+	ProjectUUID uuid.UUID `json:"project_uuid"`
+
+	Name               string         `json:"name"`
+	Engine             DatabaseEngine `json:"engine"`
+	EngineVersion      string         `json:"engine_version,omitempty"` // informational in v1
+	InstanceClass      string         `json:"instance_class"`           // dbaas RDS-style class, e.g. "db.t3.medium"
+	AllocatedStorageGB int            `json:"allocated_storage_gb"`
+
+	// Network selection. Exactly one of (VNetID+SubnetID) or NadRef is set;
+	// the handler enforces this on create. NetworkMode says which.
+	NetworkMode DatabaseNetworkMode `json:"network_mode"`
+	VNetID      *uuid.UUID          `json:"vnet_id,omitempty"`
+	SubnetID    *uuid.UUID          `json:"subnet_id,omitempty"`
+	NadRef      string              `json:"nad_ref,omitempty"`
+
+	Status  ResourceStatus `json:"status"`
+	Message string         `json:"message,omitempty"`
+
+	// EndpointAddress / EndpointPort are populated from the live CR status
+	// once the controller has assigned an IP on the data NIC. Empty until
+	// status=ACTIVE.
+	EndpointAddress string `json:"endpoint_address,omitempty"`
+	EndpointPort    int    `json:"endpoint_port,omitempty"`
+
+	// CredentialsConsumedAt is nil until GET .../credentials has been called
+	// once; subsequent calls return 410 Gone (shown-once — same as KeyVault,
+	// per managed-services contract §8).
+	CredentialsConsumedAt *time.Time `json:"credentials_consumed_at,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// DatabaseInstanceClasses is the catalog of RDS-style sizes the dbaas
+// controller accepts on spec.dbInstanceClass. dc-api validates the caller's
+// instance_class against this set before forwarding to the operator —
+// rejecting unknown classes with a 400 instead of leaving the row PENDING
+// while the controller fails admission.
+//
+// Values mirror api/v1alpha1/dbinstance_types.go in the dbaas repo. Keep in
+// sync when the catalog grows.
+var DatabaseInstanceClasses = map[string]struct{}{
+	"db.t3.micro":   {},
+	"db.t3.small":   {},
+	"db.t3.medium":  {},
+	"db.t3.large":   {},
+	"db.t3.xlarge":  {},
+	"db.t3.2xlarge": {},
+	"db.m5.large":   {},
+	"db.m5.xlarge":  {},
+	"db.m5.2xlarge": {},
+	"db.r5.large":   {},
+	"db.r5.xlarge":  {},
+	"db.r5.2xlarge": {},
+}
+
+// ValidDatabaseInstanceClass reports whether s is one of the catalog entries.
+func ValidDatabaseInstanceClass(s string) bool {
+	_, ok := DatabaseInstanceClasses[s]
+	return ok
+}

--- a/dc-api/internal/providers/dbaas/client.go
+++ b/dc-api/internal/providers/dbaas/client.go
@@ -1,0 +1,254 @@
+// Package dbaas is the dc-api-side driver for the dbaas operator's CRDs.
+//
+// dc-api never talks to the dbaas REST gateway — it only ever creates / reads
+// / deletes DBInstance Custom Resources of group dbaas.opencloud.wso2.com/
+// v1alpha1. The dbaas controller (separate workload at
+// github.com/wso2/open-cloud-datacenter) watches those CRs and provisions the
+// underlying KubeVirt VM running PostgreSQL.
+//
+// This package implements providers.DatabaseProvisioner against a dynamic
+// client (no typed K8s client — the dbaas operator's Go types live in a
+// different module that dc-api does not import). Same pattern as
+// providers/kvi/client.go.
+//
+// Task 1 (D2): 1:1 model — one DBInstance CR == one VM. No Backend CRD.
+package dbaas
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/wso2/dc-api/internal/providers"
+)
+
+// DBInstance CRD identity. Must match config/crd/bases/ in the dbaas repo.
+var (
+	groupVersion       = "dbaas.opencloud.wso2.com/v1alpha1"
+	apiGroup           = "dbaas.opencloud.wso2.com"
+	apiVersionV1alpha1 = "v1alpha1"
+
+	dbInstancesGVR = schema.GroupVersionResource{
+		Group: apiGroup, Version: apiVersionV1alpha1, Resource: "dbinstances",
+	}
+	secretsGVR = schema.GroupVersionResource{
+		Group: "", Version: "v1", Resource: "secrets",
+	}
+)
+
+// Client implements providers.DatabaseProvisioner.
+type Client struct {
+	dyn dynamic.Interface
+}
+
+// NewClient builds a DBaaS provisioner backed by the given dynamic client.
+// Reuse an existing dynamic client (e.g. from kubeovn.Client.Dynamic()) so
+// dc-api keeps one connection pool, not two.
+func NewClient(dyn dynamic.Interface) *Client {
+	return &Client{dyn: dyn}
+}
+
+// Compile-time interface satisfaction check.
+var _ providers.DatabaseProvisioner = (*Client)(nil)
+
+// ─── DBInstance CR ──────────────────────────────────────────────────────────
+
+// CreateDatabaseInstance creates a DBInstance CR in req.Namespace with the
+// seven standard dc-api.wso2.com/* labels stamped on it. Returns the raw
+// K8s API error on failure (handler maps AlreadyExists → 409).
+func (c *Client) CreateDatabaseInstance(ctx context.Context, req providers.DatabaseInstanceCreateRequest) error {
+	labels := map[string]interface{}{}
+	for k, v := range req.Labels {
+		labels[k] = v
+	}
+
+	// NetworkRef is emitted as a "<namespace>/<name>" string per dbaas CRD
+	// pattern B (api/v1alpha1/dbinstance_types.go — NetworkRef is a string
+	// field, not a struct). The handler's resolver guarantees both fields
+	// are populated.
+	networkRef := req.NetworkRef.Namespace + "/" + req.NetworkRef.Name
+
+	specMap := map[string]interface{}{
+		"dbInstanceClass":  req.InstanceClass,
+		"allocatedStorage": int64(req.AllocatedStorageGB),
+		"networkRef":       networkRef,
+	}
+	// engineVersion is reserved in the dbaas CRD (Task 2 enables it).
+	// Carry it through so the row's view stays consistent — the controller
+	// silently ignores fields it doesn't act on (contract §4.2).
+	if req.EngineVersion != "" {
+		specMap["engineVersion"] = req.EngineVersion
+	}
+	// osImage selects the Harvester VirtualMachineImage to boot from. When
+	// empty the controller uses its own CRD default (which may not exist on
+	// every cluster — see DCAPI_DBAAS_OS_IMAGE).
+	if req.OSImage != "" {
+		specMap["osImage"] = req.OSImage
+	}
+	// dnsServerIP pins the VM's resolver to the per-VPC CoreDNS (VPC mode).
+	// Without it, a VM on an isolated OVN subnet can't resolve the apt archive
+	// during cloud-init and Postgres never installs. Empty for legacy NADs.
+	if req.NetworkRef.DNSServerIP != "" {
+		specMap["dnsServerIP"] = req.NetworkRef.DNSServerIP
+	}
+
+	cr := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": groupVersion,
+		"kind":       "DBInstance",
+		"metadata": map[string]interface{}{
+			"name":      req.Name,
+			"namespace": req.Namespace,
+			"labels":    labels,
+		},
+		"spec": specMap,
+	}}
+
+	if _, err := c.dyn.Resource(dbInstancesGVR).Namespace(req.Namespace).Create(ctx, cr, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create DBInstance %s/%s: %w", req.Namespace, req.Name, err)
+	}
+	return nil
+}
+
+// GetDatabaseInstance returns the CR's translated status, or (nil, nil) when
+// the CR does not exist (handler treats that as "not yet provisioned").
+//
+// The dbaas controller writes RDS-style status.phase strings (creating,
+// available, modifying, stopped, starting, stopping, deleting, failed). The
+// translation table below maps those to the contract-canonical five-phase
+// enum (Pending / Provisioning / Ready / Failed / Terminating).
+func (c *Client) GetDatabaseInstance(ctx context.Context, namespace, name string) (*providers.DatabaseInstanceStatus, error) {
+	obj, err := c.dyn.Resource(dbInstancesGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get DBInstance %s/%s: %w", namespace, name, err)
+	}
+
+	status, _ := obj.Object["status"].(map[string]interface{})
+	if status == nil {
+		// CR exists but controller hasn't written status yet — return
+		// an empty status so callers see Phase="" and requeue.
+		return &providers.DatabaseInstanceStatus{}, nil
+	}
+
+	out := &providers.DatabaseInstanceStatus{}
+
+	// Phase mapping. Empty string when unknown — handler keeps DB row status.
+	rdsPhase, _ := status["phase"].(string)
+	out.Phase = mapRDSPhase(rdsPhase)
+
+	// Message preference: controller's status.message wins. Fall back to
+	// provisioningPhase when message is empty so the user always sees a
+	// hint of what's happening during long provisions (contract §5.1
+	// Pattern C).
+	out.Message, _ = status["message"].(string)
+	if out.Message == "" {
+		if pp, _ := status["provisioningPhase"].(string); pp != "" {
+			out.Message = "provisioning: " + pp
+		}
+	}
+
+	// status.endpoint — populated only after the controller reaches
+	// DatabaseReady (the VM has an IP on the data NIC and PostgreSQL is
+	// listening). Both fields stay empty until then.
+	if ep, ok := status["endpoint"].(map[string]interface{}); ok {
+		out.EndpointAddress, _ = ep["address"].(string)
+		// JSON numbers unmarshal as float64 via the dynamic client.
+		if p, ok := ep["port"].(float64); ok {
+			out.EndpointPort = int(p)
+		} else if p, ok := ep["port"].(int64); ok {
+			out.EndpointPort = int(p)
+		}
+	}
+
+	// status.masterUserSecret.name — dbaas-specific RDS-style placement
+	// (not the framework default status.endpoint.secretRef.name).
+	if mus, ok := status["masterUserSecret"].(map[string]interface{}); ok {
+		out.SecretRefName, _ = mus["name"].(string)
+	}
+
+	return out, nil
+}
+
+// DeleteDatabaseInstance removes the DBInstance CR. The dbaas controller's
+// finalizer runs the upstream cleanup (VM, DataVolumes, Service, Secret).
+// Idempotent: NotFound is treated as success so a double-DELETE from the
+// handler doesn't error.
+func (c *Client) DeleteDatabaseInstance(ctx context.Context, namespace, name string) error {
+	err := c.dyn.Resource(dbInstancesGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete DBInstance %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// GetDatabaseCredentialsSecret returns the raw data map of the credentials
+// Secret the dbaas controller wrote (typical keys: admin_user, admin_password,
+// ca_cert, server_cert, server_key, repl_password, exporter_password, luks_key).
+// The handler picks the subset to surface on GET .../credentials.
+// Returns (nil, nil) when the Secret does not exist.
+func (c *Client) GetDatabaseCredentialsSecret(ctx context.Context, namespace, name string) (map[string][]byte, error) {
+	obj, err := c.dyn.Resource(secretsGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get Secret %s/%s: %w", namespace, name, err)
+	}
+
+	raw, _ := obj.Object["data"].(map[string]interface{})
+	out := make(map[string][]byte, len(raw))
+	for k, v := range raw {
+		// data field values come back as either base64-encoded string or
+		// []byte depending on the decoder path.
+		switch x := v.(type) {
+		case []byte:
+			out[k] = x
+		case string:
+			out[k] = decodeBase64Maybe(x)
+		}
+	}
+	return out, nil
+}
+
+// decodeBase64Maybe returns the base64-decoded bytes of s, or s as bytes
+// when s is not valid base64. K8s API responses sometimes return secret
+// data values already-decoded as []byte and sometimes as base64 strings
+// depending on the decoder path; this normalises both.
+func decodeBase64Maybe(s string) []byte {
+	if b, err := base64.StdEncoding.DecodeString(s); err == nil {
+		return b
+	}
+	return []byte(s)
+}
+
+// mapRDSPhase translates the dbaas controller's RDS-style status.phase
+// strings into the framework's canonical five-phase enum (per
+// docs/managed-services-integration.md §5.1 Pattern B).
+//
+// Power-cycle states (stopped / starting / stopping) are mapped to Ready
+// per §5.4 — the status enum stays at five values; stop/start lives on a
+// separate action endpoint (not implemented in v1).
+//
+// Empty string when the source phase is unknown — handler keeps the DB
+// row's existing status (don't overwrite with garbage on a malformed CR).
+func mapRDSPhase(phase string) string {
+	switch phase {
+	case "creating", "modifying", "starting":
+		return "Provisioning"
+	case "available", "stopped", "stopping":
+		return "Ready"
+	case "failed":
+		return "Failed"
+	case "deleting":
+		return "Terminating"
+	}
+	return ""
+}

--- a/dc-api/internal/providers/interface.go
+++ b/dc-api/internal/providers/interface.go
@@ -622,3 +622,110 @@ type VPCNATProvisioner interface {
 	WaitVpcNATPodsGone(ctx context.Context, vpcUID string, timeout time.Duration) error
 }
 
+// DatabaseProvisioner is the optional interface that drives the dbaas
+// operator's DBInstance CRD. dc-api creates / reads / deletes CRs of group
+// dbaas.opencloud.wso2.com/v1alpha1 (kind: DBInstance) and reads the
+// credentials Secret the controller writes. The dbaas controller (separate
+// workload at github.com/wso2/open-cloud-datacenter) watches the CRs and
+// provisions the underlying KubeVirt VM running PostgreSQL.
+//
+// Task 1 (D2): 1:1 model — one Database == one DBInstance CR == one VM.
+// No DatabaseBackend (unlike KVIProvisioner). The interface is therefore
+// strictly smaller than KVIProvisioner.
+//
+// dc-api handlers depend on this interface — never on the concrete dbaas
+// adapter — so the same handler code works against a fake in tests.
+type DatabaseProvisioner interface {
+	// CreateDatabaseInstance creates a DBInstance CR in the project
+	// namespace with the seven standard dc-api.wso2.com/* labels stamped
+	// on it. Returns an AlreadyExists error if a CR of the same name
+	// exists (handler maps to 409).
+	CreateDatabaseInstance(ctx context.Context, req DatabaseInstanceCreateRequest) error
+
+	// GetDatabaseInstance returns the CR's status, or (nil, nil) when the
+	// CR does not exist (handler treats that as "not yet provisioned" —
+	// no error).
+	GetDatabaseInstance(ctx context.Context, namespace, name string) (*DatabaseInstanceStatus, error)
+
+	// DeleteDatabaseInstance removes the DBInstance CR. The dbaas
+	// controller's finalizer runs the upstream teardown (VM, DataVolumes,
+	// Service, ServiceMonitor, Secret); dc-api just deletes the CR.
+	// Idempotent: NotFound is treated as success.
+	DeleteDatabaseInstance(ctx context.Context, namespace, name string) error
+
+	// GetDatabaseCredentialsSecret returns the raw data map of the credentials
+	// Secret the controller wrote. Returns (nil, nil) when the Secret
+	// does not exist. Keys are dbaas-specific (admin_user, admin_password,
+	// ca_cert, server_cert, ...); the handler picks the subset to surface
+	// on GET .../credentials.
+	GetDatabaseCredentialsSecret(ctx context.Context, namespace, name string) (map[string][]byte, error)
+}
+
+// DatabaseInstanceCreateRequest is what the handler hands the provisioner.
+// The provisioner translates it into the DBInstance CR's metadata + spec.
+// Field naming mirrors the dbaas controller's CRD (api/v1alpha1/
+// dbinstance_types.go) so the adapter's translation is mechanical.
+type DatabaseInstanceCreateRequest struct {
+	// Name is the CR's metadata.name (e.g. "db-<8-char-uuid>"). Built by
+	// the handler via common.NamespaceScopedName("db", dbID).
+	Name string
+	// Namespace is the project-tier namespace ("dc-<tenant>-<project>").
+	Namespace string
+	// Labels is the result of common.StandardLabels(...) — the seven
+	// dc-api.wso2.com/* labels the operator must propagate to children
+	// per docs/managed-services-integration.md §6.
+	Labels map[string]string
+
+	// InstanceClass maps to spec.dbInstanceClass (e.g. "db.t3.medium").
+	// Validated by the handler against models.DatabaseInstanceClasses.
+	InstanceClass string
+	// AllocatedStorageGB maps to spec.allocatedStorage.
+	AllocatedStorageGB int
+	// EngineVersion is informational in v1 (the dbaas controller doesn't
+	// act on it). Stored in the CR spec for future-compat (Task 2).
+	EngineVersion string
+
+	// OSImage is the Harvester VirtualMachineImage ("namespace/name") the
+	// controller boots the VM from (spec.osImage). Operator-configured via
+	// DCAPI_DBAAS_OS_IMAGE; empty leaves the controller's own default.
+	OSImage string
+
+	// NetworkRef is the resolved Multus NAD identity the controller
+	// attaches the VM's data NIC to. The handler resolves it from either
+	// VPC mode (subnet → NAD) or legacy mode (pass-through), so the
+	// adapter never sees raw vnet/subnet/nad_ref fields.
+	NetworkRef DatabaseNetworkRef
+}
+
+// DatabaseNetworkRef is the namespace/name pair identifying the Multus NAD
+// the operator attaches the database VM to. Per
+// docs/managed-services-integration.md §7.1 the operator does not see how
+// the NAD was produced — only its identity.
+type DatabaseNetworkRef struct {
+	Namespace string
+	Name      string
+	// DNSServerIP is the per-VPC CoreDNS address for VPC-mode subnets, passed
+	// to the operator so the VM's dnsConfig points at a resolver reachable
+	// from the isolated VPC (defeats the KubeVirt-on-OVN DHCP DNS race that
+	// otherwise breaks apt during cloud-init). Empty for legacy bridge NADs
+	// (cluster-routable VLAN DNS works without it).
+	DNSServerIP string
+}
+
+// DatabaseInstanceStatus is the framework-friendly view of a DBInstance.status.
+// Mirrors the contract's five-phase enum so handlers don't have to grub
+// through the unstructured CR themselves. The adapter is responsible for
+// mapping the dbaas-specific status shape (RDS-style status.phase values
+// like "available", and the credential Secret at status.masterUserSecret.name
+// rather than the canonical status.endpoint.secretRef.name) into this
+// canonical view.
+type DatabaseInstanceStatus struct {
+	Phase   string // Pending|Provisioning|Ready|Failed|Terminating
+	Message string
+
+	EndpointAddress string
+	EndpointPort    int
+
+	SecretRefName string // empty until Ready
+}
+

--- a/dc-api/internal/providers/kubeovn/dns.go
+++ b/dc-api/internal/providers/kubeovn/dns.go
@@ -148,7 +148,9 @@ func (c *Client) ensureVpcCorefileConfigMap(ctx context.Context, vpcUID string) 
 	forwarders := strings.Join(c.dnsForwarders(), " ")
 	corefile := fmt.Sprintf(`.:53 {
     errors
-    health { lameduck 5s }
+    health {
+        lameduck 5s
+    }
     ready
     forward . %s { max_concurrent 1000 }
     cache 300

--- a/dc-api/internal/webhook/mutate.go
+++ b/dc-api/internal/webhook/mutate.go
@@ -99,6 +99,23 @@ func (m *Mutator) buildPatch(ctx context.Context, vm map[string]interface{}) ([]
 		return nil, nil
 	}
 
+	// If the VM declares a `pod` network, that NIC is meant to be the launcher
+	// pod's primary interface (eth0) — e.g. the dbaas DB VM's mgmt-net
+	// masquerade, which the dbaas controller reaches over the cluster pod
+	// network to probe Postgres readiness. In that case we must NOT force
+	// v1.multus-cni.io/default-network onto the OVN NAD: doing so steals eth0
+	// and strands the VM on the isolated tenant VPC, unreachable from its
+	// controller. MAC + logical_switch pinning for the OVN data NIC still
+	// apply. dc-api's own compute VMs are pure-multus (no pod network), so
+	// they are unaffected and still get default-network set.
+	hasPodNetwork := false
+	for _, net := range networks {
+		if _, ok := net["pod"]; ok {
+			hasPodNetwork = true
+			break
+		}
+	}
+
 	// Build a map from interface name → MAC so we can look up the MAC once we
 	// know which interfaces correspond to OVN NADs.
 	ifaceMAC := make(map[string]string, len(interfaces))
@@ -168,10 +185,14 @@ func (m *Mutator) buildPatch(ctx context.Context, vm map[string]interface{}) ([]
 
 		// Idempotency: if all three annotation values already match the interface
 		// MAC (and the default-network annotation is set), skip this interface.
+		// When the VM has a pod network, default-network is deliberately left
+		// alone (see hasPodNetwork above), so it must not factor into the
+		// idempotency check.
+		defaultNetworkOK := hasPodNetwork || existingAnnotations[keyDefault] == nadNS+"/"+nadName
 		if existingAnnotations[keyOVN] == mac &&
 			existingAnnotations[keyLegacy] == mac &&
 			existingAnnotations[keySwitch] == nadName &&
-			existingAnnotations[keyDefault] == nadNS+"/"+nadName {
+			defaultNetworkOK {
 			m.log.Debug().Str("iface", ifaceName).Msg("webhook: OVN annotations already correct — no-op")
 			continue
 		}
@@ -192,14 +213,18 @@ func (m *Mutator) buildPatch(ctx context.Context, vm map[string]interface{}) ([]
 		ops = append(ops, annotationOp(existingAnnotations, keyOVN, mac)...)
 		ops = append(ops, annotationOp(existingAnnotations, keyLegacy, mac)...)
 		ops = append(ops, annotationOp(existingAnnotations, keySwitch, nadName)...)
-		ops = append(ops, annotationOp(existingAnnotations, keyDefault, nadNS+"/"+nadName)...)
+		if !hasPodNetwork {
+			ops = append(ops, annotationOp(existingAnnotations, keyDefault, nadNS+"/"+nadName)...)
+		}
 
 		// Update the local map so subsequent iterations see the new values (for
 		// multiple OVN interfaces — rare but safe to handle).
 		existingAnnotations[keyOVN] = mac
 		existingAnnotations[keyLegacy] = mac
 		existingAnnotations[keySwitch] = nadName
-		existingAnnotations[keyDefault] = nadNS + "/" + nadName
+		if !hasPodNetwork {
+			existingAnnotations[keyDefault] = nadNS + "/" + nadName
+		}
 	}
 
 	return ops, nil

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -94,6 +94,13 @@ tags:
       Chunk 3 adds the human-driven secret CRUD data plane
       (`/keyvaults/{id}/secrets`), proxied through dc-api to the per-tenant
       OpenBao KV-v2 mount — callers never see OpenBao tokens.
+  - name: databases
+    description: |
+      Managed PostgreSQL databases (DBaaS). Each Database is a project-scoped
+      KubeVirt VM provisioned by the dbaas controller. Task 1 v1: Postgres
+      only, 1:1 model (one Database = one VM), shown-once credentials via
+      `GET .../credentials`. Network can be on a KubeOVN VPC subnet or a
+      legacy Multus bridge NAD — selectable per-instance.
   - name: auth
     description: |
       Backend-for-Frontend OIDC session endpoints used by cloud-ui. Not consumed by dcctl.
@@ -3980,6 +3987,201 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  # ── Task 1 — DBaaS Databases ───────────────────────────────────────────────
+  /v1/tenants/{tenant_id}/projects/{project_id}/databases:
+    parameters:
+      - $ref: "#/components/parameters/TenantID"
+      - $ref: "#/components/parameters/ProjectID"
+
+    post:
+      operationId: createDatabase
+      tags: [databases]
+      summary: Create a managed Database (async)
+      description: |
+        Creates a managed PostgreSQL Database. dc-api inserts a `PENDING` row,
+        then creates a `DBInstance` CR in the project namespace; the dbaas
+        controller provisions the VM asynchronously. Caller polls
+        `GET .../{id}` until `status` is `ACTIVE`, then retrieves the master
+        credentials exactly once via `GET .../{id}/credentials`.
+
+        **Network selection** is optional. When omitted, dc-api picks the
+        project's first ACTIVE subnet (VPC mode). Specify a `network` block
+        to pick a different subnet (VPC mode) or attach to a pre-existing
+        Multus NAD (legacy mode — for VLAN-based deployments).
+
+        **Required role**: `member` or `owner`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDatabaseRequest"
+            example:
+              name: orders
+              engine: postgres
+              instance_class: db.t3.medium
+              allocated_storage_gb: 50
+      responses:
+        "201":
+          description: Database created (provisioning in progress)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Database"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    get:
+      operationId: listDatabases
+      tags: [databases]
+      summary: List Databases in this project
+      description: |
+        Returns every Database in the (tenant, project) scope. Each row's
+        `status` / `message` / `endpoint_address` / `endpoint_port` reflect
+        the live `DBInstance` CR status, not just the DB-row snapshot.
+      responses:
+        "200":
+          description: List of Databases
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Database"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/tenants/{tenant_id}/projects/{project_id}/databases/{id}:
+    parameters:
+      - $ref: "#/components/parameters/TenantID"
+      - $ref: "#/components/parameters/ProjectID"
+      - name: id
+        in: path
+        required: true
+        description: UUID of the Database
+        schema:
+          type: string
+          format: uuid
+          example: 6f1c4d2a-0000-0000-0000-000000000071
+
+    get:
+      operationId: getDatabase
+      tags: [databases]
+      summary: Get a Database by UUID
+      description: |
+        Returns the DB row with live `DBInstance` CR status overlaid
+        (`status`, `message`, `endpoint_address`, `endpoint_port`).
+      responses:
+        "200":
+          description: Database resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Database"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: deleteDatabase
+      tags: [databases]
+      summary: Delete a Database
+      description: |
+        Issues `DELETE` on the `DBInstance` CR (the controller's finalizer
+        tears down the VM, DataVolumes, Service, and credentials Secret
+        asynchronously) and drops the dc-api row immediately. Subsequent
+        `GET` returns 404.
+
+        **Required role**: `member` or `owner`.
+      responses:
+        "204":
+          description: Database deletion accepted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/tenants/{tenant_id}/projects/{project_id}/databases/{id}/credentials:
+    parameters:
+      - $ref: "#/components/parameters/TenantID"
+      - $ref: "#/components/parameters/ProjectID"
+      - name: id
+        in: path
+        required: true
+        description: UUID of the Database
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: getDatabaseCredentials
+      tags: [databases]
+      summary: Retrieve the Database's master credentials (shown once)
+      description: |
+        Returns the master user credentials the dbaas controller provisioned.
+        **The response is shown exactly once** — subsequent calls return
+        `410 Gone`. The caller MUST store the response immediately; dc-api
+        never holds these values server-side after the first read.
+
+        Pre-conditions:
+          - The Database must have `status=ACTIVE` (controller finished
+            provisioning and PostgreSQL is accepting connections). Otherwise:
+            409 Conflict.
+          - The dbaas operator integration must be wired into this dc-api
+            deployment. Otherwise: 501 Not Implemented.
+
+        **Required role**: `member` or `owner`.
+      responses:
+        "200":
+          description: Database master credentials (shown once)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DatabaseCredentials"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Database not Ready yet — poll GET .../{id} until status=ACTIVE
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Credentials already retrieved once and cannot be retrieved again
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          description: dbaas operator integration not enabled on this deployment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 # ── Components ─────────────────────────────────────────────────────────────────
 
 components:
@@ -6256,4 +6458,186 @@ components:
           type: string
           description: Human-readable polling instruction with the GET URL
           example: "VNet is being provisioned. Poll GET /v1/vnets/{id} for status."
+
+    # ── Task 1 — DBaaS Database schemas ───────────────────────────────────────
+
+    CreateDatabaseRequest:
+      type: object
+      required: [name, instance_class, allocated_storage_gb]
+      description: |
+        Body for `POST .../databases`. Network selection is optional —
+        omit to use the project's default (first ACTIVE subnet).
+      properties:
+        name:
+          type: string
+          description: Project-unique name (DNS-label rules; ≤32 chars).
+          example: orders
+        engine:
+          type: string
+          enum: [postgres]
+          default: postgres
+          description: Database engine. v1 supports postgres only.
+        engine_version:
+          type: string
+          description: |
+            Engine version (e.g. "16"). Informational in v1 — accepted and
+            stored but not acted on by the controller until Task 2 lands
+            multi-version support.
+          example: "16"
+        instance_class:
+          type: string
+          enum:
+            - db.t3.micro
+            - db.t3.small
+            - db.t3.medium
+            - db.t3.large
+            - db.t3.xlarge
+            - db.t3.2xlarge
+            - db.m5.large
+            - db.m5.xlarge
+            - db.m5.2xlarge
+            - db.r5.large
+            - db.r5.xlarge
+            - db.r5.2xlarge
+          description: RDS-style instance size class.
+          example: db.t3.medium
+        allocated_storage_gb:
+          type: integer
+          minimum: 1
+          description: Data-volume size in GiB.
+          example: 50
+        network:
+          $ref: "#/components/schemas/DatabaseNetworkSpec"
+
+    DatabaseNetworkSpec:
+      description: |
+        Discriminated network selection. Omit to auto-pick the project's
+        default subnet (VPC mode).
+      oneOf:
+        - $ref: "#/components/schemas/DatabaseNetworkVPC"
+        - $ref: "#/components/schemas/DatabaseNetworkLegacy"
+      discriminator:
+        propertyName: mode
+        mapping:
+          vpc: "#/components/schemas/DatabaseNetworkVPC"
+          legacy: "#/components/schemas/DatabaseNetworkLegacy"
+
+    DatabaseNetworkVPC:
+      type: object
+      required: [mode, vnet_id, subnet_id]
+      description: KubeOVN-managed VPC + subnet (the modern path).
+      properties:
+        mode:
+          type: string
+          enum: [vpc]
+        vnet_id:
+          type: string
+          format: uuid
+        subnet_id:
+          type: string
+          format: uuid
+
+    DatabaseNetworkLegacy:
+      type: object
+      required: [mode, nad_ref]
+      description: |
+        Pre-existing Multus NAD on a VLAN bridge. Used for environments
+        not yet migrated to KubeOVN (e.g. lk prod).
+      properties:
+        mode:
+          type: string
+          enum: [legacy]
+        nad_ref:
+          type: string
+          description: "Multus NAD as 'namespace/name'."
+          example: "default/vm-net-100"
+
+    Database:
+      type: object
+      description: |
+        A managed Database resource. Spec fields come from create-time
+        input; status fields (`status`, `message`, `endpoint_address`,
+        `endpoint_port`) are populated from the live DBInstance CR status
+        on every GET.
+      required:
+        - id
+        - tenant_id
+        - project_id
+        - name
+        - engine
+        - instance_class
+        - allocated_storage_gb
+        - network_mode
+        - status
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenant_id:
+          type: string
+        project_id:
+          type: string
+        name:
+          type: string
+        engine:
+          type: string
+          enum: [postgres]
+        engine_version:
+          type: string
+        instance_class:
+          type: string
+        allocated_storage_gb:
+          type: integer
+        network_mode:
+          type: string
+          enum: [vpc, legacy]
+        vnet_id:
+          type: string
+          format: uuid
+          description: Set only when network_mode=vpc.
+        subnet_id:
+          type: string
+          format: uuid
+          description: Set only when network_mode=vpc.
+        nad_ref:
+          type: string
+          description: Set only when network_mode=legacy.
+        status:
+          type: string
+          enum: [PENDING, ACTIVE, FAILED, DELETING]
+        message:
+          type: string
+          description: Human-readable status message from the controller.
+        endpoint_address:
+          type: string
+          description: IP or hostname clients connect to. Empty until ACTIVE.
+        endpoint_port:
+          type: integer
+          description: TCP port. Empty until ACTIVE.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    DatabaseCredentials:
+      type: object
+      description: |
+        Master user credentials for a Database. Returned exactly once on
+        the first call to `GET .../{id}/credentials`. Save them immediately;
+        dc-api will never return them again.
+      required: [username, password]
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+        ca_cert:
+          type: string
+          description: |
+            PEM-encoded CA certificate for SSL verification. Use with
+            `sslmode=verify-ca` in psql/JDBC connection strings.
 


### PR DESCRIPTION
## Summary

- **dc-api dbaas integration**: wires the dbaas Kubernetes operator into dc-api as a managed-service provider, following the same KeyVault pattern. Full CRUD REST surface for tenant-managed PostgreSQL instances, with both legacy-NAD and KubeOVN-VPC networking modes tested end-to-end on lk-dev.
- **cloud-ui Databases pages**: Databases list page, detail page, and create drawer, following the KeyVault reference pattern.

## dc-api changes

- `internal/models/database.go` — Database domain model + 12 RDS-style instance classes
- `internal/db/schema.sql` — idempotent `databases` table (shown-once credentials, updated_at trigger)
- `internal/db/database.go` — full CRUD repository (Create/Get/List/Delete/UpdateStatus/MarkCredentialsConsumed)
- `internal/providers/interface.go` — `DatabaseProvisioner` interface + request/status types
- `internal/providers/dbaas/client.go` — dynamic-client adapter; maps dbaas controller phases to dc-api canonical enum; reads `status.masterUserSecret`
- `internal/api/handlers/database.go` — Create/Get/List/Delete/Credentials handlers; two-mode network resolution (VPC subnet→NAD, legacy, default auto-pick); shown-once credentials; live CR status overlay; `vnetDNSServerIP` helper
- `internal/api/router.go` — database routes wired
- `openapi.yaml` — full database resource schema + 5 operations
- `internal/config/config.go` — `DCAPI_DBAAS_OS_IMAGE` env var
- **Fix**: per-VPC CoreDNS Corefile malformed health block (caused CrashLoopBackOff on existing VPCs)
- **Fix**: OVN MAC webhook stealing eth0 from dbaas launcher pods in VPC mode

## cloud-ui changes

- `DatabasesListPage` — table with status, engine, instance class, storage, endpoint; polls every 5s while PENDING/DELETING; delete with type-to-confirm dialog
- `DatabaseCreateDrawer` — name + instance class (Dropdown) + storage (SpinButton); wizard + review step
- `DatabaseDetailPage` — overview card; master credentials card with shown-once `SecretRevealBanner` (username, password, ca_cert); handles 410 Gone sticky state
- `SideNav` — new "Managed services" group with Databases entry
- `router.tsx` — `/databases` and `/databases/:dbId` routes wired

## Test results

**Legacy mode**: POST→201, credentials→200 then 410, DELETE→204 ✓  
**VPC mode**: endpoint 10.200.1.x, dnsServerIP set from VNet, nc connectivity from inside VPC ✓  
**TypeScript**: zero errors against generated OpenAPI types ✓  
**Go build**: `go build ./...` clean ✓