### PR TITLE
[Fix] Delete credentials Secret from Kubernetes after shown-once

### DIFF
--- a/dc-api/internal/api/handlers/database.go
+++ b/dc-api/internal/api/handlers/database.go
@@ -578,6 +578,15 @@ func (h *DatabaseHandler) Credentials(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Delete the K8s Secret now that credentials have been consumed. Non-fatal:
+	// the db row is already stamped consumed so a retry can't fetch them again;
+	// a lingering Secret is just a minor cleanup gap, not a security failure.
+	if err := h.provisioner.DeleteCredentialsSecret(r.Context(), ns, st.SecretRefName); err != nil {
+		h.log.Error().Err(err).
+			Str("secret", ns+"/"+st.SecretRefName).
+			Msg("delete credentials secret after shown-once fetch (non-fatal)")
+	}
+
 	// dbaas controller writes admin_user/admin_password/ca_cert; map to the
 	// canonical username/password/ca_cert response shape.
 	writeJSON(w, http.StatusOK, databaseCredentialsResponse{

--- a/dc-api/internal/providers/dbaas/client.go
+++ b/dc-api/internal/providers/dbaas/client.go
@@ -218,6 +218,16 @@ func (c *Client) GetDatabaseCredentialsSecret(ctx context.Context, namespace, na
 	return out, nil
 }
 
+// DeleteCredentialsSecret removes the credentials Secret from Kubernetes.
+// Idempotent: NotFound is treated as success.
+func (c *Client) DeleteCredentialsSecret(ctx context.Context, namespace, name string) error {
+	err := c.dyn.Resource(secretsGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 // decodeBase64Maybe returns the base64-decoded bytes of s, or s as bytes
 // when s is not valid base64. K8s API responses sometimes return secret
 // data values already-decoded as []byte and sometimes as base64 strings

--- a/dc-api/internal/providers/interface.go
+++ b/dc-api/internal/providers/interface.go
@@ -659,6 +659,12 @@ type DatabaseProvisioner interface {
 	// ca_cert, server_cert, ...); the handler picks the subset to surface
 	// on GET .../credentials.
 	GetDatabaseCredentialsSecret(ctx context.Context, namespace, name string) (map[string][]byte, error)
+
+	// DeleteCredentialsSecret removes the credentials Secret from Kubernetes
+	// after it has been read and returned to the caller once. This enforces
+	// the shown-once guarantee at the Kubernetes layer as well as in the db
+	// row. Idempotent: NotFound is treated as success.
+	DeleteCredentialsSecret(ctx context.Context, namespace, name string) error
 }
 
 // DatabaseInstanceCreateRequest is what the handler hands the provisioner.

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -214,6 +214,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SharedResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -476,6 +478,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Network"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "500":


### PR DESCRIPTION
## Summary

- After the `GET .../databases/{id}/credentials` shown-once fetch, the `pg-<id>-credentials` Secret was left in Kubernetes even though the db row was already stamped `credentials_consumed_at`. This PR removes the Secret from Kubernetes immediately after it is returned to the caller.

## Changes

- `internal/providers/interface.go` — add `DeleteCredentialsSecret(ctx, namespace, name string) error` to the `DatabaseProvisioner` interface
- `internal/providers/dbaas/client.go` — implement `DeleteCredentialsSecret` on `*Client`; calls dynamic-client delete on `secretsGVR`, treats NotFound as success (idempotent)
- `internal/api/handlers/database.go` — `Credentials()` calls `DeleteCredentialsSecret` after `MarkDatabaseCredentialsConsumed` succeeds; non-fatal (log on error, 200 still returned)

## Behaviour

The shown-once guarantee was already enforced at the database row level (`credentials_consumed_at IS NULL` UPDATE race guard). This PR adds the Kubernetes layer: once credentials are returned the Secret is deleted so it cannot be read directly from the cluster either.

A delete failure is logged but does not affect the response — the db row stamp is the authoritative gate, and the Secret has no value to the caller once it has been returned.

## Test plan

- [ ] `GET /databases/{id}/credentials` on a Ready database returns credentials (200) and the `pg-<id>-credentials` Secret is gone from the project namespace afterwards
- [ ] A second `GET /databases/{id}/credentials` returns 410 (consumed) as before
- [ ] If the Secret is already deleted (e.g. controller restart cleaned it up), the call still returns 200 (NotFound treated as success)
- [ ] `go build ./dc-api/...` passes