### PR TITLE
Fix DBaaS credential Secret drift during Harvester VM provisioning

### DIFF
--- a/database/.gitignore
+++ b/database/.gitignore
@@ -1,0 +1,3 @@
+bin/
+cover.out
+

--- a/database/hack/boilerplate.go.txt
+++ b/database/hack/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright YEAR.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/database/internal/controller/dbinstance_controller.go
+++ b/database/internal/controller/dbinstance_controller.go
@@ -37,7 +37,7 @@ import (
 // probeListener is the function phaseWaitReady calls to confirm postgres
 // is actually accepting TCP before marking the instance DatabaseReady.
 // Package-level var so tests can stub it without doing real network I/O.
-var probeListener = func(c *harvester.Client, ctx context.Context, ns, vmName string, port int) error {
+var probeListener = func(c harvester.Interface, ctx context.Context, ns, vmName string, port int) error {
 	return c.DialVMListener(ctx, ns, vmName, port)
 }
 
@@ -57,7 +57,7 @@ const (
 // updates the status, and requeues for the next phase.
 type DBInstanceReconciler struct {
 	client.Client
-	Harvester *harvester.Client
+	Harvester harvester.Interface
 }
 
 // DBInstance CRD permissions.

--- a/database/internal/controller/probe_gate_test.go
+++ b/database/internal/controller/probe_gate_test.go
@@ -34,7 +34,7 @@ func TestProbeListenerStubbable(t *testing.T) {
 	t.Cleanup(func() { probeListener = orig })
 
 	called := 0
-	probeListener = func(_ *harvester.Client, _ context.Context, _, _ string, _ int) error {
+	probeListener = func(_ harvester.Interface, _ context.Context, _, _ string, _ int) error {
 		called++
 		return errors.New("refused")
 	}
@@ -46,7 +46,7 @@ func TestProbeListenerStubbable(t *testing.T) {
 		t.Fatalf("expected stub to be called once, got %d", called)
 	}
 
-	probeListener = func(_ *harvester.Client, _ context.Context, _, _ string, _ int) error {
+	probeListener = func(_ harvester.Interface, _ context.Context, _, _ string, _ int) error {
 		return nil
 	}
 	if err := probeListener(nil, context.Background(), "ns", "vm", 5432); err != nil {

--- a/database/internal/harvester/client.go
+++ b/database/internal/harvester/client.go
@@ -230,52 +230,15 @@ func (c *Client) CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName
 	vmName = fmt.Sprintf("pg-%s", p.ID)
 	secretName = fmt.Sprintf("pg-%s-credentials", p.ID)
 
-	// Generate credentials
-	adminPw := randomString(32)
-	replPw := randomString(32)
-	exporterPw := randomString(24)
-
-	// Generate per-instance TLS: ephemeral CA + server cert signed by that CA.
-	// CA key is stored in the Secret alongside DB credentials (same threat model).
-	tls, tlsErr := generateTLS(vmName)
-	if tlsErr != nil {
-		err = fmt.Errorf("TLS generation: %w", tlsErr)
+	// Resolve the Harvester VirtualMachineImage before creating credentials.
+	// If the image is missing or not ready, we should fail without leaving an
+	// untracked Secret behind.
+	imgNs, imgName, imgSC, err := c.resolveVMImage(ctx, p.OSImage)
+	if err != nil {
 		return vmName, secretName, caCertPEM, err
 	}
-	caCertPEM = tls.CACertPEM
 
-	// Store credentials, cloud-init user data, and cloud-init network data
-	// in a K8s Secret. KubeVirt's cloudInitNoCloud datasource reads keys
-	// `userdata` and `networkdata` from this Secret and feeds them to the
-	// VM at the `init-local` stage — applying networkData early enough
-	// that systemd-networkd sees the right IP/gateway/DNS *before* it
-	// times out (which is what bit us when we tried writing the netplan
-	// via cloud-init's write_files module instead).
-	cloudInit := buildCloudInit(p, adminPw, replPw, exporterPw, tls)
-	networkData := buildNetworkData(p)
-	secret := newUnstructured("v1", "Secret", secretName, p.Namespace)
-	_ = unstructured.SetNestedField(secret.Object, "Opaque", "type")
-	_ = unstructured.SetNestedField(secret.Object, map[string]any{
-		"admin_user":        p.MasterUser,
-		"admin_password":    adminPw,
-		"repl_password":     replPw,
-		"exporter_password": exporterPw,
-		"ca_cert":           tls.CACertPEM,
-		"ca_key":            tls.CAKeyPEM,
-		"server_cert":       tls.ServerCertPEM,
-		"server_key":        tls.ServerKeyPEM,
-		"userdata":          cloudInit,
-		"networkdata":       networkData,
-	}, "stringData")
-	if _, e := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Create(ctx, secret, metav1.CreateOptions{}); e != nil {
-		if err = ignoreAlreadyExists(e); err != nil {
-			return vmName, secretName, caCertPEM, err
-		}
-	}
-
-	// Resolve the Harvester VirtualMachineImage so the OS DataVolume can use
-	// the image-managed StorageClass (no cross-namespace PVC clone, no extra RBAC).
-	imgNs, imgName, imgSC, err := c.resolveVMImage(ctx, p.OSImage)
+	caCertPEM, err = c.createOrReuseCredentialSecret(ctx, p, vmName, secretName)
 	if err != nil {
 		return vmName, secretName, caCertPEM, err
 	}
@@ -382,6 +345,89 @@ func (c *Client) CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName
 		err = ignoreAlreadyExists(e)
 	}
 	return vmName, secretName, caCertPEM, err
+}
+
+func (c *Client) createOrReuseCredentialSecret(ctx context.Context, p VMCreateParams, vmName, secretName string) (string, error) {
+	existing, err := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err == nil {
+		return credentialSecretCACert(existing)
+	}
+	if !apierrors.IsNotFound(err) {
+		return "", err
+	}
+
+	// Generate credentials
+	adminPw := randomString(32)
+	replPw := randomString(32)
+	exporterPw := randomString(24)
+
+	// Generate per-instance TLS: ephemeral CA + server cert signed by that CA.
+	// CA key is stored in the Secret alongside DB credentials (same threat model).
+	tls, tlsErr := generateTLS(vmName)
+	if tlsErr != nil {
+		return "", fmt.Errorf("TLS generation: %w", tlsErr)
+	}
+
+	// Store credentials, cloud-init user data, and cloud-init network data
+	// in a K8s Secret. KubeVirt's cloudInitNoCloud datasource reads keys
+	// `userdata` and `networkdata` from this Secret and feeds them to the
+	// VM at the `init-local` stage — applying networkData early enough
+	// that systemd-networkd sees the right IP/gateway/DNS *before* it
+	// times out (which is what bit us when we tried writing the netplan
+	// via cloud-init's write_files module instead).
+	cloudInit := buildCloudInit(p, adminPw, replPw, exporterPw, tls)
+	networkData := buildNetworkData(p)
+	secret := newUnstructured("v1", "Secret", secretName, p.Namespace)
+	_ = unstructured.SetNestedField(secret.Object, "Opaque", "type")
+	_ = unstructured.SetNestedField(secret.Object, map[string]any{
+		"admin_user":        p.MasterUser,
+		"admin_password":    adminPw,
+		"repl_password":     replPw,
+		"exporter_password": exporterPw,
+		"ca_cert":           tls.CACertPEM,
+		"ca_key":            tls.CAKeyPEM,
+		"server_cert":       tls.ServerCertPEM,
+		"server_key":        tls.ServerKeyPEM,
+		"userdata":          cloudInit,
+		"networkdata":       networkData,
+	}, "stringData")
+	if _, e := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Create(ctx, secret, metav1.CreateOptions{}); e != nil {
+		if apierrors.IsAlreadyExists(e) {
+			existing, err := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			return credentialSecretCACert(existing)
+		}
+		return "", e
+	}
+
+	return tls.CACertPEM, nil
+}
+
+func credentialSecretCACert(secret *unstructured.Unstructured) (string, error) {
+	// This function reads existing secret and extract the CA cert , If CA cert is invalid or empty will throow an Error
+	// branch for the real API Server
+	data, _, _ := unstructured.NestedStringMap(secret.Object, "data")
+	if encoded, ok := data["ca_cert"]; ok {
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return "", fmt.Errorf("credentials Secret %s/%s has invalid ca_cert: %w", secret.GetNamespace(), secret.GetName(), err)
+		}
+		if len(decoded) == 0 {
+			return "", fmt.Errorf("credentials Secret %s/%s is missing ca_cert", secret.GetNamespace(), secret.GetName())
+		}
+		return string(decoded), nil
+	}
+
+	// Branch for fake client tests or manually constructred unstructred secrets only
+	// client_test.TestCreatePostgresVMCreatesSecretAndReturnsStoredCA() will use this part
+	stringData, _, _ := unstructured.NestedStringMap(secret.Object, "stringData")
+	if caCert := stringData["ca_cert"]; caCert != "" {
+		return caCert, nil
+	}
+
+	return "", fmt.Errorf("credentials Secret %s/%s is missing ca_cert", secret.GetNamespace(), secret.GetName())
 }
 
 // GetVMIReadiness fetches the VMI once and returns phase, IP, and postgres-readiness.

--- a/database/internal/harvester/client.go
+++ b/database/internal/harvester/client.go
@@ -100,6 +100,8 @@ type Client struct {
 	MgmtLogicalSwitch string
 }
 
+var _ Interface = (*Client)(nil)
+
 func NewClient(dyn dynamic.Interface, grafanaURL string) *Client {
 	return &Client{Dynamic: dyn, GrafanaURL: grafanaURL}
 }
@@ -350,6 +352,7 @@ func (c *Client) CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName
 func (c *Client) createOrReuseCredentialSecret(ctx context.Context, p VMCreateParams, vmName, secretName string) (string, error) {
 	existing, err := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err == nil {
+		// validate the secret
 		return credentialSecretCACert(existing)
 	}
 	if !apierrors.IsNotFound(err) {
@@ -481,6 +484,7 @@ func (c *Client) setVMRunning(ctx context.Context, ns, vmName string, running bo
 }
 
 // GetSecret returns the Secret's data map (values are raw bytes).
+// Not used so no need to include in the new interface.
 func (c *Client) GetSecret(ctx context.Context, ns, name string) (map[string][]byte, error) {
 	obj, err := c.Dynamic.Resource(secretGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {

--- a/database/internal/harvester/client_test.go
+++ b/database/internal/harvester/client_test.go
@@ -18,13 +18,136 @@ package harvester
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
 )
+
+func TestCreatePostgresVMDoesNotCreateSecretWhenImageResolutionFails(t *testing.T) {
+	ctx := context.Background()
+	// client without the fake image
+	client := newTestHarvesterClient()
+
+	_, secretName, _, err := client.CreatePostgresVM(ctx, testVMCreateParams())
+	if err == nil {
+		t.Fatalf("CreatePostgresVM returned nil error, want image resolution error")
+	}
+
+	// check wether secret is created : Expected = No secret created (NotFoundError)
+	if _, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, secretName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("credentials Secret lookup error = %v, want NotFound", err)
+	}
+}
+
+func TestCreatePostgresVMCreatesSecretAndReturnsStoredCA(t *testing.T) {
+	ctx := context.Background()
+	client := newTestHarvesterClient(testVMImage())
+
+	vmName, secretName, caCertPEM, err := client.CreatePostgresVM(ctx, testVMCreateParams())
+	if err != nil {
+		t.Fatalf("CreatePostgresVM returned error: %v", err)
+	}
+	if vmName != "pg-orders" {
+		t.Fatalf("VM name = %q, want pg-orders", vmName)
+	}
+	if secretName != "pg-orders-credentials" {
+		t.Fatalf("Secret name = %q, want pg-orders-credentials", secretName)
+	}
+	if caCertPEM == "" {
+		t.Fatalf("CA cert is empty")
+	}
+
+	// fetch the created fake secret
+	secret, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get credentials Secret: %v", err)
+	}
+	// In client.createOrReuseCredentialSecret() we submit stringData to the API server
+	// We Read stringData because fake client doesn't encode the submitted "stringData" into Base64 "data" as the real API server
+	secretCA, _, _ := unstructured.NestedString(secret.Object, "stringData", "ca_cert")
+	if secretCA == "" {
+		t.Fatalf("created Secret has no stringData.ca_cert")
+	}
+	// check the CA returned by CreatePostgresVM == the CA stored in the Secret
+	if caCertPEM != secretCA {
+		t.Fatalf("returned CA does not match Secret CA")
+	}
+	// fetch the VM
+	if _, err := client.Dynamic.Resource(vmGVR).Namespace("tenant-a").Get(ctx, vmName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("get created VM: %v", err)
+	}
+}
+
+func TestCreatePostgresVMReusesExistingSecretCA(t *testing.T) {
+	ctx := context.Background()
+	existingCA := "existing-ca"
+	client := newTestHarvesterClient(testVMImage(), testCredentialSecret(existingCA))
+
+	_, _, caCertPEM, err := client.CreatePostgresVM(ctx, testVMCreateParams())
+	if err != nil {
+		t.Fatalf("CreatePostgresVM returned error: %v", err)
+	}
+	if caCertPEM != existingCA {
+		t.Fatalf("returned CA = %q, want existing Secret CA %q", caCertPEM, existingCA)
+	}
+}
+
+func TestCreatePostgresVMFailsForMalformedExistingSecret(t *testing.T) {
+	ctx := context.Background()
+	secret := newUnstructured("v1", "Secret", "pg-orders-credentials", "tenant-a")
+	// No CA cert in the secret intentionally , hence malformed for the cotroller
+	_ = unstructured.SetNestedField(secret.Object, "Opaque", "type")
+	client := newTestHarvesterClient(testVMImage(), secret)
+
+	vmName, _, _, err := client.CreatePostgresVM(ctx, testVMCreateParams())
+	if err == nil {
+		t.Fatalf("CreatePostgresVM returned nil error, want missing ca_cert error")
+	}
+	if !strings.Contains(err.Error(), "missing ca_cert") {
+		t.Fatalf("error = %v, want missing ca_cert", err)
+	}
+	// check wether VM creation was failed.
+	if _, getErr := client.Dynamic.Resource(vmGVR).Namespace("tenant-a").Get(ctx, vmName, metav1.GetOptions{}); !apierrors.IsNotFound(getErr) {
+		t.Fatalf("VM lookup error = %v, want NotFound", getErr)
+	}
+}
+
+func TestCreatePostgresVMPreservesKubeOVNSettings(t *testing.T) {
+	ctx := context.Background()
+	client := newTestHarvesterClient(testVMImage())
+	client.MgmtLogicalSwitch = "ovn-default"
+	params := testVMCreateParams()
+	params.DNSServerIP = "10.96.0.10/32"
+
+	vmName, _, _, err := client.CreatePostgresVM(ctx, params)
+	if err != nil {
+		t.Fatalf("CreatePostgresVM returned error: %v", err)
+	}
+	vm, err := client.Dynamic.Resource(vmGVR).Namespace("tenant-a").Get(ctx, vmName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get created VM: %v", err)
+	}
+
+	logicalSwitch, _, _ := unstructured.NestedString(vm.Object, "spec", "template", "metadata", "annotations", "ovn.kubernetes.io/logical_switch")
+	if logicalSwitch != "ovn-default" {
+		t.Fatalf("logical switch annotation = %q, want ovn-default", logicalSwitch)
+	}
+	dnsPolicy, _, _ := unstructured.NestedString(vm.Object, "spec", "template", "spec", "dnsPolicy")
+	if dnsPolicy != "None" {
+		t.Fatalf("dnsPolicy = %q, want None", dnsPolicy)
+	}
+	nameservers, _, _ := unstructured.NestedStringSlice(vm.Object, "spec", "template", "spec", "dnsConfig", "nameservers")
+	if len(nameservers) != 1 || nameservers[0] != "10.96.0.10" {
+		t.Fatalf("nameservers = %v, want [10.96.0.10]", nameservers)
+	}
+}
 
 func TestDeployMonitoringIsIdempotent(t *testing.T) {
 	client := NewClient(fake.NewSimpleDynamicClient(runtime.NewScheme()), "https://grafana.example")
@@ -70,4 +193,44 @@ func TestDeployMonitoringIsIdempotent(t *testing.T) {
 	if address["ip"] != "192.168.40.50" {
 		t.Fatalf("Endpoint IP = %v, want 192.168.40.50", address["ip"])
 	}
+}
+
+// Helpers
+func newTestHarvesterClient(objs ...runtime.Object) *Client {
+	listKinds := map[schema.GroupVersionResource]string{
+		vmImageGVR: "VirtualMachineImageList",
+	}
+	return NewClient(fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objs...), "")
+}
+
+func testVMCreateParams() VMCreateParams {
+	return VMCreateParams{
+		ID:             "orders",
+		Namespace:      "tenant-a",
+		CPUCores:       2,
+		MemoryMB:       4096,
+		OSImage:        "ubuntu-22.04",
+		DataVolumeRef:  "pg-orders-data",
+		NADName:        "tenant-a/vm-network",
+		MasterUser:     "dbadmin",
+		DBName:         "orders",
+		Port:           5432,
+		MaxConnections: 100,
+	}
+}
+
+func testVMImage() *unstructured.Unstructured {
+	img := newUnstructured("harvesterhci.io/v1beta1", "VirtualMachineImage", "ubuntu-22.04", "default")
+	// set status.storageClassName to indicate the fake VM Image is ready
+	_ = unstructured.SetNestedField(img.Object, "longhorn-image-ubuntu", "status", "storageClassName")
+	return img
+}
+
+func testCredentialSecret(caCert string) *unstructured.Unstructured {
+	secret := newUnstructured("v1", "Secret", "pg-orders-credentials", "tenant-a")
+	_ = unstructured.SetNestedField(secret.Object, "Opaque", "type")
+	_ = unstructured.SetNestedStringMap(secret.Object, map[string]string{
+		"ca_cert": base64.StdEncoding.EncodeToString([]byte(caCert)),
+	}, "data")
+	return secret
 }

--- a/database/internal/harvester/interface.go
+++ b/database/internal/harvester/interface.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package harvester
+
+import (
+	"context"
+
+	dbaasv1 "github.com/wso2/open-cloud-datacenter/crds/dbaas/api/v1alpha1"
+)
+
+// Interface is the controller-facing Harvester contract. It intentionally
+// hides whether Harvester resources are managed through the dynamic client or
+// future typed clients.
+type Interface interface {
+	CreateDataVolume(ctx context.Context, id, ns string, sizeGB int, storageClass string) (string, error)
+	ResizeDataVolume(ctx context.Context, ns, dvName string, newSizeGB int) error
+
+	CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName, secretName, caCertPEM string, err error)
+	GetVMIReadiness(ctx context.Context, ns, vmName string) (VMIReadiness, error)
+	DialVMListener(ctx context.Context, ns, vmName string, port int) error
+	StopVM(ctx context.Context, ns, vmName string) error
+	StartVM(ctx context.Context, ns, vmName string) error
+	ResizeVM(ctx context.Context, ns, vmName string, cpuCores, memoryMB int) error
+
+	DeployMonitoring(ctx context.Context, id, ns, vmIP string) (svcName, smName, grafanaURL, promTarget string, err error)
+	TeardownAll(ctx context.Context, id, ns string, refs dbaasv1.ResourceRefs) error
+}


### PR DESCRIPTION
## Purpose
Fix a DBaaS operator reconciliation issue in the Harvester VM provisioning path.

Previously, `CreatePostgresVM` created the credentials/cloud-init Secret before resolving the Harvester `VirtualMachineImage`. If image resolution failed, the Secret could be left behind before the DBInstance status recorded it. On retry, the operator could also generate fresh CA/password material, ignore `AlreadyExists` for the Secret, and return a CA that did not match the Secret actually consumed by the VM.

Related to  #120 

## Goals
- Prevent credentials Secrets from being created when VM image resolution fails.
- Ensure an existing credentials Secret is treated as the source of truth during reconcile retries.
- Prevent `status.caCertPem` from drifting from the Secret’s stored `ca_cert`.
- Preserve existing Kube-OVN VM settings and normal VM creation behavior.

## Approach
- Moved Harvester `VirtualMachineImage` resolution before credentials generation and Secret creation.
- Added create-or-reuse behavior for the credentials Secret.
- When the credentials Secret already exists, the operator now reads and returns the stored `ca_cert`.
- If an existing Secret is malformed and does not contain `ca_cert`, VM creation fails clearly before creating the VM.
- Added unit tests for image-resolution failure, first create, retry reuse, malformed Secret handling, and Kube-OVN VM settings preservation.

Note: This PR also includes the missing `database/hack/boilerplate.go.txt` licensing header template required by the existing `make generate` / `make test` workflow. This is unrelated to the #120  runtime fix, but was needed so `controller-gen` can generate Go files with the expected license header.

## User stories
As an operator user, I want failed VM image resolution to avoid creating orphaned credentials Secrets.

As an operator user, I want DBInstance status to report the same CA certificate that is stored in the credentials Secret and used by the VM.

As an operator maintainer, I want reconciliation retries to be idempotent and safe after partial VM provisioning progress.

## Release note
Fixed DBaaS Harvester VM provisioning to avoid orphaned credentials Secrets and prevent CA certificate drift during reconcile retries.

## Documentation
N/A. This is an internal reconciliation correctness fix and does not change the public DBInstance API or user-facing configuration.

## Training
N/A. No training content changes are required.

## Certification
N/A. This bug fix does not introduce new user-facing product behavior or certification-relevant functionality.

## Marketing
N/A. This is an internal reliability fix.

## Automation tests
 - Unit tests
   - Added tests covering:
     - image resolution failure does not create a credentials Secret
     - successful VM creation returns the CA stored in the created Secret
     - retry with an existing Secret reuses the existing Secret CA
     - malformed existing Secret fails before VM creation
     - Kube-OVN logical switch and DNS settings remain preserved
 - Integration tests
   - Manually validated on a local Harvester cluster:
     - invalid image scenario does not create `pg-<dbinstance>-credentials`
     - valid image scenario provisions successfully
     - DBInstance status CA matches the credentials Secret CA
     - Successful psql connectivity from a client VM on the same VM network 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A. No sample CR changes are required for this fix.

## Related PRs
N/A

## Migrations (if applicable)
No migration is required.

Existing malformed credentials Secrets without `ca_cert` will now fail clearly instead of allowing the operator to publish unrelated newly generated CA material. Operator/admin intervention is required if such a malformed Secret already exists.

## Test environment
- Local Linux development environment
- Local Harvester cluster
- DBaaS operator deployed in `dbaas-system`
- DBInstance tested in tenant namespace
- PostgreSQL client VM with `psql` installed on the same VM network
- Go unit tests for `internal/harvester`

## Learning
Reviewed the Harvester VM provisioning flow, Kubernetes Secret behavior, controller retry/idempotency patterns, and the existing dynamic-client implementation. The fix follows the Kubernetes operator pattern of making reconciliation safe to repeat after partial progress.
