### PR TITLE
[Feature] Add a local-stack mode for fully-local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ kubeconfig
 # dcctl local state
 ~/.dcctl/
 
+# Local dev-loop overrides (per-developer cluster context/namespace/hostnames)
+scripts/dev-up.env
+
 # Terraform (if any TF files are added)
 *.tfstate
 *.tfstate.backup

--- a/cloud-ui/src/auth/RequireTenants.test.tsx
+++ b/cloud-ui/src/auth/RequireTenants.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FluentProvider } from '@fluentui/react-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import RequireTenants from './RequireTenants';
+import { AuthContext, type AuthContextValue, type AuthUser } from './context';
+import { ApiContext } from '../api/context';
+import type { ApiClient } from '../api/client';
+import { wso2LightTheme } from '../theme/themes';
+
+const ADMIN: AuthUser = {
+  sub: 'admin-sub',
+  expiresAt: '2099-01-01T00:00:00Z',
+  isAdmin: true,
+  tenants: [],
+};
+
+function authValue(user: AuthUser | null): AuthContextValue {
+  return { user, loading: false, login: () => {}, logout: async () => {} };
+}
+
+/**
+ * Fake API client whose GET('/v1/tenants') returns a fresh snapshot of
+ * whatever `tenants` holds at call time. Growing the backing array and then
+ * invalidating the query reproduces "a tenant was just registered" without
+ * touching the real BFF. The snapshot (slice) matters: a real API hands back
+ * a newly deserialized array each request, so react-query sees changed data
+ * and re-renders — returning the same mutated reference would defeat its
+ * structural sharing and mask the very transition under test.
+ */
+function makeFakeApi(tenants: unknown[]): ApiClient {
+  return {
+    GET: async (path: string) => {
+      if (path === '/v1/tenants') {
+        return { data: tenants.slice(), error: undefined, response: new Response() };
+      }
+      return { data: undefined, error: undefined, response: new Response() };
+    },
+  } as unknown as ApiClient;
+}
+
+function renderGate(client: ApiClient, queryClient: QueryClient) {
+  return render(
+    <FluentProvider theme={wso2LightTheme}>
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider value={authValue(ADMIN)}>
+          <ApiContext.Provider value={client}>
+            <MemoryRouter initialEntries={['/tenants/acme']}>
+              <Routes>
+                <Route element={<RequireTenants />}>
+                  <Route path="/tenants/:tenantId" element={<div>TENANT DASHBOARD</div>} />
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          </ApiContext.Provider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    </FluentProvider>
+  );
+}
+
+describe('RequireTenants gate', () => {
+  it('flips from the no-tenants screen to the Outlet when the tenants cache refreshes', async () => {
+    // Shared mutable backing store: starts empty (admin, zero tenants).
+    const tenants: unknown[] = [];
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    renderGate(makeFakeApi(tenants), queryClient);
+
+    // Empty → admin variant of NoTenantsPage, NOT the protected Outlet.
+    expect(await screen.findByText('No tenants registered yet')).toBeInTheDocument();
+    expect(screen.queryByText('TENANT DASHBOARD')).not.toBeInTheDocument();
+
+    // Simulate a successful registration: a tenant now exists and the dialog
+    // invalidates ['tenants'] — the same key this gate reads. No remount.
+    tenants.push({ id: 'acme', name: 'Acme', roles: ['owner'] });
+    await queryClient.invalidateQueries({ queryKey: ['tenants'] });
+
+    // Gate must flip empty → ready in place and resolve its Outlet, so the
+    // freshly registered tenant lands the user on the dashboard without a reload.
+    await waitFor(() => {
+      expect(screen.getByText('TENANT DASHBOARD')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('No tenants registered yet')).not.toBeInTheDocument();
+  });
+});

--- a/cloud-ui/src/auth/RequireTenants.tsx
+++ b/cloud-ui/src/auth/RequireTenants.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Spinner, Text, makeStyles, tokens } from '@fluentui/react-components';
-import { useEffect, useReducer, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Outlet } from 'react-router-dom';
-import { makeApiClient } from '../api/client';
+import { useApi } from '../api/useApi';
 import { useAuth } from './useAuth';
 import NoTenantsPage from '../pages/NoTenantsPage';
 
@@ -30,28 +30,6 @@ const useStyles = makeStyles({
   },
 });
 
-type GateState =
-  | { status: 'loading'; attempt: number }
-  | { status: 'error'; attempt: number }
-  | { status: 'empty'; attempt: number }
-  | { status: 'ready'; attempt: number };
-
-type GateAction =
-  | { type: 'retry' }
-  | { type: 'resolve'; tenantCount: number }
-  | { type: 'reject' };
-
-function gateReducer(state: GateState, action: GateAction): GateState {
-  switch (action.type) {
-    case 'retry':
-      return { status: 'loading', attempt: state.attempt + 1 };
-    case 'resolve':
-      return { status: action.tenantCount === 0 ? 'empty' : 'ready', attempt: state.attempt };
-    case 'reject':
-      return { status: 'error', attempt: state.attempt };
-  }
-}
-
 /**
  * Layout route that gates its children on the user having at least one
  * accessible tenant per GET /v1/tenants (DB-backed, not JWT-derived).
@@ -59,49 +37,34 @@ function gateReducer(state: GateState, action: GateAction): GateState {
  * Admins are NOT bypassed here — an admin with no tenants registered yet
  * should land on the admin variant of NoTenantsPage so they can create
  * the first tenant, not fall through to an empty TenantPickerPage.
+ *
+ * The tenant list is read through the shared react-query ['tenants'] cache —
+ * the same key TenantPickerPage and TenantSwitcher use. That coupling is
+ * deliberate: RegisterTenantDialog invalidates ['tenants'] after a successful
+ * create, which makes this gate refetch and flip empty → ready in place. So a
+ * freshly registered first tenant resolves its Outlet immediately, without the
+ * user having to reload the page.
  */
 export default function RequireTenants() {
   const styles = useStyles();
   const { user } = useAuth();
+  const api = useApi();
 
-  const [gate, dispatch] = useReducer(gateReducer, { status: 'loading', attempt: 0 });
-  const abortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    if (!user) return;
-
-    // Cancel any in-flight fetch from a previous render.
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    const client = makeApiClient();
-
-    void client
-      .GET('/v1/tenants', { signal: controller.signal } as Parameters<typeof client.GET>[1])
-      .then(({ data, response }) => {
-        if (controller.signal.aborted) return;
-        if (!response.ok) {
-          dispatch({ type: 'reject' });
-          return;
-        }
-        dispatch({ type: 'resolve', tenantCount: (data ?? []).length });
-      })
-      .catch(() => {
-        if (!controller.signal.aborted) dispatch({ type: 'reject' });
-      });
-
-    return () => {
-      controller.abort();
-    };
-    // gate.attempt drives re-fetches on retry; user drives re-fetches on login change.
-  }, [user, gate.attempt]);
+  const tenantsQuery = useQuery({
+    queryKey: ['tenants'],
+    enabled: Boolean(user),
+    queryFn: async () => {
+      const { data, error } = await api.GET('/v1/tenants');
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      return data ?? [];
+    },
+  });
 
   // RequireAuth above us already handles the loading/unauthenticated states;
   // we only render once user is non-null.
   if (!user) return null;
 
-  if (gate.status === 'loading') {
+  if (tenantsQuery.isLoading) {
     return (
       <div className={styles.loading}>
         <Spinner size="large" label="Loading tenants…" />
@@ -109,13 +72,13 @@ export default function RequireTenants() {
     );
   }
 
-  if (gate.status === 'error') {
+  if (tenantsQuery.isError) {
     return (
       <div className={styles.errorWrap}>
         <Card className={styles.errorCard}>
           <Text weight="semibold" size={500}>Could not load tenants</Text>
           <Text>There was a problem reaching the API. Check your connection and try again.</Text>
-          <Button appearance="primary" onClick={() => dispatch({ type: 'retry' })}>
+          <Button appearance="primary" onClick={() => void tenantsQuery.refetch()}>
             Retry
           </Button>
         </Card>
@@ -123,7 +86,7 @@ export default function RequireTenants() {
     );
   }
 
-  if (gate.status === 'empty') {
+  if ((tenantsQuery.data ?? []).length === 0) {
     // NoTenantsPage reads user.isAdmin internally and renders the correct variant.
     return <NoTenantsPage />;
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,9 @@ services:
       POSTGRES_PASSWORD: dc_dev_password
       POSTGRES_DB: dc_api
     ports:
-      - "5432:5432"             # reachable at localhost:5432 from DC-API on your Mac
+      # Host port is overridable via DC_PG_PORT (default 5432) so a local-stack
+      # dev DB can avoid colliding with a system Postgres already on 5432.
+      - "${DC_PG_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/docs/dev/dc-api-local-env.sh
+++ b/docs/dev/dc-api-local-env.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Source this to populate DCAPI_* env vars from a running dc-api deployment's
+# Secret + ConfigMap, so a locally-built dc-api uses the same backend config
+# (OIDC / Harvester / Rancher / KubeOVN) as the cluster — without you copying
+# any of it by hand. It then applies dev-friendly overrides: the DB URL points
+# at a port-forwarded Postgres, the listen port moves off :8080, and the log
+# level drops to debug.
+#
+# Required:
+#   DCAPI_DEV_CONTEXT   kube context of the cluster dc-api runs in
+# Optional (sensible defaults for the flux/platform layout):
+#   DCAPI_DEV_NAMESPACE   namespace dc-api is deployed in        (default: dc-system)
+#   DCAPI_DEV_SECRET      name of the dc-api Secret              (default: dc-api-secrets)
+#   DCAPI_DEV_CONFIGMAP   name of the dc-api ConfigMap           (default: dc-api-config)
+#
+# Usage (standalone):
+#   export DCAPI_DEV_CONTEXT=<your-context>
+#   source docs/dev/dc-api-local-env.sh   # then run dc-api against :15432
+# Normally you don't call this directly — scripts/dev-up.sh sources it for you.
+#
+# Companion: docs/dev/local-dc-api.md
+
+set -euo pipefail
+
+CTX="${DCAPI_DEV_CONTEXT:?set DCAPI_DEV_CONTEXT to the kube context of your dev cluster}"
+NS="${DCAPI_DEV_NAMESPACE:-dc-system}"
+SECRET="${DCAPI_DEV_SECRET:-dc-api-secrets}"
+CONFIGMAP="${DCAPI_DEV_CONFIGMAP:-dc-api-config}"
+
+ENVFILE=$(mktemp)
+trap "rm -f $ENVFILE" EXIT
+
+# Secret — base64-decode each value and emit `export KEY=<single-quoted>`.
+# Single quotes preserve newlines + special chars inside multi-line values
+# like an embedded kubeconfig. `'\''` escapes any literal single quote.
+kubectl --context "$CTX" -n "$NS" get secret "$SECRET" -o json \
+  | jq -r '.data | to_entries[] | "\(.key)\t\(.value)"' \
+  | while IFS=$'\t' read -r k v; do
+      decoded=$(printf '%s' "$v" | base64 -d)
+      escaped=$(printf '%s' "$decoded" | sed "s/'/'\\\\''/g")
+      printf "export %s='%s'\n" "$k" "$escaped" >> "$ENVFILE"
+    done
+
+# ConfigMap — same pattern, plain (non-base64) values.
+kubectl --context "$CTX" -n "$NS" get configmap "$CONFIGMAP" -o json \
+  | jq -r '.data | to_entries[] | "\(.key)\t\(.value)"' \
+  | while IFS=$'\t' read -r k v; do
+      escaped=$(printf '%s' "$v" | sed "s/'/'\\\\''/g")
+      printf "export %s='%s'\n" "$k" "$escaped" >> "$ENVFILE"
+    done
+
+source "$ENVFILE"
+
+# Dev overrides — port-forwarded Postgres, off-:8080 listen, debug logs.
+# (scripts/dev-up.sh overrides these again to suit each mode.)
+PG_PW=$(printf '%s' "$DCAPI_DB_URL" | sed -E 's|.*dc_api:([^@]+)@.*|\1|')
+export DCAPI_DB_URL="postgres://dc_api:$PG_PW@localhost:15432/dc_api?sslmode=disable"
+export DCAPI_LISTEN_ADDR=":18080"
+export DCAPI_LOG_LEVEL=debug
+
+echo "env loaded — $(env | grep -c '^DCAPI_') DCAPI_* vars from $CTX/$NS"
+echo "  DB → localhost:15432 (port-forward), listen → :18080, log → debug"

--- a/scripts/dev-up.env.example
+++ b/scripts/dev-up.env.example
@@ -1,0 +1,18 @@
+# Copy to scripts/dev-up.env (gitignored) and set your dev cluster specifics.
+# scripts/dev-up.sh sources this automatically. These let it source live
+# backend config (OIDC / Harvester / Rancher / KubeOVN) from your cluster so a
+# locally-built dc-api behaves exactly like the deployed one.
+
+# REQUIRED for `local` and `local-stack`: the kube context of your Harvester +
+# Rancher dev cluster. Find it with: kubectl config get-contexts
+export DCAPI_DEV_CONTEXT="my-dc-cluster"
+
+# Namespace dc-api is deployed in (default: dc-system — the flux/platform layout).
+# export DCAPI_DEV_NAMESPACE="dc-system"
+
+# REQUIRED for `remote`: the deployed dc-api ingress URL the cloud-ui proxies to.
+# export DCAPI_DEV_REMOTE_TARGET="https://dcapi.example.com"
+
+# Host port for the local-stack docker Postgres (default: 5433, to avoid a
+# system Postgres already on 5432).
+# export DC_PG_PORT="5433"

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,55 +1,75 @@
 #!/usr/bin/env bash
-# dev-up.sh — bring up the cloud-ui dev loop in one of two modes.
+# dev-up.sh — bring up the dc-api + cloud-ui local dev loop.
 #
-#   ./scripts/dev-up.sh local      # local dc-api + cloud-ui → talks to harvester-dev
-#   ./scripts/dev-up.sh remote     # cloud-ui only → proxies to deployed dc-api ingress
-#   ./scripts/dev-up.sh down       # tear everything down (kill bg processes)
+# The provisioning backends (Harvester, Rancher, KubeOVN, the OIDC IdP) are
+# ALWAYS a real cluster — there is no laptop-scale hypervisor. The only thing
+# that changes between modes is where the dc-api Postgres registry lives and
+# how its config is sourced.
 #
-# What each mode does:
+#   ./scripts/dev-up.sh local-stack   # RECOMMENDED daily driver.
+#       Local dc-api + cloud-ui + a LOCAL throwaway Postgres (docker compose).
+#       Backend config (OIDC / Harvester / Rancher / KubeOVN) is still sourced
+#       live from the cluster, but the registry DB is local and isolated — so
+#       schema migrations and write-heavy tests never touch the shared cluster
+#       DB and there is no reconciler race with the in-cluster dc-api pod.
 #
-#   local
-#     1. kubectl port-forward dc-postgres :15432 (background)
-#     2. build + run dc-api on :8080 with prod config sourced from the cluster
-#        Secret/ConfigMap, with these overrides:
-#          - DB URL  → localhost:15432
-#          - BFF redirect / cookie domain / post-login → localhost
-#          - LOG_LEVEL → debug
-#     3. start vite dev server with VITE_API_PROXY_TARGET=http://localhost:8080
-#     4. open http://localhost:5173
+#   ./scripts/dev-up.sh local         # Local dc-api + cloud-ui, but the DB is
+#       the CLUSTER's Postgres (port-forwarded). Use to REPRODUCE issues against
+#       real data. NOTE: shares the DB with the in-cluster dc-api pod, so both
+#       reconcile the same rows — scale the pod to 0 for exclusive write access.
 #
-#     Reads/writes the SAME dc-api postgres as prod (the prod dc-api Deployment
-#     pod is still running too — it shares the DB). Use 'scripts/dev-up.sh local
-#     --scale-down-prod' to scale the in-cluster dc-api to 0 first if you need
-#     exclusive reconciler access.
+#   ./scripts/dev-up.sh remote        # cloud-ui only → proxies to the deployed
+#       dc-api ingress. UI-only smoke tests (login lands on the deployed UI).
 #
-#   remote
-#     Just runs vite dev with the proxy pointed at the deployed ingress
-#     (https://dcapi.lk-dev.internal.wso2.com). No local dc-api. NOTE: BFF
-#     callbacks redirect to the deployed cloud-ui (cloud.lk-dev.internal.wso2.com)
-#     after login, NOT to localhost — so login from localhost in this mode
-#     lands you in the prod UI. Useful for UI-only smoke tests where the auth
-#     flow is already done, less useful for full login walk-throughs.
+#   ./scripts/dev-up.sh down          # stop the local dc-api / vite / port-forward.
+#       Leaves the local docker Postgres running so its data persists; run
+#       `docker compose down` to stop it, `down -v` to wipe it.
 #
-#   down
-#     kill background dc-api + port-forward + vite if running.
+# Configuration — point at YOUR dev cluster. Copy scripts/dev-up.env.example →
+# scripts/dev-up.env (gitignored) and set at least DCAPI_DEV_CONTEXT, or export
+# the vars in your shell:
+#   DCAPI_DEV_CONTEXT       kube context of your dev cluster   (required: local, local-stack)
+#   DCAPI_DEV_NAMESPACE     dc-api's namespace                 (default: dc-system)
+#   DCAPI_DEV_REMOTE_TARGET deployed dc-api ingress URL        (required: remote)
+#   DC_PG_PORT              host port for the local dev DB     (default: 5433)
 #
-# State files (gitignored): /tmp/sovereign-cloud-dev/*
+# State files (gitignored): /tmp/dc-dev/*
 
 set -euo pipefail
 
 REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
-STATE_DIR=/tmp/sovereign-cloud-dev
+
+# Optional, gitignored local overrides (your cluster's context, namespace, …).
+[[ -f "$REPO_ROOT/scripts/dev-up.env" ]] && source "$REPO_ROOT/scripts/dev-up.env"
+
+STATE_DIR=/tmp/dc-dev
 mkdir -p "$STATE_DIR"
 
 PGPF_PID_FILE=$STATE_DIR/pgpf.pid
 DCAPI_PID_FILE=$STATE_DIR/dc-api.pid
 VITE_PID_FILE=$STATE_DIR/vite.pid
+WATCHDOG_PID_FILE=$STATE_DIR/pgpf-watchdog.pid
 PGPF_LOG=$STATE_DIR/pgpf.log
 DCAPI_LOG=$STATE_DIR/dc-api.log
 VITE_LOG=$STATE_DIR/vite.log
 
-CTX=dcapi-controlplane-rke2
-NS=dc-system
+# Kube context + namespace the live backend config is sourced from.
+CTX="${DCAPI_DEV_CONTEXT:-}"
+NS="${DCAPI_DEV_NAMESPACE:-dc-system}"
+# Deployed dc-api ingress used by `remote` mode.
+REMOTE_API_TARGET="${DCAPI_DEV_REMOTE_TARGET:-}"
+# Host port for the local throwaway Postgres (local-stack mode). 5433 by default
+# so it doesn't collide with a system Postgres already bound to 5432.
+LOCAL_DB_PORT="${DC_PG_PORT:-5433}"
+
+require_ctx() {
+  [[ -n "$CTX" ]] || {
+    echo "error: DCAPI_DEV_CONTEXT is not set — point this at your dev cluster's kube context."
+    echo "       Copy scripts/dev-up.env.example → scripts/dev-up.env and fill it in,"
+    echo "       or: export DCAPI_DEV_CONTEXT=<context>  (see: kubectl config get-contexts)"
+    exit 1
+  }
+}
 
 stop_pid() {
   local f=$1; local name=$2
@@ -67,22 +87,84 @@ cmd_down() {
   stop_pid "$VITE_PID_FILE"   vite
   stop_pid "$DCAPI_PID_FILE"  dc-api
   # Kill the watchdog first so it doesn't relaunch the pf we're about to stop.
-  stop_pid "$STATE_DIR/pgpf-watchdog.pid" pgpf-watchdog
+  stop_pid "$WATCHDOG_PID_FILE" pgpf-watchdog
   stop_pid "$PGPF_PID_FILE"   port-forward
   # The watchdog spawned children; sweep them.
   pkill -f 'port-forward.*15432' 2>/dev/null || true
-  echo "done. logs in $STATE_DIR"
+  echo "done. local docker Postgres left running (docker compose down to stop it)."
+  echo "logs in $STATE_DIR"
 }
 
-cmd_local() {
-  # 1. postgres port-forward with auto-restart watchdog.
-  # `kubectl port-forward` drops on long HTTP/2 streams (k8s issue #74551).
-  # The watchdog re-launches it whenever the listener disappears so the dc-api
-  # pgx pool can reconnect instead of erroring out for the rest of the session.
-  WATCHDOG_PID_FILE=$STATE_DIR/pgpf-watchdog.pid
+# ── shared helpers ───────────────────────────────────────────────────────────
+
+build_dcapi() {
+  echo "  building dc-api → /tmp/dc-api-local"
+  ( cd "$REPO_ROOT/dc-api" && go build -o /tmp/dc-api-local ./cmd/dc-api/ )
+}
+
+# Source the live cluster Secret + ConfigMap into DCAPI_* env vars. (The sourced
+# script also points DCAPI_DB_URL at the port-forwarded cluster DB and sets a
+# debug log level; callers that want a different DB override DCAPI_DB_URL after.)
+load_cluster_env() {
+  source "$REPO_ROOT/docs/dev/dc-api-local-env.sh"
+}
+
+# Overrides shared by every local mode: listen on :8080 and rewrite the BFF
+# OIDC redirect/cookie settings for localhost. Requires the cloud-ui BFF OIDC
+# app to allow http://localhost:8080/v1/auth/callback as a redirect URI.
+apply_localhost_overrides() {
+  export DCAPI_LISTEN_ADDR=":8080"
+  export DCAPI_BFF_REDIRECT_URL="http://localhost:8080/v1/auth/callback"
+  export DCAPI_BFF_POST_LOGIN_REDIRECT="http://localhost:5173/"
+  export DCAPI_BFF_POST_LOGOUT_REDIRECT="http://localhost:5173/login"
+  export DCAPI_BFF_COOKIE_DOMAIN="localhost"
+  export DCAPI_BFF_COOKIE_SECURE="false"
+}
+
+run_dcapi() {
+  stop_pid "$DCAPI_PID_FILE" dc-api
+  echo "  starting dc-api on :8080 (log → $DCAPI_LOG)"
+  nohup /tmp/dc-api-local > "$DCAPI_LOG" 2>&1 &
+  echo $! > "$DCAPI_PID_FILE"
+  # health-check — kubeovn F15 bootstrap against Harvester can take 10-15s.
+  echo -n "  waiting for dc-api health"
+  for i in $(seq 1 30); do
+    sleep 1
+    if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+      echo " — ready"
+      return 0
+    fi
+    echo -n "."
+  done
+  echo ""
+  echo "  dc-api never came up; see $DCAPI_LOG"
+  tail -30 "$DCAPI_LOG"
+  exit 1
+}
+
+start_vite() {
+  stop_pid "$VITE_PID_FILE" vite
+  echo "  starting cloud-ui (vite) → http://localhost:5173"
+  ( cd "$REPO_ROOT/cloud-ui" && \
+    VITE_API_PROXY_TARGET=http://localhost:8080 \
+    nohup pnpm dev > "$VITE_LOG" 2>&1 & echo $! > "$VITE_PID_FILE" )
+  for i in $(seq 1 15); do
+    sleep 1
+    if curl -sf http://localhost:5173/ > /dev/null 2>&1; then
+      echo "  vite ready"
+      break
+    fi
+  done
+}
+
+# Postgres port-forward (cluster DB) with an auto-restart watchdog.
+# `kubectl port-forward` drops on long HTTP/2 streams (k8s issue #74551); the
+# watchdog re-launches it so the dc-api pgx pool can reconnect.
+start_pg_portforward() {
+  require_ctx
   stop_pid "$WATCHDOG_PID_FILE" pgpf-watchdog
   stop_pid "$PGPF_PID_FILE" port-forward
-  echo "[1/3] starting postgres port-forward → :15432 (with auto-restart)"
+  echo "  starting postgres port-forward → :15432 (with auto-restart)"
   (
     while true; do
       kubectl --context "$CTX" -n "$NS" port-forward svc/dc-postgres 15432:5432 \
@@ -97,81 +179,119 @@ cmd_local() {
     nc -z localhost 15432 2>/dev/null && break
   done
   nc -z localhost 15432 2>/dev/null || { echo "  port-forward failed; see $PGPF_LOG"; exit 1; }
+}
 
-  # 2. build + run dc-api
-  echo "[2/3] building dc-api → /tmp/dc-api-local"
-  ( cd "$REPO_ROOT/dc-api" && go build -o /tmp/dc-api-local ./cmd/dc-api/ )
-
-  # Source the live cluster Secret+ConfigMap as DCAPI_* env vars. Then override
-  # the BFF + DB + listen + log to point at localhost.
-  source "$REPO_ROOT/docs/dev/dc-api-local-env.sh"
-  export DCAPI_LISTEN_ADDR=":8080"
-  # BFF localhost overrides — requires that the cloud_ui_bff Asgardeo app
-  # has http://localhost:8080/v1/auth/callback registered as an allowed
-  # redirect URI. If login redirects to "Invalid redirect URI", add it via
-  # the Asgardeo console (Apps → cloud_ui_bff → Protocol → Allowed origins).
-  export DCAPI_BFF_REDIRECT_URL="http://localhost:8080/v1/auth/callback"
-  export DCAPI_BFF_POST_LOGIN_REDIRECT="http://localhost:5173/"
-  export DCAPI_BFF_POST_LOGOUT_REDIRECT="http://localhost:5173/login"
-  export DCAPI_BFF_COOKIE_DOMAIN="localhost"
-  export DCAPI_BFF_COOKIE_SECURE="false"
-
-  # kill any stale local dc-api on :8080
-  stop_pid "$DCAPI_PID_FILE" dc-api
-  echo "  starting dc-api on :8080 (log → $DCAPI_LOG)"
-  nohup /tmp/dc-api-local > "$DCAPI_LOG" 2>&1 &
-  echo $! > "$DCAPI_PID_FILE"
-
-  # health-check — kubeovn bootstrap can take 10-15s on first start
-  echo -n "  waiting for dc-api health"
+# Local throwaway Postgres via docker compose, on $LOCAL_DB_PORT.
+ensure_local_postgres() {
+  echo "  starting local postgres → :${LOCAL_DB_PORT} (docker compose)"
+  # docker-compose pins container_name: dc-postgres. If a stale, NON-running
+  # container with that name exists (e.g. from another compose project), remove
+  # it so our compose can claim the name. A running one is left as-is.
+  if docker ps -a --format '{{.Names}}' | grep -qx dc-postgres \
+     && ! docker ps --format '{{.Names}}' | grep -qx dc-postgres; then
+    docker rm dc-postgres >/dev/null 2>&1 || true
+  fi
+  ( cd "$REPO_ROOT" && DC_PG_PORT="$LOCAL_DB_PORT" docker compose up -d postgres )
+  echo -n "  waiting for postgres"
   for i in $(seq 1 30); do
-    sleep 1
-    if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+    if docker exec dc-postgres pg_isready -U dc_api >/dev/null 2>&1; then
       echo " — ready"
-      break
+      return 0
     fi
     echo -n "."
-  done
-  curl -sf http://localhost:8080/healthz > /dev/null 2>&1 || {
-    echo ""; echo "  dc-api never came up; see $DCAPI_LOG"; tail -30 "$DCAPI_LOG"; exit 1; }
-
-  # 3. vite dev server
-  stop_pid "$VITE_PID_FILE" vite
-  echo "[3/3] starting cloud-ui (vite) → http://localhost:5173"
-  ( cd "$REPO_ROOT/cloud-ui" && \
-    VITE_API_PROXY_TARGET=http://localhost:8080 \
-    nohup pnpm dev > "$VITE_LOG" 2>&1 & echo $! > "$VITE_PID_FILE" )
-
-  for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 1
-    if curl -sf http://localhost:5173/ > /dev/null 2>&1; then
-      echo "  vite ready"
-      break
-    fi
   done
+  echo ""
+  echo "  postgres did not become ready; see: docker compose logs postgres"
+  exit 1
+}
+
+# ── modes ────────────────────────────────────────────────────────────────────
+
+cmd_local_stack() {
+  require_ctx
+  echo "[1/3] local postgres (isolated dev DB)"
+  ensure_local_postgres
+
+  echo "[2/3] dc-api (local DB, real cluster backends)"
+  build_dcapi
+  load_cluster_env
+  # Override the DB → local docker Postgres. Everything else (OIDC, Harvester,
+  # Rancher, KubeOVN) stays as sourced from the cluster.
+  export DCAPI_DB_URL="postgres://dc_api:dc_dev_password@localhost:${LOCAL_DB_PORT}/dc_api?sslmode=disable"
+  apply_localhost_overrides
+  run_dcapi
+
+  echo "[3/3] cloud-ui"
+  start_vite
 
   cat <<EOF
 
-=== ready ===
+=== ready — local-stack (isolated local DB) ===
   cloud-ui   http://localhost:5173
-  dc-api     http://localhost:8080  (BFF → /v1/auth/login)
-  postgres   localhost:15432 → dc_api (prod DB via port-forward)
+  dc-api     http://localhost:8080   (BFF → /v1/auth/login, docs → /docs)
+  postgres   localhost:${LOCAL_DB_PORT} → dc_api  (LOCAL docker volume, NOT the cluster)
 
-  logs       $STATE_DIR/{pgpf,dc-api,vite}.log
-  stop       $REPO_ROOT/scripts/dev-up.sh down
+  backends   Harvester / Rancher / KubeOVN / OIDC = the cluster ($CTX)
+
+  First run? The local DB is empty. Seed a tenant + project:
+    dcctl login
+    dcctl admin tenant create acme --cpu 32 --memory 64 --storage 500
+    dcctl tenant set acme && dcctl project create dev --cpu 8 --memory 16 --storage 100
+
+  logs   $STATE_DIR/{dc-api,vite}.log
+  stop   $REPO_ROOT/scripts/dev-up.sh down     (keeps the local DB)
+         docker compose down                    (stops the DB, keeps its data)
+         docker compose down -v                 (wipes the DB)
+
+EOF
+}
+
+cmd_local() {
+  echo "[1/3] postgres port-forward (CLUSTER DB — shared with the in-cluster pod)"
+  start_pg_portforward
+
+  echo "[2/3] dc-api (cluster DB via port-forward)"
+  build_dcapi
+  load_cluster_env   # sets DCAPI_DB_URL → localhost:15432 (the port-forward)
+  apply_localhost_overrides
+  run_dcapi
+
+  echo "[3/3] cloud-ui"
+  start_vite
+
+  cat <<EOF
+
+=== ready — local (CLUSTER DB via port-forward) ===
+  cloud-ui   http://localhost:5173
+  dc-api     http://localhost:8080   (BFF → /v1/auth/login, docs → /docs)
+  postgres   localhost:15432 → dc_api  (the CLUSTER's DB — shared with the pod)
+
+  ⚠ The in-cluster dc-api pod reconciles this same DB. For exclusive write
+    testing, scale it down first:
+      kubectl --context $CTX -n $NS scale deploy/dc-api --replicas=0
+    (and back up with --replicas=1 when done).
+
+  logs   $STATE_DIR/{pgpf,dc-api,vite}.log
+  stop   $REPO_ROOT/scripts/dev-up.sh down
 
 EOF
 }
 
 cmd_remote() {
-  echo "[remote] starting cloud-ui only → proxies to https://dcapi.lk-dev.internal.wso2.com"
+  [[ -n "$REMOTE_API_TARGET" ]] || {
+    echo "error: DCAPI_DEV_REMOTE_TARGET is not set — set it to your deployed dc-api ingress URL"
+    echo "       (e.g. export DCAPI_DEV_REMOTE_TARGET=https://dcapi.example.com)"
+    exit 1
+  }
+  echo "[remote] starting cloud-ui only → proxies to $REMOTE_API_TARGET"
   echo "         NOTE: BFF callback after login redirects to the deployed cloud-ui,"
-  echo "         not localhost. For full local login flow use 'local' mode."
+  echo "         not localhost. For a full local login flow use 'local-stack'."
   stop_pid "$VITE_PID_FILE" vite
   ( cd "$REPO_ROOT/cloud-ui" && \
-    VITE_API_PROXY_TARGET=https://dcapi.lk-dev.internal.wso2.com \
+    VITE_API_PROXY_TARGET="$REMOTE_API_TARGET" \
     nohup pnpm dev > "$VITE_LOG" 2>&1 & echo $! > "$VITE_PID_FILE" )
-  for i in 1 2 3 4 5 6 7 8 9 10; do
+  for i in $(seq 1 15); do
     sleep 1
     if curl -sf http://localhost:5173/ > /dev/null 2>&1; then
       echo "  vite ready → http://localhost:5173"
@@ -181,11 +301,16 @@ cmd_remote() {
 }
 
 case "${1:-}" in
-  local)  cmd_local  ;;
-  remote) cmd_remote ;;
-  down)   cmd_down   ;;
+  local-stack) cmd_local_stack ;;
+  local)       cmd_local       ;;
+  remote)      cmd_remote      ;;
+  down)        cmd_down        ;;
   *)
-    echo "usage: $0 {local|remote|down}"
+    echo "usage: $0 {local-stack|local|remote|down}"
+    echo "  local-stack  local dc-api + cloud-ui + LOCAL docker Postgres (daily driver)"
+    echo "  local        local dc-api + cloud-ui against the CLUSTER DB (issue repro)"
+    echo "  remote       cloud-ui only, proxied to the deployed dc-api ingress"
+    echo "  down         stop local dc-api / vite / port-forward"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## What

Adds a `local-stack` mode to `scripts/dev-up.sh` — a fully-local dev loop (local Postgres + local dc-api + cloud-ui) that talks to the real cluster backends but uses an isolated local database.

## Why

This is the fast inner loop for control-plane work: edit Go/TSX, rebuild locally in seconds, click through the UI — without waiting on the image-build → publish → Flux-reconcile outer loop. Using an isolated local DB (instead of the cluster's) means schema migrations and write-heavy tests never touch the shared cluster registry, and there's no reconciler race with the in-cluster dc-api pod.

The provisioning backends (Harvester, Rancher, KubeOVN, the OIDC IdP) are always the real cluster — there is no laptop-scale hypervisor — so only the registry DB is local.

## Modes

| Mode | DB | Use |
|---|---|---|
| `local-stack` (new) | local docker Postgres | daily driver; safe migrations + writes |
| `local` | cluster DB (port-forward) | reproduce issues against real data |
| `remote` | — | cloud-ui only, proxied to a deployed dc-api |

## Changes

- `scripts/dev-up.sh`: add `local-stack`; factor shared steps into helpers; parametrize the per-developer cluster context / namespace / remote ingress via env, sourced from a gitignored `scripts/dev-up.env`.
- `scripts/dev-up.env.example`: documented template for those values.
- `docker-compose.yaml`: make the host Postgres port overridable via `DC_PG_PORT` (default `5432`) so the local DB can avoid a system Postgres on 5432.
- `docs/dev/dc-api-local-env.sh`: generic helper that loads a dc-api deployment's Secret + ConfigMap into `DCAPI_*` env vars.
- `.gitignore`: ignore the per-developer `scripts/dev-up.env`.

No datacenter-internal specifics — anyone can point it at their own cluster via `scripts/dev-up.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
