### PR TITLE
[Chore] Add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,75 @@
+name: "🐞 Report a Bug"
+description: Something does not work as expected.
+labels: ["Type/Bug"]
+title: "[Bug]: "
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please search existing issues
+        first to avoid duplicates, and do **not** include secrets, tokens, or
+        kubeconfigs in logs you paste below.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the platform is affected?
+      options:
+        - Control Plane (dc-api)
+        - Cloud UI
+        - CLI (dcctl)
+        - Terraform Modules
+        - Operators
+        - Docs
+        - Other
+      multiple: false
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the problem, including any error output or logs.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the steps you followed when you encountered the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: false
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How badly does this affect you?
+      options:
+        - Severity/Blocker
+        - Severity/Critical
+        - Severity/Major
+        - Severity/Minor
+        - Severity/Trivial
+      multiple: false
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / Commit
+      description: The release tag, image tag, or git commit of the affected component(s).
+      placeholder: "e.g. dc-api v0.4.2, cloud-ui @ a1b2c3d"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/02-improvement.yml
@@ -1,0 +1,36 @@
+name: "🚀 Improvement"
+description: Suggest an improvement to existing functionality.
+labels: ["Type/Improvement"]
+title: "[Improvement]: "
+
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the platform does this relate to?
+      options:
+        - Control Plane (dc-api)
+        - Cloud UI
+        - CLI (dcctl)
+        - Terraform Modules
+        - Operators
+        - Docs
+        - Other
+      multiple: false
+    validations:
+      required: true
+  - type: textarea
+    id: limitation
+    attributes:
+      label: Current Limitation
+      description: Describe the current behavior and why it falls short.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: Describe the improvement you would like to see.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/03-task.yml
+++ b/.github/ISSUE_TEMPLATE/03-task.yml
@@ -1,0 +1,36 @@
+name: "✍️ Task"
+description: Track a concrete unit of work.
+labels: ["Type/Task"]
+title: "[Task]: "
+
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the platform does this task touch?
+      options:
+        - Control Plane (dc-api)
+        - Cloud UI
+        - CLI (dcctl)
+        - Terraform Modules
+        - Operators
+        - Docs
+        - Other
+      multiple: false
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what needs to be done.
+    validations:
+      required: true
+  - type: input
+    id: related
+    attributes:
+      label: Related Issues
+      description: Link any related issues or epics (e.g. "Part of #123").
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04-epic.yml
+++ b/.github/ISSUE_TEMPLATE/04-epic.yml
@@ -1,0 +1,37 @@
+name: "📁 Epic"
+description: Track a large body of work that spans multiple issues.
+labels: ["Type/Epic"]
+title: "[Epic]: "
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the epic and the problem it solves.
+    validations:
+      required: true
+  - type: textarea
+    id: goals
+    attributes:
+      label: Goals / Scope
+      description: What is in scope for this epic, and what is explicitly out of scope?
+    validations:
+      required: false
+  - type: textarea
+    id: children
+    attributes:
+      label: Child Issues / Tasks
+      description: Checklist of the issues that make up this epic.
+      placeholder: |
+        - [ ] #123
+        - [ ] #124
+    validations:
+      required: false
+  - type: input
+    id: designdoc
+    attributes:
+      label: Design Document
+      description: Link to the design document, if one exists.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# Set to false to require every new issue to use one of the forms above.
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/wso2/open-cloud-datacenter/security/advisories/new
+    about: Please report security issues privately via a draft advisory — do not open a public issue.


### PR DESCRIPTION
## Summary

Adds structured GitHub issue forms under `.github/ISSUE_TEMPLATE/` so issues are filed with consistent, triage-ready fields. The forms are adapted from the WSO2 consumer project's templates and genericized for this public repository.

Closes #127

## Templates

- **01-bug** — Area · Description · Steps to Reproduce · Expected Behavior · Severity · Version/Commit
- **02-improvement** — Area · Current Limitation · Suggested Improvement
- **03-task** — Area · Description · Related Issues
- **04-epic** — Description · Goals/Scope · Child Issues checklist · Design Document
- **config.yml** — routes security reports to a private GitHub advisory (Discussions is disabled on this repo, so no Discussions link)

## Genericization for public

- Removed the internal project-board reference (`projects: [...]`) and internal environment names.
- Retargeted the `area` dropdown to this repository's own components: dc-api, cloud-ui, dcctl, Terraform, operators, docs — no Harvester/Rancher, which live in their own orgs/repos.
- Skipped the consumer-only change-request template.

## Labels

Each form auto-applies its `Type/*` label (all already present). Alongside this PR the label taxonomy was rounded out in repo settings — `Area/*` component routing to match the dropdown, plus `Type/Security`, `Type/Refactor`, `Breaking Change`, `Relationship/Dependency`/`Dependent`, `Help Wanted`, `Needs Discussion`, and `dependencies` — drawing on the conventions in `thunder-id` and `openchoreo`. Labels are repository metadata, not files, so they aren't part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
