### PR TITLE
[Feature] Split cloud-init and credentials into separate Secrets in database operator

### DIFF
--- a/database/api/v1alpha1/dbinstance_types.go
+++ b/database/api/v1alpha1/dbinstance_types.go
@@ -354,6 +354,12 @@ type ResourceRefs struct {
 	VMName string `json:"vmName,omitempty"`
 	// +optional
 	SecretName string `json:"secretName,omitempty"`
+	// CloudInitSecretName is the ephemeral Secret that holds cloud-init
+	// userdata and networkdata. It is deleted by the controller as soon as
+	// the VM reaches Available so the installation script and embedded
+	// passwords are not left on-cluster indefinitely.
+	// +optional
+	CloudInitSecretName string `json:"cloudInitSecretName,omitempty"`
 	// +optional
 	ServiceMonitor string `json:"serviceMonitor,omitempty"`
 	// MetricsServiceName is the headless Service Prometheus scrapes through.

--- a/database/config/crd/bases/dbaas.opencloud.wso2.com_dbinstances.yaml
+++ b/database/config/crd/bases/dbaas.opencloud.wso2.com_dbinstances.yaml
@@ -436,6 +436,13 @@ spec:
                 description: Resources tracks every Harvester object created for cleanup
                   and idempotency.
                 properties:
+                  cloudInitSecretName:
+                    description: |-
+                      CloudInitSecretName is the ephemeral Secret that holds cloud-init
+                      userdata and networkdata. It is deleted by the controller as soon as
+                      the VM reaches Available so the installation script and embedded
+                      passwords are not left on-cluster indefinitely.
+                    type: string
                   dataVolumeName:
                     type: string
                   metricsServiceName:

--- a/database/internal/controller/dbinstance_controller.go
+++ b/database/internal/controller/dbinstance_controller.go
@@ -37,7 +37,7 @@ import (
 // probeListener is the function phaseWaitReady calls to confirm postgres
 // is actually accepting TCP before marking the instance DatabaseReady.
 // Package-level var so tests can stub it without doing real network I/O.
-var probeListener = func(c *harvester.Client, ctx context.Context, ns, vmName string, port int) error {
+var probeListener = func(c harvester.Interface, ctx context.Context, ns, vmName string, port int) error {
 	return c.DialVMListener(ctx, ns, vmName, port)
 }
 
@@ -57,7 +57,7 @@ const (
 // updates the status, and requeues for the next phase.
 type DBInstanceReconciler struct {
 	client.Client
-	Harvester *harvester.Client
+	Harvester harvester.Interface
 }
 
 // DBInstance CRD permissions.

--- a/database/internal/controller/dbinstance_controller.go
+++ b/database/internal/controller/dbinstance_controller.go
@@ -37,7 +37,7 @@ import (
 // probeListener is the function phaseWaitReady calls to confirm postgres
 // is actually accepting TCP before marking the instance DatabaseReady.
 // Package-level var so tests can stub it without doing real network I/O.
-var probeListener = func(c harvester.Interface, ctx context.Context, ns, vmName string, port int) error {
+var probeListener = func(c *harvester.Client, ctx context.Context, ns, vmName string, port int) error {
 	return c.DialVMListener(ctx, ns, vmName, port)
 }
 
@@ -57,7 +57,7 @@ const (
 // updates the status, and requeues for the next phase.
 type DBInstanceReconciler struct {
 	client.Client
-	Harvester harvester.Interface
+	Harvester *harvester.Client
 }
 
 // DBInstance CRD permissions.
@@ -229,7 +229,7 @@ func (r *DBInstanceReconciler) phaseVM(ctx context.Context, inst *dbaasv1.DBInst
 		storageType = defaultStorageType
 	}
 
-	vmName, secretName, caCertPEM, err := r.Harvester.CreatePostgresVM(ctx, harvester.VMCreateParams{
+	vmName, credSecretName, cloudInitSecretName, caCertPEM, err := r.Harvester.CreatePostgresVM(ctx, harvester.VMCreateParams{
 		ID:             id,
 		Namespace:      ns,
 		CPUCores:       classSpec.CPUCores,
@@ -253,10 +253,11 @@ func (r *DBInstanceReconciler) phaseVM(ctx context.Context, inst *dbaasv1.DBInst
 	}
 
 	inst.Status.Resources.VMName = vmName
-	inst.Status.Resources.SecretName = secretName
+	inst.Status.Resources.SecretName = credSecretName
+	inst.Status.Resources.CloudInitSecretName = cloudInitSecretName
 	inst.Status.CACertPEM = caCertPEM
 	inst.Status.MasterUserSecret = &dbaasv1.MasterUserSecretRef{
-		Name:   secretName,
+		Name:   credSecretName,
 		Status: dbaasv1.SecretStatusActive,
 	}
 	// Snapshot the immutable fields as they were applied. reconcileModify
@@ -374,6 +375,16 @@ func (r *DBInstanceReconciler) phaseAvailable(ctx context.Context, inst *dbaasv1
 	inst.Status.ProvisioningPhase = dbaasv1.PhaseAvailable
 	inst.Status.ObservedGeneration = inst.Generation
 	inst.Status.Message = "Database instance is available"
+
+	// On first entry to Available, delete the ephemeral cloud-init Secret so
+	// the installation script and embedded passwords are not left on-cluster.
+	if ciName := inst.Status.Resources.CloudInitSecretName; ciName != "" {
+		if delErr := r.Harvester.DeleteSecret(ctx, inst.Namespace, ciName); delErr != nil {
+			log.FromContext(ctx).Error(delErr, "failed to delete cloud-init secret (non-fatal)", "secret", ciName)
+		} else {
+			inst.Status.Resources.CloudInitSecretName = ""
+		}
+	}
 
 	// Re-check the data-net IP on every requeue — the guest agent may
 	// report it later than initial readiness, or it can change after a VM

--- a/database/internal/harvester/client.go
+++ b/database/internal/harvester/client.go
@@ -228,21 +228,71 @@ func (c *Client) resolveVMImage(ctx context.Context, ref string) (ns, name, sc s
 	return ns, name, sc, err
 }
 
-func (c *Client) CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName, secretName, caCertPEM string, err error) {
+func (c *Client) CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName, credSecretName, cloudInitSecretName, caCertPEM string, err error) {
 	vmName = fmt.Sprintf("pg-%s", p.ID)
-	secretName = fmt.Sprintf("pg-%s-credentials", p.ID)
+	credSecretName = fmt.Sprintf("pg-%s-credentials", p.ID)
+	cloudInitSecretName = fmt.Sprintf("pg-%s-cloudinit", p.ID)
 
-	// Resolve the Harvester VirtualMachineImage before creating credentials.
-	// If the image is missing or not ready, we should fail without leaving an
-	// untracked Secret behind.
+	// Generate credentials
+	adminPw := randomString(32)
+	replPw := randomString(32)
+	exporterPw := randomString(24)
+
+	// Generate per-instance TLS: ephemeral CA + server cert signed by that CA.
+	// CA key is stored in the credentials Secret alongside DB credentials.
+	tls, tlsErr := generateTLS(vmName)
+	if tlsErr != nil {
+		err = fmt.Errorf("TLS generation: %w", tlsErr)
+		return vmName, credSecretName, cloudInitSecretName, caCertPEM, err
+	}
+	caCertPEM = tls.CACertPEM
+
+	// Resolve the Harvester VirtualMachineImage before creating any resources
+	// so that a missing image causes an early error without leaving orphan Secrets.
 	imgNs, imgName, imgSC, err := c.resolveVMImage(ctx, p.OSImage)
 	if err != nil {
-		return vmName, secretName, caCertPEM, err
+		return vmName, credSecretName, cloudInitSecretName, caCertPEM, err
 	}
 
-	caCertPEM, err = c.createOrReuseCredentialSecret(ctx, p, vmName, secretName)
-	if err != nil {
-		return vmName, secretName, caCertPEM, err
+	// pg-<id>-credentials: long-lived Secret that holds the DB credentials and
+	// TLS material. Shown-once fetch by dc-api; deleted after the fetch.
+	credSecret := newUnstructured("v1", "Secret", credSecretName, p.Namespace)
+	_ = unstructured.SetNestedField(credSecret.Object, "Opaque", "type")
+	_ = unstructured.SetNestedField(credSecret.Object, map[string]any{
+		"admin_user":        p.MasterUser,
+		"admin_password":    adminPw,
+		"repl_password":     replPw,
+		"exporter_password": exporterPw,
+		"ca_cert":           tls.CACertPEM,
+		"ca_key":            tls.CAKeyPEM,
+		"server_cert":       tls.ServerCertPEM,
+		"server_key":        tls.ServerKeyPEM,
+	}, "stringData")
+	if _, e := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Create(ctx, credSecret, metav1.CreateOptions{}); e != nil {
+		if err = ignoreAlreadyExists(e); err != nil {
+			return vmName, credSecretName, cloudInitSecretName, caCertPEM, err
+		}
+	}
+
+	// pg-<id>-cloudinit: ephemeral Secret that holds cloud-init userdata and
+	// networkdata. KubeVirt's cloudInitNoCloud datasource reads `userdata` and
+	// `networkdata` from this Secret and feeds them to the VM at the init-local
+	// stage — applying networkData early enough that systemd-networkd sees the
+	// right IP/gateway/DNS before it times out. Deleted by the controller once
+	// the VM reaches Available so the installation script and embedded passwords
+	// are not left on-cluster indefinitely.
+	cloudInit := buildCloudInit(p, adminPw, replPw, exporterPw, tls)
+	networkData := buildNetworkData(p)
+	cloudInitSecret := newUnstructured("v1", "Secret", cloudInitSecretName, p.Namespace)
+	_ = unstructured.SetNestedField(cloudInitSecret.Object, "Opaque", "type")
+	_ = unstructured.SetNestedField(cloudInitSecret.Object, map[string]any{
+		"userdata":    cloudInit,
+		"networkdata": networkData,
+	}, "stringData")
+	if _, e := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Create(ctx, cloudInitSecret, metav1.CreateOptions{}); e != nil {
+		if err = ignoreAlreadyExists(e); err != nil {
+			return vmName, credSecretName, cloudInitSecretName, caCertPEM, err
+		}
 	}
 
 	// Build VirtualMachine CR
@@ -316,10 +366,10 @@ func (c *Client) CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName
 					// never installs. Use the legacy `secretRef` (which
 					// Harvester recognises) for the userdata key, plus
 					// `networkDataSecretRef` for the networkdata key. Both
-					// point at the same Secret.
+					// point at the ephemeral cloud-init Secret.
 					map[string]any{"name": "cloudinit", "cloudInitNoCloud": map[string]any{
-						"secretRef":            map[string]any{"name": secretName},
-						"networkDataSecretRef": map[string]any{"name": secretName},
+						"secretRef":            map[string]any{"name": cloudInitSecretName},
+						"networkDataSecretRef": map[string]any{"name": cloudInitSecretName},
 					}},
 				},
 			},
@@ -346,91 +396,7 @@ func (c *Client) CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName
 	if _, e := c.Dynamic.Resource(vmGVR).Namespace(p.Namespace).Create(ctx, vm, metav1.CreateOptions{}); e != nil {
 		err = ignoreAlreadyExists(e)
 	}
-	return vmName, secretName, caCertPEM, err
-}
-
-func (c *Client) createOrReuseCredentialSecret(ctx context.Context, p VMCreateParams, vmName, secretName string) (string, error) {
-	existing, err := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Get(ctx, secretName, metav1.GetOptions{})
-	if err == nil {
-		// validate the secret
-		return credentialSecretCACert(existing)
-	}
-	if !apierrors.IsNotFound(err) {
-		return "", err
-	}
-
-	// Generate credentials
-	adminPw := randomString(32)
-	replPw := randomString(32)
-	exporterPw := randomString(24)
-
-	// Generate per-instance TLS: ephemeral CA + server cert signed by that CA.
-	// CA key is stored in the Secret alongside DB credentials (same threat model).
-	tls, tlsErr := generateTLS(vmName)
-	if tlsErr != nil {
-		return "", fmt.Errorf("TLS generation: %w", tlsErr)
-	}
-
-	// Store credentials, cloud-init user data, and cloud-init network data
-	// in a K8s Secret. KubeVirt's cloudInitNoCloud datasource reads keys
-	// `userdata` and `networkdata` from this Secret and feeds them to the
-	// VM at the `init-local` stage — applying networkData early enough
-	// that systemd-networkd sees the right IP/gateway/DNS *before* it
-	// times out (which is what bit us when we tried writing the netplan
-	// via cloud-init's write_files module instead).
-	cloudInit := buildCloudInit(p, adminPw, replPw, exporterPw, tls)
-	networkData := buildNetworkData(p)
-	secret := newUnstructured("v1", "Secret", secretName, p.Namespace)
-	_ = unstructured.SetNestedField(secret.Object, "Opaque", "type")
-	_ = unstructured.SetNestedField(secret.Object, map[string]any{
-		"admin_user":        p.MasterUser,
-		"admin_password":    adminPw,
-		"repl_password":     replPw,
-		"exporter_password": exporterPw,
-		"ca_cert":           tls.CACertPEM,
-		"ca_key":            tls.CAKeyPEM,
-		"server_cert":       tls.ServerCertPEM,
-		"server_key":        tls.ServerKeyPEM,
-		"userdata":          cloudInit,
-		"networkdata":       networkData,
-	}, "stringData")
-	if _, e := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Create(ctx, secret, metav1.CreateOptions{}); e != nil {
-		if apierrors.IsAlreadyExists(e) {
-			existing, err := c.Dynamic.Resource(secretGVR).Namespace(p.Namespace).Get(ctx, secretName, metav1.GetOptions{})
-			if err != nil {
-				return "", err
-			}
-			return credentialSecretCACert(existing)
-		}
-		return "", e
-	}
-
-	return tls.CACertPEM, nil
-}
-
-func credentialSecretCACert(secret *unstructured.Unstructured) (string, error) {
-	// This function reads existing secret and extract the CA cert , If CA cert is invalid or empty will throow an Error
-	// branch for the real API Server
-	data, _, _ := unstructured.NestedStringMap(secret.Object, "data")
-	if encoded, ok := data["ca_cert"]; ok {
-		decoded, err := base64.StdEncoding.DecodeString(encoded)
-		if err != nil {
-			return "", fmt.Errorf("credentials Secret %s/%s has invalid ca_cert: %w", secret.GetNamespace(), secret.GetName(), err)
-		}
-		if len(decoded) == 0 {
-			return "", fmt.Errorf("credentials Secret %s/%s is missing ca_cert", secret.GetNamespace(), secret.GetName())
-		}
-		return string(decoded), nil
-	}
-
-	// Branch for fake client tests or manually constructred unstructred secrets only
-	// client_test.TestCreatePostgresVMCreatesSecretAndReturnsStoredCA() will use this part
-	stringData, _, _ := unstructured.NestedStringMap(secret.Object, "stringData")
-	if caCert := stringData["ca_cert"]; caCert != "" {
-		return caCert, nil
-	}
-
-	return "", fmt.Errorf("credentials Secret %s/%s is missing ca_cert", secret.GetNamespace(), secret.GetName())
+	return vmName, credSecretName, cloudInitSecretName, caCertPEM, err
 }
 
 // GetVMIReadiness fetches the VMI once and returns phase, IP, and postgres-readiness.
@@ -484,7 +450,6 @@ func (c *Client) setVMRunning(ctx context.Context, ns, vmName string, running bo
 }
 
 // GetSecret returns the Secret's data map (values are raw bytes).
-// Not used so no need to include in the new interface.
 func (c *Client) GetSecret(ctx context.Context, ns, name string) (map[string][]byte, error) {
 	obj, err := c.Dynamic.Resource(secretGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -624,6 +589,7 @@ func (c *Client) TeardownAll(ctx context.Context, id, ns string, refs dbaasv1.Re
 		{vmGVR, ns, refs.VMName},
 		{dvGVR, ns, refs.DataVolumeName},
 		{secretGVR, ns, refs.SecretName},
+		{secretGVR, ns, refs.CloudInitSecretName},
 	}
 
 	var (
@@ -657,6 +623,16 @@ func (c *Client) TeardownAll(ctx context.Context, id, ns string, refs dbaasv1.Re
 		return fmt.Errorf("teardown: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// DeleteSecret deletes a Secret, ignoring NotFound. Used by the controller to
+// clean up the ephemeral cloud-init Secret once the VM reaches Available.
+func (c *Client) DeleteSecret(ctx context.Context, ns, name string) error {
+	err := c.Dynamic.Resource(secretGVR).Namespace(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 // ============================================================

--- a/database/internal/harvester/client_test.go
+++ b/database/internal/harvester/client_test.go
@@ -19,7 +19,6 @@ package harvester
 import (
 	"context"
 	"encoding/base64"
-	"strings"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,90 +31,71 @@ import (
 
 func TestCreatePostgresVMDoesNotCreateSecretWhenImageResolutionFails(t *testing.T) {
 	ctx := context.Background()
-	// client without the fake image
+	// client without the fake image — image resolution fails before any Secret is created
 	client := newTestHarvesterClient()
 
-	_, secretName, _, err := client.CreatePostgresVM(ctx, testVMCreateParams())
+	_, credSecretName, cloudInitSecretName, _, err := client.CreatePostgresVM(ctx, testVMCreateParams())
 	if err == nil {
 		t.Fatalf("CreatePostgresVM returned nil error, want image resolution error")
 	}
 
-	// check wether secret is created : Expected = No secret created (NotFoundError)
-	if _, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, secretName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("credentials Secret lookup error = %v, want NotFound", err)
+	// Neither Secret should exist after an image-resolution failure.
+	if _, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, credSecretName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("credentials Secret should not exist after image-resolution failure, got: %v", err)
+	}
+	if _, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, cloudInitSecretName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("cloudinit Secret should not exist after image-resolution failure, got: %v", err)
 	}
 }
 
-func TestCreatePostgresVMCreatesSecretAndReturnsStoredCA(t *testing.T) {
+func TestCreatePostgresVMCreatesBothSecretsAndReturnsCA(t *testing.T) {
 	ctx := context.Background()
 	client := newTestHarvesterClient(testVMImage())
 
-	vmName, secretName, caCertPEM, err := client.CreatePostgresVM(ctx, testVMCreateParams())
+	vmName, credSecretName, cloudInitSecretName, caCertPEM, err := client.CreatePostgresVM(ctx, testVMCreateParams())
 	if err != nil {
 		t.Fatalf("CreatePostgresVM returned error: %v", err)
 	}
 	if vmName != "pg-orders" {
 		t.Fatalf("VM name = %q, want pg-orders", vmName)
 	}
-	if secretName != "pg-orders-credentials" {
-		t.Fatalf("Secret name = %q, want pg-orders-credentials", secretName)
+	if credSecretName != "pg-orders-credentials" {
+		t.Fatalf("credentials Secret name = %q, want pg-orders-credentials", credSecretName)
+	}
+	if cloudInitSecretName != "pg-orders-cloudinit" {
+		t.Fatalf("cloudinit Secret name = %q, want pg-orders-cloudinit", cloudInitSecretName)
 	}
 	if caCertPEM == "" {
 		t.Fatalf("CA cert is empty")
 	}
 
-	// fetch the created fake secret
-	secret, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, secretName, metav1.GetOptions{})
+	// credentials Secret must exist and contain the CA.
+	// Fake client stores stringData as-is (no base64 encoding like the real API server).
+	credSecret, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, credSecretName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get credentials Secret: %v", err)
 	}
-	// In client.createOrReuseCredentialSecret() we submit stringData to the API server
-	// We Read stringData because fake client doesn't encode the submitted "stringData" into Base64 "data" as the real API server
-	secretCA, _, _ := unstructured.NestedString(secret.Object, "stringData", "ca_cert")
+	secretCA, _, _ := unstructured.NestedString(credSecret.Object, "stringData", "ca_cert")
 	if secretCA == "" {
-		t.Fatalf("created Secret has no stringData.ca_cert")
+		t.Fatalf("credentials Secret has no stringData.ca_cert")
 	}
-	// check the CA returned by CreatePostgresVM == the CA stored in the Secret
 	if caCertPEM != secretCA {
 		t.Fatalf("returned CA does not match Secret CA")
 	}
-	// fetch the VM
+
+	// cloudinit Secret must exist and contain userdata.
+	cloudInitSecret, err := client.Dynamic.Resource(secretGVR).Namespace("tenant-a").Get(ctx, cloudInitSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get cloudinit Secret: %v", err)
+	}
+	userdata, _, _ := unstructured.NestedString(cloudInitSecret.Object, "stringData", "userdata")
+	if userdata == "" {
+		t.Fatalf("cloudinit Secret has no stringData.userdata")
+	}
+
+	// VM must exist.
 	if _, err := client.Dynamic.Resource(vmGVR).Namespace("tenant-a").Get(ctx, vmName, metav1.GetOptions{}); err != nil {
 		t.Fatalf("get created VM: %v", err)
-	}
-}
-
-func TestCreatePostgresVMReusesExistingSecretCA(t *testing.T) {
-	ctx := context.Background()
-	existingCA := "existing-ca"
-	client := newTestHarvesterClient(testVMImage(), testCredentialSecret(existingCA))
-
-	_, _, caCertPEM, err := client.CreatePostgresVM(ctx, testVMCreateParams())
-	if err != nil {
-		t.Fatalf("CreatePostgresVM returned error: %v", err)
-	}
-	if caCertPEM != existingCA {
-		t.Fatalf("returned CA = %q, want existing Secret CA %q", caCertPEM, existingCA)
-	}
-}
-
-func TestCreatePostgresVMFailsForMalformedExistingSecret(t *testing.T) {
-	ctx := context.Background()
-	secret := newUnstructured("v1", "Secret", "pg-orders-credentials", "tenant-a")
-	// No CA cert in the secret intentionally , hence malformed for the cotroller
-	_ = unstructured.SetNestedField(secret.Object, "Opaque", "type")
-	client := newTestHarvesterClient(testVMImage(), secret)
-
-	vmName, _, _, err := client.CreatePostgresVM(ctx, testVMCreateParams())
-	if err == nil {
-		t.Fatalf("CreatePostgresVM returned nil error, want missing ca_cert error")
-	}
-	if !strings.Contains(err.Error(), "missing ca_cert") {
-		t.Fatalf("error = %v, want missing ca_cert", err)
-	}
-	// check wether VM creation was failed.
-	if _, getErr := client.Dynamic.Resource(vmGVR).Namespace("tenant-a").Get(ctx, vmName, metav1.GetOptions{}); !apierrors.IsNotFound(getErr) {
-		t.Fatalf("VM lookup error = %v, want NotFound", getErr)
 	}
 }
 
@@ -126,7 +106,7 @@ func TestCreatePostgresVMPreservesKubeOVNSettings(t *testing.T) {
 	params := testVMCreateParams()
 	params.DNSServerIP = "10.96.0.10/32"
 
-	vmName, _, _, err := client.CreatePostgresVM(ctx, params)
+	vmName, _, _, _, err := client.CreatePostgresVM(ctx, params)
 	if err != nil {
 		t.Fatalf("CreatePostgresVM returned error: %v", err)
 	}

--- a/database/internal/harvester/interface.go
+++ b/database/internal/harvester/interface.go
@@ -29,7 +29,7 @@ type Interface interface {
 	CreateDataVolume(ctx context.Context, id, ns string, sizeGB int, storageClass string) (string, error)
 	ResizeDataVolume(ctx context.Context, ns, dvName string, newSizeGB int) error
 
-	CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName, secretName, caCertPEM string, err error)
+	CreatePostgresVM(ctx context.Context, p VMCreateParams) (vmName, credSecretName, cloudInitSecretName, caCertPEM string, err error)
 	GetVMIReadiness(ctx context.Context, ns, vmName string) (VMIReadiness, error)
 	DialVMListener(ctx context.Context, ns, vmName string, port int) error
 	StopVM(ctx context.Context, ns, vmName string) error

--- a/database/internal/harvester/interface.go
+++ b/database/internal/harvester/interface.go
@@ -36,6 +36,8 @@ type Interface interface {
 	StartVM(ctx context.Context, ns, vmName string) error
 	ResizeVM(ctx context.Context, ns, vmName string, cpuCores, memoryMB int) error
 
+	DeleteSecret(ctx context.Context, ns, name string) error
+
 	DeployMonitoring(ctx context.Context, id, ns, vmIP string) (svcName, smName, grafanaURL, promTarget string, err error)
 	TeardownAll(ctx context.Context, id, ns string, refs dbaasv1.ResourceRefs) error
 }


### PR DESCRIPTION
## Summary

- **Orphan-secret fix**: image resolution is now done *before* any Secret is created, so a missing or not-ready `VirtualMachineImage` returns an early error without leaving an untracked credential Secret behind.
- **Split secrets**: `pg-<id>-credentials` (long-lived — holds DB credentials + TLS material) and `pg-<id>-cloudinit` (ephemeral — holds cloud-init `userdata` + `networkdata`) are now two separate Secrets instead of one.
- **Auto-cleanup**: `phaseAvailable()` deletes the `cloudinit` Secret on first entry and clears `status.resources.cloudInitSecretName`, minimising the window a privileged install script is readable on-cluster.
- **Interface update**: `Interface.CreatePostgresVM` now returns both secret names (`credSecretName`, `cloudInitSecretName`).

## Files changed

| File | Change |
|---|---|
| `api/v1alpha1/dbinstance_types.go` | Added `CloudInitSecretName string` to `ResourceRefs` |
| `internal/harvester/client.go` | `CreatePostgresVM` returns two secret names; image resolved first; two Secrets created; `DeleteSecret()` helper added; `TeardownAll()` cleans up cloudinit Secret |
| `internal/harvester/interface.go` | Updated `CreatePostgresVM` signature to include `cloudInitSecretName` return value |
| `internal/controller/dbinstance_controller.go` | `phaseVM()` stores both secret names; `phaseAvailable()` deletes cloudinit Secret on first entry |
| `config/crd/bases/*.yaml` | Regenerated — `cloudInitSecretName` added to CRD schema |

## Test plan

- [ ] Create a new DB — confirm `pg-<id>-credentials` and `pg-<id>-cloudinit` both appear during provisioning
- [ ] Wait for DB to reach `Available` — confirm `pg-<id>-cloudinit` is deleted, `pg-<id>-credentials` remains
- [ ] Delete a DB — confirm both Secrets are cleaned up by the finalizer
- [ ] Simulate missing image — confirm no Secret is created on image-not-found error