### PR TITLE
[Chore] Replace the legacy PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,52 +1,18 @@
-## Purpose
-> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
+## Summary
 
-## Goals
-> Describe the solutions that this feature/fix will introduce to resolve the problems described above
+<!-- What this change does and the problem it solves. Link issues, e.g. Closes #123. -->
 
-## Approach
-> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.
+## Changes
 
-## User stories
-> Summary of user stories addressed by this change>
+<!-- The notable changes — call out anything user-facing (API, CLI, UI, or Terraform module inputs/outputs). -->
 
-## Release note
-> Brief description of the new feature or bug fix as it will appear in the release notes
+## Testing
 
-## Documentation
-> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact
+<!-- How you verified this, and the result. -->
 
-## Training
-> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable
+## Checklist
 
-## Certification
-> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.
-
-## Marketing
-> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable
-
-## Automation tests
- - Unit tests 
-   > Code coverage information
- - Integration tests
-   > Details about the test cases and coverage
-
-## Security checks
- - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- - Ran FindSecurityBugs plugin and verified report? yes/no
- - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
-
-## Samples
-> Provide high-level details about the samples related to this feature
-
-## Related PRs
-> List any other related PRs
-
-## Migrations (if applicable)
-> Describe migration steps and platforms on which migration has been tested
-
-## Test environment
-> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
- 
-## Learning
-> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
+- [ ] Tests / validation for the changed area pass
+- [ ] Docs updated if behaviour or interfaces changed
+- [ ] No secrets, tokens, or kubeconfigs committed
+- [ ] No internal or other-repository names, private hostnames, or environment names included


### PR DESCRIPTION
## Summary

The repository's PR template was the generic WSO2-product template (Certification, Marketing, Training, FindSecurityBugs, a JDK/DB/browser test matrix, …) — almost none of which applies to this repo's actual products: the Go control plane, the Terraform module catalog, or the operators. Contributors had to wade through a wall of "N/A" fields just to open a PR.

## Changes

- Replace `pull_request_template.md` with a short template: **Summary**, **Changes**, **Testing**, and a checklist (tests/validation pass, docs updated, no committed secrets, no internal/other-repo names).

## Why on `main`

GitHub serves the PR template only from the repository's default branch (`main`); templates on other branches are ignored, so this single file necessarily governs PRs against every branch. It's a community-health/meta file rather than legacy product code, so updating it doesn't reopen the frozen `main` codebase.

## Testing

N/A — Markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
