### PR TITLE
Add dbaas-operator deployment module

### DIFF
--- a/modules/operators/database/README.md
+++ b/modules/operators/database/README.md
@@ -1,0 +1,187 @@
+# database
+
+Deploys the **dbaas-operator** (RDS-style managed PostgreSQL via Harvester
+KubeVirt VMs) onto a Harvester RKE2 cluster. Sibling of
+`modules/operators/keyvault`.
+
+## Source of truth
+
+This module derives from the dbaas-operator's `config/` directory (kubebuilder
+layout) on the `operators` branch of
+`github.com/wso2/open-cloud-datacenter`. The canonical deployment path is:
+
+```bash
+kubectl kustomize database/config/default | kubectl apply -f -
+# or equivalently, from database/:
+make deploy
+```
+
+The kustomize build entry point is `database/config/default/kustomization.yaml`.
+The `namePrefix: dbaas-` directive applies to all generated resource names.
+This module re-expresses every resource in that canonical output as typed
+Terraform so the same cluster state is managed without requiring kustomize
+at apply time.
+
+## How to refresh from upstream
+
+When the operator releases a new version:
+
+1. Check out the `operators` branch of `open-cloud-datacenter`.
+2. Rebuild the canonical output:
+   ```bash
+   kubectl kustomize database/config/default
+   ```
+3. Diff each resource (by `kind` + `name`) against the corresponding TF
+   resource block in `main.tf`. Common drift areas:
+   - New or changed RBAC rules in `dbaas-manager-role`
+   - New container args from `manager_metrics_patch.yaml` or future patches
+   - Memory/CPU limit changes
+   - New ports or volume mounts
+4. Update `crds/crd-dbinstances.yaml` alongside the operator image tag bump
+   — CRD schema changes must travel with the image version.
+5. Bump `db_image_tag` in the consumer's `terraform.tfvars`.
+
+## What it deploys (dbaas-operator)
+
+Resource names below are the post-`dbaas-`-prefix names that appear on the
+cluster. These match `kubectl kustomize database/config/default`.
+
+| Resource | Name | Kind |
+|---|---|---|
+| Namespace | `dbaas-system` (var) | `Namespace` |
+| CRD | `dbinstances.dbaas.opencloud.wso2.com` | `CustomResourceDefinition` |
+| ServiceAccount | `dbaas-controller-manager` | `ServiceAccount` |
+| Role | `dbaas-leader-election-role` | `Role` (namespaced) |
+| RoleBinding | `dbaas-leader-election-rolebinding` | `RoleBinding` (namespaced) |
+| ClusterRole | `dbaas-manager-role` | `ClusterRole` |
+| ClusterRoleBinding | `dbaas-manager-rolebinding` | `ClusterRoleBinding` |
+| ClusterRole | `dbaas-metrics-auth-role` | `ClusterRole` |
+| ClusterRoleBinding | `dbaas-metrics-auth-rolebinding` | `ClusterRoleBinding` |
+| ClusterRole | `dbaas-metrics-reader` | `ClusterRole` |
+| ClusterRole | `dbaas-dbinstance-admin-role` | `ClusterRole` (aggregates to `admin`) |
+| ClusterRole | `dbaas-dbinstance-editor-role` | `ClusterRole` (aggregates to `edit`) |
+| ClusterRole | `dbaas-dbinstance-viewer-role` | `ClusterRole` (aggregates to `view`) |
+| Service | `dbaas-controller-manager-metrics-service` | `Service` (port 8443/HTTPS) |
+| Deployment | `dbaas-controller-manager` | `Deployment` |
+| Secret (optional) | `ghcr-pull-secret` | `kubernetes.io/dockerconfigjson` |
+
+Optional resources (gated by boolean variables):
+
+| Resource | Name | Controlled by |
+|---|---|---|
+| NetworkPolicy | `dbaas-allow-metrics-traffic` | `enable_metrics_network_policy` |
+| ServiceMonitor | `dbaas-controller-manager-metrics-monitor` | `enable_prometheus_servicemonitor` |
+
+CRD files live under `crds/` inside this module and are loaded at plan time
+via `file()`. They must be kept in sync with the operator image version.
+
+## Prerequisites
+
+- **Harvester RKE2 cluster** running Kubernetes >= 1.28. This is the workload
+  cluster that hosts the dbaas-operator and the per-DBInstance VMs — not the
+  dc-api management cluster.
+- **KubeVirt + CDI installed.** Harvester ships with both; verify via
+  `kubectl get crd virtualmachines.kubevirt.io datavolumes.cdi.kubevirt.io`.
+- **A storage class** (typically `longhorn`) usable by the per-DBInstance
+  DataVolumes. The class name is specified on the DBInstance CR spec
+  (`storageType`), not by this module.
+- **KubeOVN with a usable logical switch** for the VM management NIC. The
+  default `ovn-default` works for most clusters; override
+  `db_mgmt_logical_switch` for non-default deployments.
+- **A pre-existing `NetworkAttachmentDefinition`** for the data VLAN each
+  DBInstance attaches to (referenced by `spec.networkRef`). The controller
+  does not create NADs — the platform Terraform layer (or dc-api) does.
+- **Pod Security Admission compatibility:** the `dbaas-system` namespace is
+  compatible with `enforce=restricted` (non-root, drops ALL capabilities,
+  read-only root filesystem, `seccompProfile: RuntimeDefault`). No PSA label
+  is added to the namespace by this module — the caller sets the level.
+- For `enable_prometheus_servicemonitor = true`: Prometheus Operator CRDs
+  (`monitoring.coreos.com/v1`) must be installed (e.g. via kube-prometheus-stack).
+- For `enable_cert_manager_metrics = true`: cert-manager must be installed
+  and must have issued a `Certificate` named `metrics-certs` in the
+  dbaas namespace, producing a Secret named `metrics-server-cert`.
+
+## Usage
+
+The caller creates a `kubernetes` provider pointing at the target cluster
+and passes it via the `providers` block:
+
+```hcl
+provider "kubernetes" {
+  alias       = "harvester_cluster"
+  config_path = "/path/to/harvester-rke2.yaml"
+}
+
+module "database_operator" {
+  source = "github.com/wso2/open-cloud-datacenter//modules/operators/database?ref=terraform/v0.2.0"
+
+  providers = {
+    kubernetes = kubernetes.harvester_cluster
+  }
+
+  db_image     = "ghcr.io/wso2/dbaas-controller"
+  db_image_tag = "v0.2.15-split-secrets"
+
+  # Optional — override only when the cluster uses a non-default KubeOVN
+  # logical switch for VM management interfaces.
+  # db_mgmt_logical_switch = "tenant-mgmt"
+
+  ghcr_username = var.ghcr_username
+  ghcr_pat      = var.ghcr_pat
+
+  # Optional — off by default; enable only when the cluster has these operators
+  # enable_metrics_network_policy    = true
+  # enable_prometheus_servicemonitor = true
+  # enable_cert_manager_metrics      = true
+}
+```
+
+## Inputs
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `db_namespace` | `string` | `"dbaas-system"` | Namespace the dbaas-operator runs in |
+| `db_image` | `string` | `"ghcr.io/wso2/dbaas-controller"` | Image registry path, no tag |
+| `db_image_tag` | `string` | `"v0.2.15-split-secrets"` | Pinned image tag |
+| `db_mgmt_logical_switch` | `string` | `"ovn-default"` | KubeOVN logical switch for the VM mgmt NIC |
+| `ghcr_username` | `string` | `""` | GHCR username; leave empty to skip pull secret |
+| `ghcr_pat` | `string` (sensitive) | `""` | GHCR PAT; leave empty to skip pull secret |
+| `enable_metrics_network_policy` | `bool` | `false` | Create NetworkPolicy gating /metrics ingress to `metrics: enabled` namespaces |
+| `enable_prometheus_servicemonitor` | `bool` | `false` | Create ServiceMonitor (requires Prometheus Operator CRDs) |
+| `enable_cert_manager_metrics` | `bool` | `false` | Mount cert-manager TLS certs into the metrics endpoint (requires cert-manager + a Certificate CR named `metrics-certs`) |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `db_namespace` | Namespace the controller is deployed into |
+| `db_deployment_name` | Name of the controller-manager Deployment |
+| `db_image` | Fully-qualified `image:tag` used by the Deployment |
+
+## Image lifecycle
+
+The Deployment carries `lifecycle { ignore_changes = [... container[0].image] }`.
+This means TF seeds the initial image on first apply, then CI owns rolling it
+forward via `kubectl set image`. To force TF to pin a specific tag again,
+remove the resource from state and re-apply, or explicitly bump `db_image_tag`
+after removing the lifecycle block temporarily.
+
+## Composition with upstream layers
+
+This module sits downstream of `harvester-integration` (which registers the
+cluster with Rancher) and `dc-controlplane` (which creates the RKE2 cluster).
+The consumer layer wires the kubernetes provider from the cluster's kubeconfig
+output, exactly as `dc-controlplane-services` and `modules/operators/keyvault`
+do today.
+
+## Deviations from kustomize build output
+
+| kustomize | This module | Reason |
+|---|---|---|
+| `managed-by: kustomize` | `managed-by: terraform` | Reflects actual deployment tool |
+| `imagePullSecrets` always absent | Conditional on `ghcr_username`+`ghcr_pat` | Allows pull-secret injection without altering the canonical YAML |
+| Image `wso2vick/ocd-dbaas:v0.2.10` | `var.db_image:var.db_image_tag` | Caller-controlled; not pinned in module |
+| `--mgmt-logical-switch=ovn-default` (hard-coded) | `--mgmt-logical-switch=${var.db_mgmt_logical_switch}` | Per-env override without forking config/manager |
+| NetworkPolicy: commented out in kustomize | Optional via `enable_metrics_network_policy` | Preserves kustomize default (off) while making it available |
+| ServiceMonitor: commented out in kustomize | Optional via `enable_prometheus_servicemonitor` | Avoids hard dependency on Prometheus Operator |
+| cert-manager patches: commented out in kustomize | Optional via `enable_cert_manager_metrics` | Avoids hard dependency on cert-manager |

--- a/modules/operators/database/crds/crd-dbinstances.yaml
+++ b/modules/operators/database/crds/crd-dbinstances.yaml
@@ -1,0 +1,472 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: dbinstances.dbaas.opencloud.wso2.com
+spec:
+  group: dbaas.opencloud.wso2.com
+  names:
+    kind: DBInstance
+    listKind: DBInstanceList
+    plural: dbinstances
+    shortNames:
+    - dbi
+    singular: dbinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.dbInstanceClass
+      name: Class
+      type: string
+    - jsonPath: .status.endpoint.address
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DBInstance represents a managed PostgreSQL database on Harvester HCI.
+          Namespaced — each DBInstance lives in a tenant namespace. All Harvester
+          child resources (VM, DataVolume, Secret, Service, ServiceMonitor) are
+          created in the same namespace as the DBInstance.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              DBInstanceSpec defines the desired state of a managed PostgreSQL database.
+
+              Field support status (v1alpha1):
+                - implemented mutable post-create: dbInstanceClass, allocatedStorage,
+                  running, deletionProtection
+                - implemented immutable post-create (modify is refused): networkRef,
+                  osImage, dbName, masterUsername, port, storageType, staticNetwork,
+                  vmPassword, engineVersion
+                - NOT IMPLEMENTED: manageMasterUserPassword, masterUserPasswordRef,
+                  multiAZ, dbParameterGroupRef, tags, s3BackupConfig,
+                  backupRetentionPeriod, preferredBackupWindow. These fields exist in
+                  the schema for forward compatibility but the reconciler does not
+                  apply them. See ARCHITECTURE.md for the roadmap.
+            properties:
+              allocatedStorage:
+                description: |-
+                  AllocatedStorage in GiB.
+                  Mutable: changing this on an Available instance resizes the pgdata
+                  DataVolume (only larger values are accepted by CDI/Longhorn).
+                minimum: 1
+                type: integer
+              backupRetentionPeriod:
+                description: |-
+                  BackupRetentionPeriod in days. 0 (default) = disabled.
+                  NOT YET IMPLEMENTED: no pgBackRest install, schedule, or retention
+                  enforcement runs today. The field is recorded but inert.
+                minimum: 0
+                type: integer
+              dbInstanceClass:
+                description: |-
+                  DBInstanceClass maps to VM CPU/RAM. e.g. "db.t3.medium", "db.m5.large".
+                  Mutable: changing the class on an Available instance resizes the VM.
+                minLength: 1
+                type: string
+              dbName:
+                description: |-
+                  DBName is the initial database to create. Default: the instance name.
+                  Must follow PostgreSQL identifier rules: start with a letter or
+                  underscore, contain only letters, digits, underscores, or "$",
+                  max 63 characters. The reconciler also double-quotes this identifier
+                  when emitting CREATE DATABASE; the regex catches invalid values at
+                  apply time so failures don't appear later inside cloud-init.
+                  Immutable after first reconcile; modify is refused.
+                maxLength: 63
+                pattern: ^[a-zA-Z_][a-zA-Z0-9_$]{0,62}$
+                type: string
+              dbParameterGroupRef:
+                description: |-
+                  DBParameterGroupRef references a DBParameterGroup by name.
+                  NOT YET IMPLEMENTED — the DBParameterGroup CRD does not exist in this
+                  module.
+                type: string
+              deletionProtection:
+                description: |-
+                  DeletionProtection prevents accidental deletion. While true, the
+                  finalizer refuses to tear the instance down.
+                  Mutable.
+                type: boolean
+              dnsServerIP:
+                description: |-
+                  DNSServerIP, when set, pins the VM's resolver via KubeVirt
+                  dnsPolicy=None + dnsConfig.nameservers. Required on Kube-OVN VPC
+                  subnets: KubeVirt's bridge-mode virt-launcher runs an internal DHCP
+                  server that otherwise copies the launcher pod's cluster resolv.conf
+                  (unreachable cluster DNS) into the VM, so the VM can't resolve the apt
+                  archive and cloud-init's package install fails. The control plane
+                  (dc-api) supplies the per-VPC CoreDNS address here. Empty leaves
+                  KubeVirt's default DNS behaviour (correct for cluster-routable VLANs).
+                type: string
+              engineVersion:
+                description: |-
+                  EngineVersion is the PostgreSQL major version, e.g. "16".
+                  NOT YET IMPLEMENTED: cloud-init installs whatever PostgreSQL the OS
+                  image's apt repo provides (Ubuntu 24.04 → PG 16; older → older). The
+                  field is recorded but does not drive package selection.
+                type: string
+              manageMasterUserPassword:
+                description: |-
+                  ManageMasterUserPassword: if true, auto-generate the admin password
+                  and store it in the credentials Secret; if false, read it from
+                  MasterUserPasswordRef.
+                  NOT YET IMPLEMENTED: the controller always generates a random password
+                  regardless of this field's value, and never reads
+                  MasterUserPasswordRef. The fields are reserved.
+                type: boolean
+              masterUserPasswordRef:
+                description: |-
+                  MasterUserPasswordRef points to a K8s Secret containing the
+                  user-supplied admin password.
+                  NOT YET IMPLEMENTED — see ManageMasterUserPassword.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+              masterUsername:
+                description: |-
+                  MasterUsername for the admin user. Default "dbadmin".
+                  Must follow PostgreSQL identifier rules: start with a letter or
+                  underscore, contain only letters, digits, underscores, or "$",
+                  max 63 characters. The reconciler also double-quotes this identifier
+                  when emitting CREATE ROLE; the regex catches invalid values at
+                  apply time so failures don't appear later inside cloud-init.
+                  Immutable after first reconcile.
+                maxLength: 63
+                pattern: ^[a-zA-Z_][a-zA-Z0-9_$]{0,62}$
+                type: string
+              multiAZ:
+                description: |-
+                  MultiAZ enables Patroni HA with a standby VM.
+                  NOT YET IMPLEMENTED — no standby is created.
+                type: boolean
+              networkRef:
+                description: |-
+                  NetworkRef is a Harvester NAD reference (namespace/name) for the VLAN
+                  network the database VM attaches to. This is the VM's only network
+                  interface: client traffic, package install during cloud-init, and the
+                  Prometheus metrics scrape all go through it. The NAD must already exist
+                  on the cluster (the controller does not create networks) and the VLAN
+                  must have internet egress.
+                  Immutable after first reconcile.
+                  Example: "iaas-net/vm-subnet-001".
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              osImage:
+                description: |-
+                  OSImage is the Harvester VirtualMachineImage to clone for the VM's
+                  OS disk. Either "<ns>/<name>" or just "<name>" (resolved in the
+                  "default" namespace), or the image's spec.displayName.
+                  Immutable after first reconcile.
+                type: string
+              port:
+                description: |-
+                  Port for PostgreSQL. Default 5432.
+                  Immutable after first reconcile.
+                maximum: 65535
+                minimum: 1
+                type: integer
+              preferredBackupWindow:
+                description: |-
+                  PreferredBackupWindow in UTC, e.g. "02:00-03:00".
+                  NOT YET IMPLEMENTED — see BackupRetentionPeriod.
+                pattern: ^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$
+                type: string
+              running:
+                default: true
+                description: |-
+                  Running controls the VM power state. false = stopped (storage preserved).
+                  Mutable: toggling sets KubeVirt spec.running on the underlying VM.
+                type: boolean
+              s3BackupConfig:
+                description: |-
+                  S3BackupConfig for pgBackRest S3 target.
+                  NOT YET IMPLEMENTED — values are written to /etc/dbaas/bootstrap.env
+                  on the VM but no backup process consumes them.
+                properties:
+                  bucket:
+                    type: string
+                  endpoint:
+                    type: string
+                  region:
+                    type: string
+                  secretRef:
+                    description: SecretRef is a K8s Secret name with accessKey + secretKey.
+                    type: string
+                required:
+                - bucket
+                - endpoint
+                - secretRef
+                type: object
+              staticNetwork:
+                description: |-
+                  StaticNetwork, when set, configures the VM's data NIC with a static
+                  IPv4 address, gateway, and DNS servers instead of running DHCP. Use
+                  this on VLANs that don't have a DHCP server reachable from the VM.
+                  When nil, cloud-init runs DHCP on the data NIC (the default).
+                  Immutable after first reconcile (in-VM netplan reconfiguration is not
+                  implemented).
+                properties:
+                  address:
+                    description: Address is the IPv4 address with CIDR prefix, e.g.
+                      "192.168.40.50/24".
+                    pattern: ^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}\/(3[0-2]|[12]?\d)$
+                    type: string
+                  gateway:
+                    description: Gateway is the IPv4 default gateway, e.g. "192.168.40.1".
+                    pattern: ^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$
+                    type: string
+                  nameservers:
+                    description: |-
+                      Nameservers are the DNS server IPs the VM should use. Supply at
+                      least one — cloud-init will fail to resolve apt mirrors without DNS.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  searchDomains:
+                    description: SearchDomains are DNS search-domain suffixes. Optional.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - address
+                - gateway
+                - nameservers
+                type: object
+              storageType:
+                description: |-
+                  StorageType maps to a Longhorn StorageClass. Default "longhorn".
+                  Immutable after first reconcile (StorageClass cannot change on a
+                  bound PVC).
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Tags are user-defined labels.
+                  NOT YET IMPLEMENTED — not propagated to child resources or dashboards.
+                type: object
+              vmPassword:
+                description: |-
+                  VMPassword sets the default console/SSH password for the VM user
+                  (ubuntu). For development and debugging only — leave empty in
+                  production. Immutable after first reconcile.
+                type: string
+            required:
+            - allocatedStorage
+            - dbInstanceClass
+            - networkRef
+            type: object
+          status:
+            description: DBInstanceStatus defines the observed state of a DBInstance.
+            properties:
+              appliedSpec:
+                description: |-
+                  AppliedSpec is the snapshot of immutable-after-create spec fields
+                  captured at first successful reconcile. The reconciler refuses to
+                  advance ObservedGeneration when any of these fields differ from the
+                  current spec, because the implementation cannot carry the change
+                  through to the running database. Used for honest modify semantics.
+                properties:
+                  dbName:
+                    type: string
+                  engineVersion:
+                    type: string
+                  masterUsername:
+                    type: string
+                  networkRef:
+                    type: string
+                  osImage:
+                    type: string
+                  port:
+                    type: integer
+                  storageType:
+                    type: string
+                type: object
+              caCertPem:
+                description: CACertPEM is the generated CA for SSL verification.
+                type: string
+              conditions:
+                description: Conditions for each sub-resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              endpoint:
+                description: Endpoint is populated when the database is reachable.
+                properties:
+                  address:
+                    type: string
+                  jdbcUrl:
+                    type: string
+                  port:
+                    type: integer
+                required:
+                - address
+                - port
+                type: object
+              grafanaUrl:
+                description: GrafanaURL is the per-instance Grafana dashboard URL.
+                type: string
+              masterUserSecret:
+                description: MasterUserSecret references the K8s Secret with credentials.
+                properties:
+                  name:
+                    type: string
+                  status:
+                    description: Status is "active" or "impaired".
+                    type: string
+                required:
+                - name
+                - status
+                type: object
+              message:
+                description: Message is a human-readable description of the current
+                  state.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration tracks which spec version has been
+                  reconciled.
+                format: int64
+                type: integer
+              phase:
+                description: Phase matches RDS DBInstanceStatus strings.
+                type: string
+              prometheusTarget:
+                description: PrometheusTarget is the scrape target for the instance's
+                  metrics exporter.
+                type: string
+              provisioningPhase:
+                description: ProvisioningPhase tracks which reconcile step we're on.
+                type: string
+              readReplicas:
+                description: ReadReplicas tracks child replica identifiers.
+                items:
+                  type: string
+                type: array
+              resources:
+                description: Resources tracks every Harvester object created for cleanup
+                  and idempotency.
+                properties:
+                  cloudInitSecretName:
+                    description: |-
+                      CloudInitSecretName is the ephemeral Secret that holds cloud-init
+                      userdata and networkdata. It is deleted by the controller as soon as
+                      the VM reaches Available so the installation script and embedded
+                      passwords are not left on-cluster indefinitely.
+                    type: string
+                  dataVolumeName:
+                    type: string
+                  metricsServiceName:
+                    description: |-
+                      MetricsServiceName is the headless Service Prometheus scrapes through.
+                      Tracked separately from ServiceMonitor so the finalizer's TeardownAll
+                      can delete it (forgetting it leaves orphan Services in the tenant ns).
+                    type: string
+                  nadName:
+                    description: |-
+                      NADName is the Multus NetworkAttachmentDefinition the VM's data NIC
+                      attaches to. The controller does not create the NAD; this just records
+                      the reference from spec.networkRef so callers can see it on the CR.
+                    type: string
+                  secretName:
+                    type: string
+                  serviceMonitor:
+                    type: string
+                  vmName:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/modules/operators/database/main.tf
+++ b/modules/operators/database/main.tf
@@ -1,0 +1,675 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# DC Managed-Service Operators — database (dbaas-operator)
+#
+# Deploys the controller tier for the dbaas-operator (RDS-style managed
+# PostgreSQL via Harvester KubeVirt VMs) onto a Harvester RKE2 cluster.
+# Sibling of modules/operators/keyvault — same shape, different operator.
+#
+# All provider config (kubernetes host + credentials) lives in the calling
+# environment layer. This module only contains resource definitions.
+#
+# Source: the dbaas-operator's `config/` directory (kubebuilder layout) on
+#   the `operators` branch of github.com/wso2/open-cloud-datacenter. The
+#   canonical deployment command is `kustomize build config/default |
+#   kubectl apply`. This module re-expresses that output as typed Terraform
+#   resources so the same cluster state is managed idiomatically without
+#   requiring kustomize at apply time.
+#
+# How to refresh from upstream:
+#   1. Check out the `operators` branch of open-cloud-datacenter
+#   2. Run: kubectl kustomize database/config/default
+#   3. Diff each resource kind+name against the corresponding TF resource below.
+#   4. Reconcile any structural changes (new RBAC rules, new container args,
+#      changed limits, new ports/mounts).
+#   5. Bump crds/crd-dbinstances.yaml alongside the operator image tag bump —
+#      schema changes must travel with the image version.
+# ─────────────────────────────────────────────────────────────────────────────
+
+locals {
+  # Emitted on every resource so the label set is consistent. Canonical
+  # kustomize labels are app.kubernetes.io/name=dbaas +
+  # app.kubernetes.io/managed-by=kustomize; we swap managed-by to terraform.
+  db_labels = {
+    "app.kubernetes.io/name"       = "dbaas"
+    "app.kubernetes.io/managed-by" = "terraform"
+  }
+
+  # True only when both credentials are provided. Drives the pull-secret
+  # count and the Deployment's imagePullSecrets block.
+  db_pull_secret_enabled = var.ghcr_username != "" && var.ghcr_pat != ""
+}
+
+# ── Dbaas-operator: Namespace ─────────────────────────────────────────────────
+
+resource "kubernetes_namespace" "dbaas_system" {
+  metadata {
+    name = var.db_namespace
+    labels = merge(local.db_labels, {
+      "control-plane" = "controller-manager"
+    })
+  }
+  lifecycle {
+    # Rancher and other cluster-level controllers add annotations that TF
+    # should not fight on every plan.
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+# ── Dbaas-operator: GHCR pull secret (optional) ──────────────────────────────
+
+resource "kubernetes_secret" "db_ghcr_pull" {
+  count = local.db_pull_secret_enabled ? 1 : 0
+
+  metadata {
+    name      = "ghcr-pull-secret"
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+    labels    = local.db_labels
+  }
+  type = "kubernetes.io/dockerconfigjson"
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "ghcr.io" = {
+          username = var.ghcr_username
+          password = var.ghcr_pat
+          auth     = base64encode("${var.ghcr_username}:${var.ghcr_pat}")
+        }
+      }
+    })
+  }
+}
+
+# ── Dbaas-operator: CRDs ──────────────────────────────────────────────────────
+# kubernetes_manifest is used here because there is no typed Terraform resource
+# for CustomResourceDefinitions. The manifest content is sourced verbatim from
+# the operator's kubebuilder-generated CRD file — bump along with operator
+# version bumps.
+
+resource "kubernetes_manifest" "crd_dbinstances" {
+  manifest = yamldecode(file("${path.module}/crds/crd-dbinstances.yaml"))
+
+  # CRD updates are additive in apiextensions.k8s.io — new versions are
+  # appended, old versions kept until explicitly removed. Structural schema
+  # changes require a delete + re-apply (handled by destroy + re-apply of
+  # this resource).
+  field_manager {
+    # Use server-side apply so Kubernetes handles list-map merges in the
+    # openAPIV3Schema correctly. Without this, nested list fields in CRD
+    # schemas produce noisy in-place diffs on every plan.
+    force_conflicts = true
+  }
+}
+
+# ── Dbaas-operator: ServiceAccount ───────────────────────────────────────────
+# kustomize namePrefix "dbaas-" yields name "dbaas-controller-manager".
+
+resource "kubernetes_service_account" "dbaas_controller_manager" {
+  metadata {
+    name      = "dbaas-controller-manager"
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+    labels    = local.db_labels
+  }
+}
+
+# ── Dbaas-operator: Leader-election Role + RoleBinding ───────────────────────
+# Scoped to dbaas-system. The controller uses standard kubebuilder leader
+# election via ConfigMaps/Leases in its own namespace.
+
+resource "kubernetes_role_v1" "db_leader_election" {
+  metadata {
+    name      = "dbaas-leader-election-role"
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+    labels    = local.db_labels
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = ["coordination.k8s.io"]
+    resources  = ["leases"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["events"]
+    verbs      = ["create", "patch"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "db_leader_election" {
+  metadata {
+    name      = "dbaas-leader-election-rolebinding"
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+    labels    = local.db_labels
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.db_leader_election.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.dbaas_controller_manager.metadata[0].name
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+  }
+}
+
+# ── Dbaas-operator: manager ClusterRole + ClusterRoleBinding ─────────────────
+# Cluster-scoped so the controller can manage child Harvester resources
+# (VMs, DataVolumes), Secrets, Services, and ServiceMonitors across every
+# tenant namespace where a DBInstance is created.
+#
+# Rules mirror the +kubebuilder:rbac markers in
+# database/internal/controller/dbinstance_controller.go (operators branch).
+
+resource "kubernetes_cluster_role_v1" "db_manager" {
+  metadata {
+    name = "dbaas-manager-role"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["endpoints", "services"]
+    verbs      = ["create", "delete", "get", "update"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["create", "delete", "get"]
+  }
+  rule {
+    api_groups = ["cdi.kubevirt.io"]
+    resources  = ["datavolumes"]
+    verbs      = ["create", "delete", "get", "update"]
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances"]
+    verbs      = ["create", "delete", "get", "list", "patch", "update", "watch"]
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances/finalizers"]
+    verbs      = ["update"]
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances/status"]
+    verbs      = ["get", "patch", "update"]
+  }
+  rule {
+    api_groups = ["harvesterhci.io"]
+    resources  = ["virtualmachineimages"]
+    verbs      = ["get", "list"]
+  }
+  rule {
+    api_groups = ["kubevirt.io"]
+    resources  = ["virtualmachineinstances"]
+    verbs      = ["get"]
+  }
+  rule {
+    api_groups = ["kubevirt.io"]
+    resources  = ["virtualmachines"]
+    verbs      = ["create", "delete", "get", "update"]
+  }
+  rule {
+    api_groups = ["monitoring.coreos.com"]
+    resources  = ["servicemonitors"]
+    verbs      = ["create", "delete", "get", "update"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "db_manager" {
+  metadata {
+    name   = "dbaas-manager-rolebinding"
+    labels = local.db_labels
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.db_manager.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.dbaas_controller_manager.metadata[0].name
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+  }
+}
+
+# ── Dbaas-operator: metrics-auth ClusterRole + ClusterRoleBinding ────────────
+# Allows the metrics endpoint to perform TokenReview + SubjectAccessReview so
+# Prometheus scrape jobs can authenticate to the protected /metrics endpoint.
+
+resource "kubernetes_cluster_role_v1" "db_metrics_auth" {
+  metadata {
+    name = "dbaas-metrics-auth-role"
+  }
+  rule {
+    api_groups = ["authentication.k8s.io"]
+    resources  = ["tokenreviews"]
+    verbs      = ["create"]
+  }
+  rule {
+    api_groups = ["authorization.k8s.io"]
+    resources  = ["subjectaccessreviews"]
+    verbs      = ["create"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "db_metrics_auth" {
+  metadata {
+    name = "dbaas-metrics-auth-rolebinding"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.db_metrics_auth.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.dbaas_controller_manager.metadata[0].name
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+  }
+}
+
+# ── Dbaas-operator: metrics-reader ClusterRole ───────────────────────────────
+# Grants non-resource URL /metrics access. Bind to Prometheus ServiceAccounts
+# in the consumer layer if you want scrape-authenticated Prometheus.
+
+resource "kubernetes_cluster_role_v1" "db_metrics_reader" {
+  metadata {
+    name = "dbaas-metrics-reader"
+  }
+  rule {
+    non_resource_urls = ["/metrics"]
+    verbs             = ["get"]
+  }
+}
+
+# ── Dbaas-operator: helper ClusterRoles (admin / editor / viewer) ────────────
+# Kubebuilder scaffolds these for cluster admins to delegate object-level
+# access to DBInstance CRs. The operator itself does not use them — they are
+# scaffolding aids for human operators.
+#
+# Carry the rbac.authorization.k8s.io/aggregate-to-{admin,edit,view}=true
+# labels so the cluster's default admin/edit/view ClusterRoles aggregate
+# DBInstance verbs automatically (matches kustomize default output).
+
+resource "kubernetes_cluster_role_v1" "db_dbinstance_admin" {
+  metadata {
+    name = "dbaas-dbinstance-admin-role"
+    labels = merge(local.db_labels, {
+      "rbac.authorization.k8s.io/aggregate-to-admin" = "true"
+    })
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances"]
+    verbs      = ["*"]
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances/status"]
+    verbs      = ["get"]
+  }
+}
+
+resource "kubernetes_cluster_role_v1" "db_dbinstance_editor" {
+  metadata {
+    name = "dbaas-dbinstance-editor-role"
+    labels = merge(local.db_labels, {
+      "rbac.authorization.k8s.io/aggregate-to-edit" = "true"
+    })
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances"]
+    verbs      = ["create", "delete", "get", "list", "patch", "update", "watch"]
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances/status"]
+    verbs      = ["get"]
+  }
+}
+
+resource "kubernetes_cluster_role_v1" "db_dbinstance_viewer" {
+  metadata {
+    name = "dbaas-dbinstance-viewer-role"
+    labels = merge(local.db_labels, {
+      "rbac.authorization.k8s.io/aggregate-to-view" = "true"
+    })
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances"]
+    verbs      = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["dbaas.opencloud.wso2.com"]
+    resources  = ["dbinstances/status"]
+    verbs      = ["get"]
+  }
+}
+
+# ── Dbaas-operator: Metrics Service ──────────────────────────────────────────
+# Exposes port 8443 (the controller's metrics HTTPS port). The controller's
+# health probes run on 8081; this Service is for Prometheus scraping only.
+# Port 8443 is wired by the manager_metrics_patch applied in kustomize/default.
+
+resource "kubernetes_service" "db_metrics" {
+  metadata {
+    name      = "dbaas-controller-manager-metrics-service"
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+    labels = merge(local.db_labels, {
+      "control-plane" = "controller-manager"
+    })
+  }
+  spec {
+    selector = {
+      "control-plane"          = "controller-manager"
+      "app.kubernetes.io/name" = "dbaas"
+    }
+    port {
+      name        = "https"
+      port        = 8443
+      protocol    = "TCP"
+      target_port = 8443
+    }
+  }
+}
+
+# ── Dbaas-operator: NetworkPolicy (optional) ─────────────────────────────────
+# Gates ingress to the metrics endpoint (8443) from namespaces labelled
+# `metrics: enabled`. Off by default — the canonical kustomize/default has the
+# network-policy resource commented out. Enable when the cluster has
+# NetworkPolicy enforcement and you want to restrict who can scrape /metrics.
+
+resource "kubernetes_network_policy_v1" "db_allow_metrics" {
+  count = var.enable_metrics_network_policy ? 1 : 0
+
+  metadata {
+    name      = "dbaas-allow-metrics-traffic"
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+    labels    = local.db_labels
+  }
+
+  spec {
+    pod_selector {
+      match_labels = {
+        "control-plane"          = "controller-manager"
+        "app.kubernetes.io/name" = "dbaas"
+      }
+    }
+    policy_types = ["Ingress"]
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            "metrics" = "enabled"
+          }
+        }
+      }
+      ports {
+        port     = "8443"
+        protocol = "TCP"
+      }
+    }
+  }
+}
+
+# ── Dbaas-operator: Deployment ───────────────────────────────────────────────
+
+resource "kubernetes_deployment" "dbaas_controller_manager" {
+  metadata {
+    name      = "dbaas-controller-manager"
+    namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+    labels = merge(local.db_labels, {
+      "control-plane" = "controller-manager"
+    })
+  }
+
+  # Same CI-ownership pattern as the keyvault module: TF seeds the initial
+  # image; after the first apply, CI rolls it forward via
+  # `kubectl set image`. Ignoring the image here prevents noisy revert diffs
+  # on every plan after a CI deploy. Change the tag by updating db_image_tag
+  # + running apply only when you want TF to pin a specific release.
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations,
+      spec[0].template[0].spec[0].container[0].image,
+    ]
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        "control-plane"          = "controller-manager"
+        "app.kubernetes.io/name" = "dbaas"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "control-plane"          = "controller-manager"
+          "app.kubernetes.io/name" = "dbaas"
+        }
+        annotations = {
+          # Marks the primary container for `kubectl logs` / `kubectl exec`
+          # auto-selection — standard kubebuilder convention.
+          "kubectl.kubernetes.io/default-container" = "manager"
+        }
+      }
+
+      spec {
+        service_account_name             = kubernetes_service_account.dbaas_controller_manager.metadata[0].name
+        termination_grace_period_seconds = 10
+
+        security_context {
+          run_as_non_root = true
+          seccomp_profile {
+            type = "RuntimeDefault"
+          }
+        }
+
+        dynamic "image_pull_secrets" {
+          for_each = local.db_pull_secret_enabled ? [1] : []
+          content {
+            name = kubernetes_secret.db_ghcr_pull[0].metadata[0].name
+          }
+        }
+
+        container {
+          name              = "manager"
+          image             = "${var.db_image}:${var.db_image_tag}"
+          image_pull_policy = "IfNotPresent"
+          command           = ["/manager"]
+
+          # --metrics-bind-address is added by manager_metrics_patch in
+          # kustomize/default. It binds the HTTPS metrics server on :8443.
+          # --mgmt-logical-switch is dbaas-specific (KubeOVN management
+          # subnet for the VM mgmt NIC) — see db_mgmt_logical_switch.
+          # --metrics-cert-path is only added when enable_cert_manager_metrics
+          # is true (cert_metrics_manager_patch effect).
+          args = concat(
+            [
+              "--metrics-bind-address=:8443",
+              "--leader-elect",
+              "--health-probe-bind-address=:8081",
+              "--mgmt-logical-switch=${var.db_mgmt_logical_switch}",
+            ],
+            var.enable_cert_manager_metrics ? ["--metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs"] : [],
+          )
+
+          security_context {
+            read_only_root_filesystem  = true
+            allow_privilege_escalation = false
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          port {
+            name           = "health"
+            container_port = 8081
+            protocol       = "TCP"
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8081
+            }
+            initial_delay_seconds = 15
+            period_seconds        = 20
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/readyz"
+              port = 8081
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
+
+          resources {
+            requests = {
+              cpu    = "10m"
+              memory = "64Mi"
+            }
+            limits = {
+              cpu    = "500m"
+              memory = "128Mi"
+            }
+          }
+
+          # cert_metrics_manager_patch mounts the cert-manager-issued Secret
+          # at /tmp/k8s-metrics-server/metrics-certs. Only present when TLS
+          # cert rotation is enabled for the metrics endpoint.
+          dynamic "volume_mount" {
+            for_each = var.enable_cert_manager_metrics ? [1] : []
+            content {
+              name       = "metrics-certs"
+              mount_path = "/tmp/k8s-metrics-server/metrics-certs"
+              read_only  = true
+            }
+          }
+        }
+
+        dynamic "volume" {
+          for_each = var.enable_cert_manager_metrics ? [1] : []
+          content {
+            name = "metrics-certs"
+            secret {
+              secret_name = "metrics-server-cert"
+              optional    = false
+              items {
+                key  = "ca.crt"
+                path = "ca.crt"
+              }
+              items {
+                key  = "tls.crt"
+                path = "tls.crt"
+              }
+              items {
+                key  = "tls.key"
+                path = "tls.key"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.crd_dbinstances,
+    kubernetes_cluster_role_binding_v1.db_manager,
+  ]
+}
+
+# ── Dbaas-operator: ServiceMonitor (optional) ────────────────────────────────
+# Requires the Prometheus Operator CRDs (monitoring.coreos.com/v1) to be
+# installed on the target cluster. Off by default — enable only when the
+# cluster runs kube-prometheus-stack or another Prometheus Operator deployment.
+# Mirrors the commented config/prometheus/monitor.yaml in kustomize/default.
+#
+# When enable_cert_manager_metrics is also true, the tlsConfig is updated to
+# use the cert-manager-issued metrics-server-cert Secret instead of
+# insecureSkipVerify. This mirrors the effect of monitor_tls_patch.yaml.
+
+resource "kubernetes_manifest" "db_service_monitor" {
+  count = var.enable_prometheus_servicemonitor ? 1 : 0
+
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+    metadata = {
+      name      = "dbaas-controller-manager-metrics-monitor"
+      namespace = kubernetes_namespace.dbaas_system.metadata[0].name
+      labels = merge(local.db_labels, {
+        "control-plane" = "controller-manager"
+      })
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          "control-plane"          = "controller-manager"
+          "app.kubernetes.io/name" = "dbaas"
+        }
+      }
+      endpoints = [
+        var.enable_cert_manager_metrics ? {
+          path            = "/metrics"
+          port            = "https"
+          scheme          = "https"
+          bearerTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          tlsConfig = {
+            serverName         = "dbaas-controller-manager-metrics-service.${kubernetes_namespace.dbaas_system.metadata[0].name}.svc"
+            insecureSkipVerify = false
+            ca = {
+              secret = {
+                name = "metrics-server-cert"
+                key  = "ca.crt"
+              }
+            }
+            cert = {
+              secret = {
+                name = "metrics-server-cert"
+                key  = "tls.crt"
+              }
+            }
+            keySecret = {
+              name = "metrics-server-cert"
+              key  = "tls.key"
+            }
+          }
+          } : {
+          path            = "/metrics"
+          port            = "https"
+          scheme          = "https"
+          bearerTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          tlsConfig = {
+            serverName         = null
+            insecureSkipVerify = true
+            ca                 = null
+            cert               = null
+            keySecret          = null
+          }
+        }
+      ]
+    }
+  }
+}

--- a/modules/operators/database/outputs.tf
+++ b/modules/operators/database/outputs.tf
@@ -1,0 +1,14 @@
+output "db_namespace" {
+  value       = kubernetes_namespace.dbaas_system.metadata[0].name
+  description = "Namespace the dbaas-operator controller is deployed into."
+}
+
+output "db_deployment_name" {
+  value       = kubernetes_deployment.dbaas_controller_manager.metadata[0].name
+  description = "Name of the dbaas-operator controller-manager Deployment."
+}
+
+output "db_image" {
+  value       = "${var.db_image}:${var.db_image_tag}"
+  description = "Fully-qualified image reference (registry/image:tag) used by the dbaas-operator Deployment."
+}

--- a/modules/operators/database/variables.tf
+++ b/modules/operators/database/variables.tf
@@ -1,0 +1,71 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# database (dbaas-operator) module — inputs
+#
+# Sibling of modules/operators/keyvault. Per-operator variables are prefixed
+# (db_*) so the namespace stays clean when sibling operators compose in the
+# same root module.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Dbaas operator ────────────────────────────────────────────────────────────
+
+variable "db_namespace" {
+  type        = string
+  description = "Namespace the dbaas-operator controller runs in. Must exist or be created by this module (default: 'dbaas-system')."
+  default     = "dbaas-system"
+}
+
+variable "db_image" {
+  type        = string
+  description = "Container image registry path for the dbaas-operator, without a tag (e.g. 'ghcr.io/wso2/dbaas-controller')."
+  default     = "ghcr.io/wso2/dbaas-controller"
+}
+
+variable "db_image_tag" {
+  type        = string
+  description = "Pinned image tag for the dbaas-operator. Never 'latest' — a fixed tag ensures plan output is deterministic and rollback is possible."
+  default     = "v0.2.15-split-secrets"
+}
+
+variable "db_mgmt_logical_switch" {
+  type        = string
+  description = "KubeOVN logical switch name the controller uses for the management NIC on each DB VM. Passed to the manager as --mgmt-logical-switch. Default 'ovn-default' matches the cluster-default KubeOVN switch; override when DB VMs must attach to a non-default management subnet."
+  default     = "ovn-default"
+}
+
+# ── GHCR image pull credentials (optional) ────────────────────────────────────
+# Both must be set together. If either is empty the pull secret is skipped and
+# the Deployment has no imagePullSecrets — suitable for clusters that already
+# have cluster-level registry credentials or when the image is public.
+
+variable "ghcr_username" {
+  type        = string
+  description = "GitHub username for pulling images from ghcr.io. Set together with ghcr_pat to create a 'ghcr-pull-secret' in the operator namespace. Leave empty for public images or clusters with pre-existing registry credentials."
+  default     = ""
+}
+
+variable "ghcr_pat" {
+  type        = string
+  sensitive   = true
+  description = "GitHub Personal Access Token with read:packages scope. Required when ghcr_username is set. Stored as a kubernetes.io/dockerconfigjson Secret in the operator namespace."
+  default     = ""
+}
+
+# ── Optional feature toggles ──────────────────────────────────────────────────
+
+variable "enable_metrics_network_policy" {
+  type        = bool
+  description = "When true, creates a NetworkPolicy restricting /metrics (port 8443) ingress to namespaces labelled 'metrics: enabled'. Mirrors the commented config/network-policy resource. Off by default to match the kustomize/default baseline. Enable when the cluster has NetworkPolicy enforcement (Calico/Cilium)."
+  default     = false
+}
+
+variable "enable_prometheus_servicemonitor" {
+  type        = bool
+  description = "When true, creates a ServiceMonitor (monitoring.coreos.com/v1) that points Prometheus at the controller-manager metrics Service. Requires the Prometheus Operator CRDs to be installed on the target cluster (e.g. via kube-prometheus-stack). Off by default to avoid a hard dependency on the Prometheus Operator."
+  default     = false
+}
+
+variable "enable_cert_manager_metrics" {
+  type        = bool
+  description = "When true, mounts the cert-manager-issued 'metrics-server-cert' Secret into the manager container and adds --metrics-cert-path, enabling TLS on the /metrics endpoint. Also updates the ServiceMonitor tlsConfig when enable_prometheus_servicemonitor is true. Requires cert-manager to be installed and to have issued a Certificate named 'metrics-certs' in the dbaas namespace."
+  default     = false
+}

--- a/modules/operators/database/versions.tf
+++ b/modules/operators/database/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `modules/operators/database/` — sibling of `modules/operators/keyvault` — deploying the **dbaas-operator** (RDS-style managed PostgreSQL via Harvester KubeVirt VMs) as typed Terraform resources.
- Re-expresses every resource emitted by `kubectl kustomize database/config/default` on the `operators` branch as typed `kubernetes_*` resources, so the same cluster state is managed without requiring kustomize at apply time.
- Same shape, conventions, and lifecycle behaviour as the keyvault module — drops in alongside it in a `20-operators/` layer.

## Resources created (16 in canonical config)

| Kind | Name |
|---|---|
| Namespace | `dbaas-system` (var) |
| CRD | `dbinstances.dbaas.opencloud.wso2.com` |
| ServiceAccount | `dbaas-controller-manager` |
| Role / RoleBinding | `dbaas-leader-election-*` |
| ClusterRole / Binding | `dbaas-manager-role*`, `dbaas-metrics-auth-role*` |
| ClusterRole | `dbaas-metrics-reader`, `dbaas-dbinstance-{admin,editor,viewer}-role` (aggregates to default `admin`/`edit`/`view`) |
| Service | `dbaas-controller-manager-metrics-service` (port 8443/HTTPS) |
| Deployment | `dbaas-controller-manager` |
| Secret (optional) | `ghcr-pull-secret` (conditional on `ghcr_username`+`ghcr_pat`) |

Optional resources (`enable_metrics_network_policy`, `enable_prometheus_servicemonitor`, `enable_cert_manager_metrics`) are off by default to match kustomize/default.

## Deviations from kustomize output (documented in README)

- Caller-controlled image via `db_image` / `db_image_tag` (no hard-coded pin)
- `--mgmt-logical-switch` parameterized via `db_mgmt_logical_switch` so non-default KubeOVN deployments don't require forking `config/manager`
- `imagePullSecrets` conditional on credentials provided (mirrors keyvault)
- `managed-by: kustomize` → `managed-by: terraform` on every resource

## Verified end-to-end on lk-dev

- `terraform apply` → 16/16 resources created in ~30s
- Controller pod reaches `1/1 Running`, leader lease acquired, controller workers started
- CRD registered, all RBAC bindings in place
- Smoke-test `DBInstance` progressed `creating` → `WaitingForCloudInit` → `Available` with a reachable endpoint on the chosen VLAN (post cloud-init apt install of PostgreSQL)

## Test plan

- [ ] Reviewers verify the module structurally mirrors `modules/operators/keyvault/`
- [ ] Reviewers cross-check the RBAC rules in `dbaas-manager-role` against the `+kubebuilder:rbac` markers in `database/internal/controller/dbinstance_controller.go` on the `operators` branch
- [ ] Reviewers confirm the bundled `crds/crd-dbinstances.yaml` matches the current `config/crd/bases/dbaas.opencloud.wso2.com_dbinstances.yaml` on `operators`
- [ ] On apply: `kubectl get dbi -A` works (CRD registered), controller pod is Running, sample DBInstance creation progresses through phases