### PR TITLE
[Fix] Repair integration suite (node-pool compile + tenant slugs)

### DIFF
--- a/dc-api/test/integration/cluster_steve_test.go
+++ b/dc-api/test/integration/cluster_steve_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers/harvester"
 	"github.com/wso2/dc-api/internal/providers/rancher"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -278,7 +279,15 @@ func TestClusterSteve_FullLifecycle_LiveCluster(t *testing.T) {
 		NodeMemoryGB: 8,
 		NodeDiskGB:   60,
 		NodeImage:    imageID,
-		NodeCount:    1,
+		// SystemPool is required since the AKS-style multi-pool refactor; the flat
+		// NodeCPU/MemoryGB/DiskGB above carry its resolved compute.
+		SystemPool: &models.NodePool{
+			Name:                "system",
+			Role:                models.NodePoolRoleSystem,
+			Size:                "medium",
+			Count:               1,
+			HarvesterConfigName: "nc-" + clusterName + "-system",
+		},
 		// No TenantSubnetNAD for this test — we use the legacy single-NIC path
 		// because setting up a live VNet + Subnet within the test would require
 		// the full networking stack. The SA bootstrap skips when TenantSubnetNAD

--- a/dc-api/test/integration/env_test.go
+++ b/dc-api/test/integration/env_test.go
@@ -629,6 +629,26 @@ func (n *nopClusterProvider) GetKubeconfig(_ context.Context, _ string) (string,
 	return "", fmt.Errorf("nop")
 }
 
+// AKS-style node-pool methods. The integration twin of the contract-test fix in
+// commit 6be7d15: the multi-pool refactor grew the ClusterProvider interface but
+// this nop was missed (integration tests aren't in CI). All return the nop error
+// — never invoked by the suites that use this provider.
+func (n *nopClusterProvider) AddNodePool(_ context.Context, _ string, _ *models.NodePool, _, _, _, _ string) error {
+	return fmt.Errorf("nop")
+}
+func (n *nopClusterProvider) ScaleNodePool(_ context.Context, _, _ string, _ int) error {
+	return fmt.Errorf("nop")
+}
+func (n *nopClusterProvider) UpdateNodePoolTaintsLabels(_ context.Context, _, _ string, _ []models.NodePoolTaint, _ map[string]string) error {
+	return fmt.Errorf("nop")
+}
+func (n *nopClusterProvider) RemoveNodePool(_ context.Context, _, _, _ string) error {
+	return fmt.Errorf("nop")
+}
+func (n *nopClusterProvider) GetNodePoolStatuses(_ context.Context, _ string) (map[string]models.NodePoolStatus, error) {
+	return nil, fmt.Errorf("nop")
+}
+
 // Compile-time interface checks.
 var _ providers.ComputeProvider = &nopComputeProvider{}
 var _ providers.ClusterProvider = &nopClusterProvider{}

--- a/dc-api/test/integration/fixtures.go
+++ b/dc-api/test/integration/fixtures.go
@@ -25,6 +25,23 @@ func randomName(suffix string) string {
 	return fmt.Sprintf("test-%x-%s", b, suffix)
 }
 
+// randomTenantID returns a unique tenant slug for tests that satisfies the
+// production tenant-id validation `^[a-z][a-z0-9-]{0,30}[a-z0-9]$` (max 32
+// chars). randomName() can't be used for tenants: its `test-<8hex>-<suffix>`
+// form, concatenated after a descriptive prefix, overflows 32 chars and is
+// rejected with HTTP 400. The "test-" prefix is preserved (cleanup and the
+// HasPrefix helpers rely on it); the label is truncated and the random token
+// kept to 6 hex chars so the total never exceeds 32.
+func randomTenantID(label string) string {
+	b := make([]byte, 3)
+	_, _ = rand.Read(b)
+	const maxLabel = 32 - len("test-") - len("-") - 6 // 20
+	if len(label) > maxLabel {
+		label = label[:maxLabel]
+	}
+	return fmt.Sprintf("test-%s-%x", label, b)
+}
+
 // defaultProjectID is the project slug created by clientForTenant for every
 // test tenant. Tests that don't care about project granularity use this.
 const defaultProjectID = "default"

--- a/dc-api/test/integration/option_d_test.go
+++ b/dc-api/test/integration/option_d_test.go
@@ -57,8 +57,8 @@ func TestOptionD_PlatformAdminSubsPromotesWithoutGroup(t *testing.T) {
 	envAdminSub := "sub-env-admin-" + suffix
 	subEnv := optionDSubEnv(t, envAdminSub)
 
-	tenantA := "test-optd-env-a-" + suffix
-	tenantB := "test-optd-env-b-" + suffix
+	tenantA := randomTenantID("optd-env-a")
+	tenantB := randomTenantID("optd-env-b")
 	insertRole(t, subEnv, "seed-a-"+suffix, tenantA, models.RoleOwner)
 	insertRole(t, subEnv, "seed-b-"+suffix, tenantB, models.RoleMember)
 
@@ -92,7 +92,7 @@ func TestOptionD_DisplayAliasRoundTrip(t *testing.T) {
 	t.Parallel()
 	subEnv := optionDSubEnv(t)
 
-	tenantID := "test-optd-alias-" + randomName("t")
+	tenantID := randomTenantID("optd-alias")
 	ownerSub := "sub-optd-alias-owner-" + randomName("u")
 	inviteeSub := "sub-optd-alias-invitee-" + randomName("u")
 	alias := "alice-laptop"
@@ -134,7 +134,7 @@ func TestOptionD_InviteUpsertsTenantsRegistry(t *testing.T) {
 	adminSub := "sub-optd-inv-admin-" + suffix
 	subEnv := optionDSubEnv(t, adminSub)
 
-	tenantID := "test-optd-inv-reg-" + suffix
+	tenantID := randomTenantID("optd-inv-reg")
 	ownerSub := "sub-optd-inv-owner-" + suffix
 	inviteeSub := "sub-optd-inv-invitee-" + suffix
 

--- a/dc-api/test/integration/rbac_members_test.go
+++ b/dc-api/test/integration/rbac_members_test.go
@@ -35,7 +35,7 @@ func TestMembers_OwnerCanInviteAndList(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-members-invite-" + randomName("t")
+	tenantID := randomTenantID("members-invite")
 	ownerSub := "sub-owner-invite-" + randomName("u")
 	inviteeSub := "sub-invitee-" + randomName("u")
 
@@ -90,7 +90,7 @@ func TestMembers_MemberCannotInvite(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-members-noinvite-" + randomName("t")
+	tenantID := randomTenantID("members-noinvite")
 	memberSub := "sub-member-noinvite-" + randomName("u")
 	someUserSub := "sub-target-" + randomName("u")
 
@@ -113,7 +113,7 @@ func TestMembers_OwnerCanRemoveOtherMember(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-members-remove-" + randomName("t")
+	tenantID := randomTenantID("members-remove")
 	ownerSub := "sub-owner-remove-" + randomName("u")
 	inviteeSub := "sub-invitee-remove-" + randomName("u")
 
@@ -150,7 +150,7 @@ func TestMembers_CannotRemoveLastOwner(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-members-lastowner-" + randomName("t")
+	tenantID := randomTenantID("members-lastowner")
 	ownerSub := "sub-owner-last-" + randomName("u")
 
 	insertRole(t, subEnv, ownerSub, tenantID, models.RoleOwner)
@@ -179,7 +179,7 @@ func TestMembers_InviteDuplicateReturnsConflict(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-members-dup-" + randomName("t")
+	tenantID := randomTenantID("members-dup")
 	ownerSub := "sub-owner-dup-" + randomName("u")
 	inviteeSub := "sub-invitee-dup-" + randomName("u")
 
@@ -209,8 +209,8 @@ func TestMembers_CrossTenantOpsReturn404(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantA := "test-tenant-a-xcomp-" + randomName("t")
-	tenantB := "test-tenant-b-xcomp-" + randomName("t")
+	tenantA := randomTenantID("xcomp-a")
+	tenantB := randomTenantID("xcomp-b")
 	ownerSub := "sub-owner-xcomp-" + randomName("u")
 
 	insertRole(t, subEnv, ownerSub, tenantA, models.RoleOwner)
@@ -246,7 +246,7 @@ func TestMembers_ListExcludesServiceAccounts(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-members-nosa-" + randomName("t")
+	tenantID := randomTenantID("members-nosa")
 	ownerSub := "sub-owner-nosa-" + randomName("u")
 
 	insertRole(t, subEnv, ownerSub, tenantID, models.RoleOwner)

--- a/dc-api/test/integration/rbac_service_account_api_test.go
+++ b/dc-api/test/integration/rbac_service_account_api_test.go
@@ -96,7 +96,7 @@ func memberClientForSATests(t *testing.T, tenantID string) *APIClient {
 //   - The captured token can authenticate a real API call (GET /v1/vnets → 200).
 func TestServiceAccountAPI_OwnerCanCreate_GetTokenOnce(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-api-create-" + randomName("t")
+	tenantID := randomTenantID("sa-api-create")
 	owner := ownerClientForSATests(t, tenantID)
 	ctx := context.Background()
 
@@ -142,7 +142,7 @@ func TestServiceAccountAPI_OwnerCanCreate_GetTokenOnce(t *testing.T) {
 // receives 403 when attempting to create a service account.
 func TestServiceAccountAPI_MemberCannotCreate(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-api-member-create-" + randomName("t")
+	tenantID := randomTenantID("sa-api-mbr-create")
 	member := memberClientForSATests(t, tenantID)
 	ctx := context.Background()
 
@@ -158,7 +158,7 @@ func TestServiceAccountAPI_MemberCannotCreate(t *testing.T) {
 //   - GET list → 2 items, no "token" or "token_hash" in any item.
 func TestServiceAccountAPI_OwnerCanList_ExcludesTokenFields(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-api-list-" + randomName("t")
+	tenantID := randomTenantID("sa-api-list")
 	owner := ownerClientForSATests(t, tenantID)
 	ctx := context.Background()
 
@@ -194,7 +194,7 @@ func TestServiceAccountAPI_OwnerCanList_ExcludesTokenFields(t *testing.T) {
 // two SAs with the same name in the same tenant returns 409.
 func TestServiceAccountAPI_DuplicateNameReturnsConflict(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-api-dup-" + randomName("t")
+	tenantID := randomTenantID("sa-api-dup")
 	owner := ownerClientForSATests(t, tenantID)
 	ctx := context.Background()
 
@@ -214,7 +214,7 @@ func TestServiceAccountAPI_DuplicateNameReturnsConflict(t *testing.T) {
 //   - The captured token no longer authenticates → 401.
 func TestServiceAccountAPI_OwnerCanDelete_TokenStopsWorking(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-api-delete-" + randomName("t")
+	tenantID := randomTenantID("sa-api-delete")
 	owner := ownerClientForSATests(t, tenantID)
 	ctx := context.Background()
 
@@ -250,8 +250,8 @@ func TestServiceAccountAPI_OwnerCanDelete_TokenStopsWorking(t *testing.T) {
 // tenant A cannot POST / GET / DELETE service accounts on tenant B's namespace.
 func TestServiceAccountAPI_CrossTenantOpsReturn404(t *testing.T) {
 	t.Parallel()
-	tenantA := "test-sa-api-cross-a-" + randomName("t")
-	tenantB := "test-sa-api-cross-b-" + randomName("t")
+	tenantA := randomTenantID("sa-api-cross-a")
+	tenantB := randomTenantID("sa-api-cross-b")
 
 	ownerA := ownerClientForSATests(t, tenantA)
 	ownerB := ownerClientForSATests(t, tenantB)
@@ -289,7 +289,7 @@ func TestServiceAccountAPI_CrossTenantOpsReturn404(t *testing.T) {
 // the transactional delete is exercised correctly.
 func TestServiceAccountAPI_DeleteRemovesRoleAssignments(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-api-del-ra-" + randomName("t")
+	tenantID := randomTenantID("sa-api-del-ra")
 	owner := ownerClientForSATests(t, tenantID)
 	ctx := context.Background()
 

--- a/dc-api/test/integration/rbac_service_account_test.go
+++ b/dc-api/test/integration/rbac_service_account_test.go
@@ -141,7 +141,7 @@ func clientForServiceAccount(t *testing.T, tenantID string, role models.Role) (*
 // owner role can list, create, and delete VNets.
 func TestRBAC_ServiceAccount_OwnerCanDoEverything(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-owner-" + randomName("t")
+	tenantID := randomTenantID("sa-owner")
 	if !strings.HasPrefix(tenantID, "test-") {
 		tenantID = "test-" + tenantID
 	}
@@ -179,7 +179,7 @@ func TestRBAC_ServiceAccount_OwnerCanDoEverything(t *testing.T) {
 // member role can create but not delete VNets.
 func TestRBAC_ServiceAccount_MemberCannotDelete(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-member-" + randomName("t")
+	tenantID := randomTenantID("sa-member")
 	if !strings.HasPrefix(tenantID, "test-") {
 		tenantID = "test-" + tenantID
 	}
@@ -226,7 +226,7 @@ func TestRBAC_ServiceAccount_InvalidTokenReturns401(t *testing.T) {
 	// ── Valid format but wrong secret → 401 ──────────────────────────────────
 	// Create a real SA, then send a token with the correct lookup_id but a
 	// corrupted secret. The bcrypt comparison will fail.
-	tenantID := "test-sa-invalid-" + randomName("t")
+	tenantID := randomTenantID("sa-invalid")
 	// Generate a token solely for its lookup_id; we will NOT use the matching secret.
 	_, lookupID, _ := generateSAToken(t)
 	tokenHash := hashSecret(t, "correct-secret-that-we-will-not-send")
@@ -265,7 +265,7 @@ func TestRBAC_ServiceAccount_InvalidTokenReturns401(t *testing.T) {
 // SA request, the last_used column is set to a non-nil, recent timestamp.
 func TestRBAC_ServiceAccount_LastUsedUpdated(t *testing.T) {
 	t.Parallel()
-	tenantID := "test-sa-lastused-" + randomName("t")
+	tenantID := randomTenantID("sa-lastused")
 
 	client, saID := clientForServiceAccount(t, tenantID, models.RoleMember)
 	ctx := context.Background()

--- a/dc-api/test/integration/tenants_test.go
+++ b/dc-api/test/integration/tenants_test.go
@@ -28,7 +28,7 @@ func TestTenants_Member_SingleTenant(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-list-single-" + randomName("t")
+	tenantID := randomTenantID("list-single")
 	userSub := "sub-list-single-" + randomName("u")
 	insertRole(t, subEnv, userSub, tenantID, models.RoleMember)
 
@@ -58,8 +58,8 @@ func TestTenants_Member_MultiTenant(t *testing.T) {
 	userSub := "sub-list-multi-" + suffix
 	// Use a sortable prefix so the expected order is deterministic regardless
 	// of randomName.
-	tenantA := "test-tenant-list-multi-a-" + suffix
-	tenantB := "test-tenant-list-multi-b-" + suffix
+	tenantA := randomTenantID("list-multi-a")
+	tenantB := randomTenantID("list-multi-b")
 
 	insertRole(t, subEnv, userSub, tenantA, models.RoleOwner)
 	insertRole(t, subEnv, userSub, tenantB, models.RoleViewer)
@@ -89,7 +89,7 @@ func TestTenants_Member_MultipleRolesSameTenant(t *testing.T) {
 	t.Parallel()
 	subEnv := rbacSubEnv(t)
 
-	tenantID := "test-tenant-list-multirole-" + randomName("t")
+	tenantID := randomTenantID("list-multirole")
 	userSub := "sub-list-multirole-" + randomName("u")
 	insertRole(t, subEnv, userSub, tenantID, models.RoleOwner)
 	insertRole(t, subEnv, userSub, tenantID, models.RoleMember)
@@ -115,8 +115,8 @@ func TestTenants_Admin_SeesAllTenantsAsOwner(t *testing.T) {
 	subEnv := rbacSubEnv(t)
 
 	suffix := randomName("admin")
-	tenantA := "test-tenant-admin-list-a-" + suffix
-	tenantB := "test-tenant-admin-list-b-" + suffix
+	tenantA := randomTenantID("admin-list-a")
+	tenantB := randomTenantID("admin-list-b")
 
 	// Seed both tenants with assignments under different (non-admin) users.
 	// The admin should see both tenants in their list.


### PR DESCRIPTION
The `test/integration` suite had two independent, pre-existing breakages that went unnoticed because integration tests are not run in CI (they need a live Harvester + KubeOVN cluster). This PR fixes both so the suite compiles and passes again.

**1. Compile break (`nopClusterProvider`).** The AKS-style multi-pool work grew the `ClusterProvider` interface with five node-pool methods (`AddNodePool`, `ScaleNodePool`, `UpdateNodePoolTaintsLabels`, `RemoveNodePool`, `GetNodePoolStatuses`) and replaced the flat `NodeCount` field on `ClusterCreateSpec` with a required `SystemPool`. The contract-test nop provider was updated for this, but the integration suite's `nopClusterProvider` was missed, so `go test -tags integration ./test/integration/...` no longer compiled. Fix: add the five no-op methods and update the one stale live-cluster test to the `SystemPool` shape.

**2. Over-length tenant slugs.** Since `tenant_id` slug validation landed (`^[a-z][a-z0-9-]{0,30}[a-z0-9]$`, max 32 chars), many tests built tenant slugs like `"test-tenant-members-invite-" + randomName("t")` that expand to ~42 chars and are rejected with HTTP 400 before any handler logic runs. Fix: a `randomTenantID(label)` fixture that always emits a compliant `test-<label>-<6hex>` slug, applied to the ~30 over-length constructions.

**Verification.** Against a live harvester-dev cluster: `go test -tags integration` for the members, service-account, role-matrix, autoprovision, tenants, option-D, and phase-6a suites now passes 35/35 (0 failures). `go build ./...` and `go vet -tags integration ./test/integration/...` are clean.

Note: the role-matrix tests still use fixed tenant slugs, so rapid back-to-back runs can transiently collide on a not-yet-drained namespace; randomising those is a reasonable follow-up but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
