### PR TITLE
Retire dc-runner from the GitOps platform

### DIFF
--- a/examples/consumer/flux/platform-overlay/kustomization.yaml
+++ b/examples/consumer/flux/platform-overlay/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
   # - ./sealed-dc-api-tls.yaml
   # - ./sealed-ghcr-pull-secret.yaml
   # - ./sealed-ghcr-pull-secret-flux-system.yaml
-  # - ./sealed-github-runner-pat.yaml
   #
   # keyvault-system ghcr-pull-secret is NOT here. KVI controller runs
   # on the Harvester cluster (TF-deployed), not on dcapi-controlplane.
@@ -86,33 +85,11 @@ patches:
         value: "ghcr.io/CHANGE-ME-org/cloud-ui"
   # keyvault-operator ImageRepository patch removed — KVI is
   # TF-deployed on Harvester, not Flux-managed here.
-
-  # ARC dc-runner: point at the SOURCE repo where the CI workflows
-  # live, NOT the consumer/Flux state repo. ARC registers runners
-  # per-repo; `runs-on: dc-runner` in source-repo workflows only
-  # matches a runner registered to that repo. PAT secret name stays
-  # as github-runner-pat — that's what the wizard's seal step writes.
   #
-  # Also overrides the runner container image with a "fat" dc-runner
-  # built from the consumer's CI (extends actions/actions-runner with
-  # make, build-essential, kubectl, helm, yq — the toolkit any
-  # Makefile-driven Go project or kubectl-touching workflow needs).
-  # The chart's containerMode:dind helper looks up containers[0] by
-  # name=runner and overlays the dind env/volume wiring on top.
-  # Default below assumes the consumer publishes dc-runner under the
-  # same GHCR org as dc-api/cloud-ui; edit the image ref if you build
-  # it elsewhere.
-  - target: { kind: HelmRelease, name: dc-runner, namespace: arc-runners }
-    patch: |-
-      - op: replace
-        path: /spec/values/githubConfigUrl
-        value: "https://github.com/CHANGE-ME-github-owner/CHANGE-ME-github-repo"
-      - op: add
-        path: /spec/values/template/spec/containers
-        value:
-          - name: runner
-            image: ghcr.io/CHANGE-ME-org/dc-runner:latest
-            command: ["/home/runner/run.sh"]
+  # ARC dc-runner patch removed — the dc-runner is retired (its arc/base is
+  # no longer in flux/platform/kustomization.yaml). Builds run on GitHub-
+  # hosted runners and deploys are done by Flux, so there's nothing left
+  # for an in-cluster self-hosted runner to do.
 
 # Swap the placeholder ghcr.io/wso2/* images in the OCD base Deployments
 # for this consumer's actual builds + pin an initial tag. The

--- a/flux/platform/kustomization.yaml
+++ b/flux/platform/kustomization.yaml
@@ -4,7 +4,9 @@ resources:
   - dc-api/base
   - dc-postgres/base
   - cloud-ui/base
-  - arc/base
+  # arc/base (self-hosted GitHub Actions runner) retired — superseded by the
+  # GitOps model: image builds run on GitHub-hosted runners, deploys are done
+  # by Flux, so the in-cluster push-deploy runner has no remaining job.
 
 # keyvault-operator is NOT here. KVI controller + OpenBao instances
 # run on the Harvester cluster (per docs/kvi-controller-design.md),

--- a/scripts/init-flux.sh
+++ b/scripts/init-flux.sh
@@ -473,21 +473,7 @@ cmd_init() {
   auto_or_ask ocd_ref             "OCD pin (tag or branch)"   "flux-bootstrap"   "ocd_ref"           "spike/flux-gitops"
   auto_or_ask git_branch          "Consumer-repo branch"      "flux-bootstrap"   "git_branch"        "spike/flux-gitops"
 
-  # Used to render the ARC dc-runner HelmRelease's githubConfigUrl
-  # patch. THIS IS THE SOURCE REPO WHERE CI WORKFLOWS LIVE — not the
-  # consumer/Flux state repo. ARC registers runners per-repo; a
-  # workflow in repo-A whose `runs-on: dc-runner` won't match a
-  # runner registered to repo-B.
-  #
-  # Read from the 06-flux-bootstrap layer's `runner_github_owner` +
-  # `runner_github_repo` outputs (consumer sets these in tfvars).
-  # Falls back to prompt if those outputs aren't set yet.
-  echo
-  echo "  ℹ  ARC runner repo: the SOURCE repo where your CI workflows live"
-  echo "     (.github/workflows/*.yaml). NOT the consumer/Flux-state repo."
-  echo "     Auto-resolved from 06-flux-bootstrap tfvars when set there."
-  auto_or_ask runner_github_owner "GitHub owner of the SOURCE repo (where workflows live)" "flux-bootstrap" "runner_github_owner" "" "$SLUG_RE"
-  auto_or_ask runner_github_repo  "GitHub repo name of the SOURCE repo"                   "flux-bootstrap" "runner_github_repo"  "" "$SLUG_RE"
+  # dc-runner retired (no arc/base in flux/platform) — no runner_github_* needed.
   auto_or_ask dc_api_tag          "Initial dc-api image tag"  "flux-bootstrap"   "dc_api_initial_tag"           "latest"
   auto_or_ask cloud_ui_tag        "Initial cloud-ui image tag" "flux-bootstrap"  "cloud_ui_initial_tag"         "latest"
   # keyvault-operator image tag is set by the TF module that deploys
@@ -521,8 +507,6 @@ cmd_init() {
       -e "s|ref=v0\\.9\\.0|ref=$ocd_ref|g" \
       -e "s|github.com/wso2/open-cloud-datacenter|github.com/$ocd_owner/$ocd_repo|g" \
       -e "s|    tag: v0\\.9\\.0|    $ocd_ref_field: $ocd_ref|g" \
-      -e "s|CHANGE-ME-github-owner|$runner_github_owner|g" \
-      -e "s|CHANGE-ME-github-repo|$runner_github_repo|g" \
       "$src" > "$dst"
     echo "  wrote $dst"
   }
@@ -645,13 +629,7 @@ cmd_seal() {
   echo "     Used by dc-system + flux-system to pull images."
   ask_secret ghcr_pat                  "GHCR personal-access token (read:packages)"
 
-  echo
-  echo "  ℹ  Runner PAT: SEPARATE classic GitHub PAT for the ARC self-hosted runner"
-  echo "     to register itself on the consumer repo. Generate at:"
-  echo "       https://github.com/settings/tokens (classic)  →  scope: repo"
-  echo "     Kept separate from the GHCR PAT for least-privilege: the runner PAT"
-  echo "     can register/deregister runners + read issues; the pull PAT only reads packages."
-  ask_secret runner_pat                "GitHub PAT for ARC runner registration (repo scope)"
+  # Runner PAT prompt removed — dc-runner retired (no arc/base in flux/platform).
 
   echo
   echo "  ℹ  Ingress TLS cert (covers both $dcapi_hostname and $cloudui_hostname)"
@@ -728,11 +706,7 @@ cmd_seal() {
   # keyvault-system pull secret removed — KVI runs on Harvester
   # (TF-deployed), not on dcapi-controlplane.
 
-  # GitHub runner PAT — read by the ARC runner scale-set HelmRelease in
-  # arc-runners. The key name `github_token` matches what the
-  # gha-runner-scale-set chart expects when `githubConfigSecret: github-runner-pat`.
-  seal github-runner-pat arc-runners \
-       --from-literal=github_token="$runner_pat"
+  # GitHub runner PAT seal removed — dc-runner retired (no arc/base in flux/platform).
 
   # dc-api-tls
   if [[ "$tls_source" == "b" ]]; then
@@ -775,7 +749,6 @@ cmd_seal() {
       print "  - ./sealed-dc-api-tls.yaml"
       print "  - ./sealed-ghcr-pull-secret.yaml"
       print "  - ./sealed-ghcr-pull-secret-flux-system.yaml"
-      print "  - ./sealed-github-runner-pat.yaml"
       skip = 1
       next
     }


### PR DESCRIPTION
## What

Removes the dc-runner (Actions Runner Controller) from the Flux platform:

- Drops `- arc/base` from `flux/platform/kustomization.yaml` so the platform no longer installs the runner scale set.
- Removes the dc-runner HelmRelease patch and its `sealed-github-runner-pat` reference from the consumer overlay template (`examples/consumer/flux/platform-overlay/kustomization.yaml`).
- Strips the runner-PAT prompts and the `sealed-github-runner-pat` sealing step from `scripts/init-flux.sh`.

## Why

Under the GitOps model, deployments are driven by Flux reconciling Git — not by an in-cluster self-hosted runner. CI runs on GitHub-hosted runners, so the dc-runner had nothing left to do. Removing it simplifies the platform, drops one HelmRelease and its dependencies from every cluster, and removes a long-lived credential (the runner PAT) from the secret surface that operators have to provision and rotate.

## Validation

Rendered the consumer overlay with the updated `init-flux.sh`, sealed the (now runner-PAT-free) secret set, and reconciled a full control-plane cluster end-to-end with Flux: `infrastructure` and `platform` Kustomizations both reach `Ready`, dc-api / cloud-ui / postgres come up, and no `arc`/runner namespaces or HelmReleases remain.
