### PR TITLE
[Fix] Make ImagePolicy timestamp tags sort numerically

### DIFF
--- a/flux/platform/cloud-ui/base/image-automation.yaml
+++ b/flux/platform/cloud-ui/base/image-automation.yaml
@@ -22,7 +22,7 @@ spec:
   # ../dc-api/base/image-automation.yaml for the full rationale on why
   # alphabetical-sort of hex SHAs was broken.
   filterTags:
-    pattern: '^(?P<ts>\d{8}-\d{6})-[a-f0-9]+$'
-    extract: '$ts'
+    pattern: '^(?P<ts>\d{8})-(?P<tm>\d{6})-[a-f0-9]+$'
+    extract: '$ts$tm'
   policy:
     numerical: { order: asc }

--- a/flux/platform/dc-api/base/image-automation.yaml
+++ b/flux/platform/dc-api/base/image-automation.yaml
@@ -27,15 +27,15 @@ spec:
   imageRepositoryRef:
     name: dc-api
   # Filter on the timestamp-prefixed tag format that the OCD workflows
-  # publish: <YYYYMMDD>-<HHMMSS>-<git-sha>. The ts capture group extracts
-  # 14 decimal digits we then sort numerically — picks the most recently
+  # publish: <YYYYMMDD>-<HHMMSS>-<git-sha>. The date and time capture groups
+  # concatenate to 14 decimal digits we then sort numerically — picks the most recently
   # built image. Bare-SHA tags (the previous format) are deliberately NOT
   # matched here; alphabetical-sort of hex SHAs is meaningless and
   # previously pinned us on whatever SHA happened to start with "ff",
   # missing every newer build.
   filterTags:
-    pattern: '^(?P<ts>\d{8}-\d{6})-[a-f0-9]+$'
-    extract: '$ts'
+    pattern: '^(?P<ts>\d{8})-(?P<tm>\d{6})-[a-f0-9]+$'
+    extract: '$ts$tm'
   policy:
     numerical:
       order: asc


### PR DESCRIPTION
## Summary

The `dc-api` and `cloud-ui` `ImagePolicy` resources sort the `<YYYYMMDD>-<HHMMSS>` timestamp prefix **numerically** to pick the newest image — but the extract kept the hyphen (`20260528-153652`), which `image-reflector-controller` can't parse:

```
ImagePolicy/dc-api  Ready=False: failed to parse invalid numeric value '20260528-153652'
```

So the policy never resolves a `latestImage` → Image Update Automation never bumps the tag, **and** any Kustomization that health-checks these ImagePolicies (e.g. a consumer `platform` Kustomization) times out reconciling indefinitely. Images build and push but never deploy.

Closes #131

## Fix

Capture date and time as separate groups and concatenate, so the extract is 14 pure digits:

```yaml
filterTags:
  pattern: '^(?P<ts>\d{8})-(?P<tm>\d{6})-[a-f0-9]+$'
  extract: '$ts$tm'        # "20260528153652"
policy:
  numerical: { order: asc }
```

Verified: the new pattern extracts `20260530101500` (parses as an int) for a sample `20260530-101500-<sha>` tag.

## Rollout

Consumers that track `flux/platform?ref=controlplane` pick this up automatically — the ImagePolicy resolves the latest tag → IUA bumps the overlay `newTag` → the stuck `platform` health check passes → `dc-api`/`cloud-ui` roll forward to the newest build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
