### PR TITLE
Fix Harvester Cloud Provider not setting cluster name on downstream clusters similar to UI provisioned clusters

### DIFF
--- a/modules/tenancy/k8s-cluster/main.tf
+++ b/modules/tenancy/k8s-cluster/main.tf
@@ -50,6 +50,9 @@ locals {
 harvester-cloud-provider:
   clusterName: ${var.cluster_name}
   cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+  global:
+    cattle:
+      clusterName: ${var.cluster_name}
 EOF
   ) : ""
 


### PR DESCRIPTION
## Description

This PR fixes a critical initialization bug in our downstream RKE2 tenant clusters where the `harvester-cloud-provider` would fail to register the correct guest cluster name, causing it to fall back to the default identifier (`kubernetes`). 

As a result, the Harvester IPPool allocation controller would continuously reject LoadBalancer service sync requests due to a mismatched `Cluster` requirement profile, triggering persistent `SyncLoadBalancerFailed` tracking errors on the guest nodes.

---

## Root Cause Analysis

The issue stems from a hidden prioritization conflict between how the Rancher UI provisions an RKE2 cluster versus how the `rancher2` Terraform provider compiles the core API payload:

1. **Rancher Automated Injections:** When a cluster is provisioned via the API, the backend orchestration engine automatically injects a nested `global.cattle.clusterId` tracking map into the cluster payload.
2. **Chart Template Priority Bug:** Inside the `harvester-cloud-provider` Helm chart, the internal priority engine evaluates configuration identifiers in a strict sequence:
   * **Priority 1:** `global.cattle.clusterName`
   * **Priority 2:** `global.cattle.clusterId` (Defaults to `"kubernetes"` fallback if missing)
   * **Priority 3:** Root-level `clusterName`
3. **The IaC Mismatch:** The official provider documentation instructs users to pass the target identity via the root `harvester-cloud-provider.clusterName` parameter. However, because Rancher automatically injects a `clusterId` payload block, the chart evaluator stops processing at Priority 2 and forces a hardcoded fallback to `"kubernetes"`, completely dropping the custom root-level parameter.

While the Rancher UI patches this dynamically at the dashboard interface layer, pure infrastructure-as-code deployments through Terraform completely bypassed the patch, causing a functional regression.

---

## Solution Implemented

To ensure backward/forward compatibility and bypass the Helm translation/priority logic mismatch entirely, the template configuration block has been updated to explicitly declare the cluster name at **both** the root level and inside the high-priority nested object map:

```hcl
harvester-cloud-provider:
  clusterName: ${var.cluster_name}
  cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
  global:
    cattle:
      clusterName: ${var.cluster_name}