### PR TITLE
Add node pools support for rancher RKE2 bootstrap cluster module & Optional Nginx LB VM module

### DIFF
--- a/modules/platform/nginx-lb-vm/main.tf
+++ b/modules/platform/nginx-lb-vm/main.tf
@@ -60,8 +60,27 @@ resource "harvester_virtualmachine" "nginx_lb" {
     }
   }
 
+  # Harvester auto-creates a cloudinitdisk when a cloud-init secret is attached.
+  # Declare it here so the provider does not try to remove it on every plan.
+  dynamic "disk" {
+    for_each = [1]
+    content {
+      name = "cloudinitdisk"
+      type = "disk"
+      bus  = "virtio"
+      size = "0Gi"
+    }
+  }
+
   cloudinit {
     user_data_secret_name    = harvester_cloudinit_secret.cloudinit.name
     network_data_secret_name = harvester_cloudinit_secret.cloudinit.name
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Harvester manages the cloudinitdisk size automatically; ignore it to prevent perpetual drift.
+      disk[1].size,
+    ]
   }
 }

--- a/modules/platform/nginx-lb-vm/main.tf
+++ b/modules/platform/nginx-lb-vm/main.tf
@@ -1,0 +1,67 @@
+resource "harvester_cloudinit_secret" "cloudinit" {
+  name      = "${var.vm_name}-cloudinit"
+  namespace = var.harvester_namespace
+
+  user_data = templatefile("${path.module}/templates/cloud-init.yaml.tpl", {
+    password = var.vm_password
+    nginx_conf_b64 = base64encode(templatefile("${path.module}/templates/nginx.conf.tpl", {
+      rancher_hostname = var.rancher_hostname
+      node_ips         = var.rke2_node_ips
+    }))
+    tls_cert_b64        = base64encode(var.tls_cert)
+    tls_key_b64         = base64encode(var.tls_key)
+    ssh_authorized_keys = var.ssh_authorized_keys
+  })
+
+  network_data = templatefile("${path.module}/templates/network-config.yaml.tpl", {
+    static_ip     = var.static_ip
+    gateway       = var.gateway
+    subnet_prefix = var.subnet_prefix
+    dns_servers   = length(var.dns_servers) > 0 ? var.dns_servers : ["8.8.8.8"]
+  })
+}
+
+resource "harvester_virtualmachine" "nginx_lb" {
+  name                 = var.vm_name
+  namespace            = var.harvester_namespace
+  restart_after_update = true
+
+  cpu    = var.vm_cpu
+  memory = var.vm_memory
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  ssh_keys = var.ssh_key_ids
+
+  network_interface {
+    name         = var.network_interface_name
+    type         = "bridge"
+    network_name = var.network_name
+  }
+
+  disk {
+    name       = "disk-0"
+    type       = "disk"
+    size       = var.vm_disk_size
+    bus        = "virtio"
+    boot_order = 1
+
+    image       = var.image_id
+    auto_delete = var.vm_disk_auto_delete
+  }
+
+  dynamic "input" {
+    for_each = var.enable_usb_tablet ? [1] : []
+    content {
+      name = "tablet"
+      type = "tablet"
+      bus  = "usb"
+    }
+  }
+
+  cloudinit {
+    user_data_secret_name    = harvester_cloudinit_secret.cloudinit.name
+    network_data_secret_name = harvester_cloudinit_secret.cloudinit.name
+  }
+}

--- a/modules/platform/nginx-lb-vm/outputs.tf
+++ b/modules/platform/nginx-lb-vm/outputs.tf
@@ -1,0 +1,9 @@
+output "vm_id" {
+  value       = harvester_virtualmachine.nginx_lb.id
+  description = "Harvester resource ID (namespace/name) of the nginx LB VM"
+}
+
+output "static_ip" {
+  value       = var.static_ip
+  description = "Static IP of the nginx LB VM"
+}

--- a/modules/platform/nginx-lb-vm/templates/cloud-init.yaml.tpl
+++ b/modules/platform/nginx-lb-vm/templates/cloud-init.yaml.tpl
@@ -1,0 +1,50 @@
+#cloud-config
+ssh_pwauth: true
+chpasswd:
+  list:
+    - "ubuntu:${password}"
+  expire: False
+%{~ if length(ssh_authorized_keys) > 0 }
+
+ssh_authorized_keys:
+%{ for key in ssh_authorized_keys ~}
+  - ${key}
+%{ endfor ~}
+%{~ endif }
+
+packages:
+  - qemu-guest-agent
+  - curl
+  - gnupg
+  - lsb-release
+
+write_files:
+  - path: /etc/nginx/nginx.conf
+    permissions: '0644'
+    encoding: b64
+    content: ${nginx_conf_b64}
+  - path: /etc/nginx/certs/tls.crt
+    permissions: '0644'
+    encoding: b64
+    content: ${tls_cert_b64}
+  - path: /etc/nginx/certs/tls.key
+    permissions: '0600'
+    encoding: b64
+    content: ${tls_key_b64}
+
+runcmd:
+  - systemctl enable --now qemu-guest-agent
+  - |
+    (
+      until curl -s --connect-timeout 5 http://1.1.1.1 > /dev/null; do
+        sleep 5
+      done
+
+      curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor > /usr/share/keyrings/nginx-archive-keyring.gpg
+      echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" > /etc/apt/sources.list.d/nginx.list
+      apt-get update
+      apt-get install -y nginx
+
+      mkdir -p /etc/nginx/certs
+      nginx -t && systemctl enable --now nginx
+    ) >> /var/log/nginx-setup.log 2>&1 &

--- a/modules/platform/nginx-lb-vm/templates/network-config.yaml.tpl
+++ b/modules/platform/nginx-lb-vm/templates/network-config.yaml.tpl
@@ -1,0 +1,14 @@
+version: 2
+ethernets:
+  enp1s0:
+    dhcp4: false
+    addresses:
+      - ${static_ip}/${subnet_prefix}
+    routes:
+      - to: default
+        via: ${gateway}
+    nameservers:
+      addresses:
+%{~ for dns in dns_servers }
+        - ${dns}
+%{~ endfor }

--- a/modules/platform/nginx-lb-vm/templates/nginx.conf.tpl
+++ b/modules/platform/nginx-lb-vm/templates/nginx.conf.tpl
@@ -1,0 +1,165 @@
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections 4096;
+    multi_accept on;
+    use epoll;
+}
+
+stream {
+
+    upstream rancher-registration {
+        least_conn;
+%{ for ip in node_ips ~}
+        server ${ip}:9345 max_fails=3 fail_timeout=30s;
+%{ endfor ~}
+    }
+
+    upstream rancher-k8s-api {
+        least_conn;
+%{ for ip in node_ips ~}
+        server ${ip}:6443 max_fails=3 fail_timeout=30s;
+%{ endfor ~}
+    }
+
+    server {
+        listen 9345;
+        proxy_pass rancher-registration;
+        proxy_timeout 3600s;
+        proxy_connect_timeout 10s;
+    }
+
+    server {
+        listen 6443;
+        proxy_pass rancher-k8s-api;
+        proxy_timeout 3600s;
+        proxy_connect_timeout 10s;
+    }
+
+}
+
+http {
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 75s;
+    keepalive_requests 10000;
+    types_hash_max_size 2048;
+    server_tokens off;
+
+    client_max_body_size 200M;
+    client_body_buffer_size 512k;
+
+    proxy_buffer_size 128k;
+    proxy_buffers 8 256k;
+    proxy_busy_buffers_size 256k;
+    proxy_temp_file_write_size 256k;
+
+    proxy_read_timeout 300s;
+    proxy_connect_timeout 10s;
+    proxy_send_timeout 300s;
+
+    open_file_cache max=20000 inactive=30s;
+    open_file_cache_valid 60s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors on;
+
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_timeout 1h;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 1024;
+    gzip_proxied any;
+
+    server {
+        listen 80;
+        server_name ${rancher_hostname};
+        return 301 https://$host$request_uri;
+    }
+
+    upstream rancher-nodeport {
+        least_conn;
+%{ for ip in node_ips ~}
+        server ${ip}:443 max_fails=3 fail_timeout=30s;
+%{ endfor ~}
+        keepalive 64;
+    }
+
+    server {
+
+        listen 443 ssl http2;
+        server_name ${rancher_hostname};
+
+        ssl_certificate     /etc/nginx/certs/tls.crt;
+        ssl_certificate_key /etc/nginx/certs/tls.key;
+
+        location ^~ /k8s/clusters/ {
+            proxy_pass https://rancher-nodeport;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
+        location ~* ^/(v3/subscribe|api/websocket) {
+            proxy_pass https://rancher-nodeport;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
+        location ~* ^/(assets/|dashboard/assets/) {
+            proxy_pass https://rancher-nodeport;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering on;
+            expires 1h;
+            add_header Cache-Control "public";
+            etag on;
+        }
+
+        location / {
+            proxy_pass https://rancher-nodeport;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_buffering on;
+            proxy_read_timeout 300s;
+        }
+
+    }
+
+}

--- a/modules/platform/nginx-lb-vm/variables.tf
+++ b/modules/platform/nginx-lb-vm/variables.tf
@@ -1,0 +1,124 @@
+variable "vm_name" {
+  type        = string
+  description = "Name of the nginx load balancer VM"
+  default     = "rancher-lb"
+}
+
+variable "harvester_namespace" {
+  type        = string
+  description = "Harvester namespace to deploy into"
+}
+
+variable "vm_cpu" {
+  type        = number
+  description = "vCPU count"
+  default     = 2
+}
+
+variable "vm_memory" {
+  type        = string
+  description = "Memory size (e.g. '4Gi')"
+  default     = "4Gi"
+}
+
+variable "vm_disk_size" {
+  type        = string
+  description = "Root disk size"
+  default     = "20Gi"
+}
+
+variable "vm_disk_auto_delete" {
+  type    = bool
+  default = true
+}
+
+variable "image_id" {
+  type        = string
+  description = "Harvester image ID (namespace/name) for the VM OS image"
+}
+
+variable "network_name" {
+  type        = string
+  description = "Full NAD reference (namespace/name) for the bridge network"
+}
+
+variable "network_interface_name" {
+  type    = string
+  default = "nic-1"
+}
+
+variable "vm_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "ssh_key_ids" {
+  type        = list(string)
+  description = "Existing Harvester SSH key IDs to attach"
+  default     = []
+}
+
+variable "ssh_authorized_keys" {
+  type        = list(string)
+  description = "Actual SSH public key strings to place in cloud-init ssh_authorized_keys. Harvester requires these to match any key referenced in ssh_key_ids."
+  default     = []
+}
+
+variable "static_ip" {
+  type        = string
+  description = "Static IP address for the nginx LB VM"
+
+  validation {
+    condition     = var.static_ip != ""
+    error_message = "static_ip is required for the nginx LB VM."
+  }
+}
+
+variable "gateway" {
+  type        = string
+  description = "Default gateway for the static IP"
+}
+
+variable "subnet_prefix" {
+  type        = number
+  description = "CIDR prefix length (e.g. 25 for /25)"
+  default     = 24
+}
+
+variable "dns_servers" {
+  type        = list(string)
+  description = "DNS servers written as nameservers in netplan. Defaults to [\"8.8.8.8\"] when empty."
+  default     = []
+}
+
+variable "rke2_node_ips" {
+  type        = list(string)
+  description = "List of RKE2 node IPs to load-balance"
+
+  validation {
+    condition     = length(var.rke2_node_ips) > 0
+    error_message = "At least one RKE2 node IP must be provided."
+  }
+}
+
+variable "rancher_hostname" {
+  type        = string
+  description = "FQDN used as nginx server_name for the Rancher vhost"
+}
+
+variable "tls_cert" {
+  type        = string
+  sensitive   = true
+  description = "PEM-encoded TLS certificate (full chain)"
+}
+
+variable "tls_key" {
+  type        = string
+  sensitive   = true
+  description = "PEM-encoded TLS private key"
+}
+
+variable "enable_usb_tablet" {
+  type    = bool
+  default = true
+}

--- a/modules/platform/nginx-lb-vm/versions.tf
+++ b/modules/platform/nginx-lb-vm/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    harvester = {
+      source  = "harvester/harvester"
+      version = "~> 1.7"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/platform/rancher/main.tf
+++ b/modules/platform/rancher/main.tf
@@ -17,6 +17,10 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -58,6 +62,29 @@ resource "harvester_image" "vm_image" {
 
 locals {
   image_id = var.image_url != "" ? harvester_image.vm_image[0].id : var.ubuntu_image_id
+
+  # Parse the Harvester kubeconfig so cloud-init can query the Kubernetes API from
+  # inside each VM to discover its virt-launcher pod IP.  In masquerade mode every
+  # VM gets the same internal address (10.0.2.2), so without the pod IP etcd peer
+  # URLs conflict and the secondary nodes can never join.  The pod IPs are unique
+  # and reachable between VMs via the Calico overlay (10.52.x.x range).
+  #
+  # Only parsed when kubeconfig_path is set AND node_count > 1 (single-node has no
+  # etcd peers so the default 10.0.2.2 node-ip is fine).
+  #
+  # try() guards against file("") when kubeconfig_path is empty — Terraform
+  # evaluates both branches of a ternary for errors, so a plain file() call
+  # with an empty-string path would fail even when the condition is false.
+  _kc_content = try(file(var.harvester_kubeconfig_path), "")
+  _kc = (
+    var.node_count > 1 && local._kc_content != ""
+    ? yamldecode(local._kc_content)
+    : null
+  )
+  harvester_api_url  = try(local._kc.clusters[0].cluster.server, "")
+  harvester_ca_b64   = try(local._kc.clusters[0].cluster["certificate-authority-data"], "")
+  harvester_cert_b64 = try(local._kc.users[0].user["client-certificate-data"], "")
+  harvester_key_b64  = try(local._kc.users[0].user["client-key-data"], "")
 }
 
 check "image_source_required" {
@@ -65,6 +92,14 @@ check "image_source_required" {
     condition     = var.image_url != "" || var.ubuntu_image_id != ""
     error_message = "Either image_url (to download a new image) or ubuntu_image_id (to reference an existing one) must be set."
   }
+}
+
+# ── RKE2 cluster join token ───────────────────────────────────────────────────
+# Generated once and stored in Terraform state. All nodes receive the same token
+# via their individual cloud-init secrets so they can form a cluster.
+resource "random_password" "rke2_token" {
+  length  = 64
+  special = false
 }
 
 # ── SSH key pair (greenfield only) ────────────────────────────────────────────
@@ -92,18 +127,35 @@ resource "harvester_cloudinit_secret" "cloudinit" {
   depends_on = [kubernetes_namespace.harvester_ns]
 
   user_data = templatefile("${path.module}/templates/cloud-init.yaml.tpl", {
-    password         = var.vm_password
-    cluster_dns      = var.rancher_hostname
-    rancher_password = var.bootstrap_password
-    ssh_public_key   = tls_private_key.bootstrap_key[0].public_key_openssh
-    node_index       = count.index
-    node_count       = var.node_count
-    lb_ip            = var.ippool_start
-    rke2_version     = var.rke2_version
-    rancher_version  = var.rancher_version
-    tls_source       = var.tls_source
-    tls_cert_b64     = var.tls_source == "secret" ? base64encode(var.tls_cert) : ""
-    tls_key_b64      = var.tls_source == "secret" ? base64encode(var.tls_key) : ""
+    password           = var.vm_password
+    cluster_dns        = var.rancher_hostname
+    rancher_password   = var.bootstrap_password
+    ssh_public_key     = tls_private_key.bootstrap_key[0].public_key_openssh
+    node_index         = count.index
+    node_count         = var.node_count
+    lb_ip              = var.ippool_start
+    rke2_version       = var.rke2_version
+    rancher_version    = var.rancher_version
+    tls_source         = var.tls_source
+    tls_cert_b64       = var.tls_source == "secret" ? base64encode(var.tls_cert) : ""
+    tls_key_b64        = var.tls_source == "secret" ? base64encode(var.tls_key) : ""
+    rke2_cluster_token = random_password.rke2_token.result
+    primary_dns        = var.primary_dns
+    # Pod IP discovery (masquerade) / ConfigMap join coordination (bridge+MetalLB):
+    # both paths use the Harvester Kubernetes API with the embedded kubeconfig creds.
+    harvester_api_url   = local.harvester_api_url
+    harvester_ca_b64    = local.harvester_ca_b64
+    harvester_cert_b64  = local.harvester_cert_b64
+    harvester_key_b64   = local.harvester_key_b64
+    harvester_namespace = var.harvester_namespace
+    # MetalLB: when use_metallb = true, MetalLB is installed on node 0 and the
+    # VIP (ippool_start) is announced via L2 on the VM VLAN instead of using
+    # the Harvester LB controller (which cannot reach bridge-mode VM backends
+    # without inter-VLAN routing from Harvester host nodes to the guest VLAN).
+    use_metallb     = var.use_metallb
+    metallb_version = var.metallb_version
+    metallb_ip      = var.ippool_start
+    vm_name         = var.vm_name
   })
 }
 
@@ -131,6 +183,37 @@ check "existing_cloudinit_secret_name_required" {
   }
 }
 
+# ── Bridge network (greenfield) ───────────────────────────────────────────────
+# Creates a NetworkAttachmentDefinition in harvester_namespace so bridge-mode VMs
+# can attach to it. The NAD name is var.network_name; VMs reference it as
+# "<namespace>/<name>". Set create_bridge_network = false when the NAD already
+# exists (brownfield) and pass the full "<namespace>/<name>" as network_name.
+resource "harvester_network" "bridge" {
+  count = var.network_type == "bridge" && var.create_bridge_network ? 1 : 0
+
+  name                 = var.network_name
+  namespace            = var.harvester_namespace
+  vlan_id              = var.cluster_vlan_id
+  cluster_network_name = var.cluster_network_name
+
+  route_mode    = var.cluster_vlan_gateway != "" ? "manual" : "auto"
+  route_cidr    = var.cluster_vlan_gateway != "" ? var.cluster_vlan_cidr : null
+  route_gateway = var.cluster_vlan_gateway != "" ? var.cluster_vlan_gateway : null
+
+  depends_on = [kubernetes_namespace.harvester_ns]
+}
+
+locals {
+  # Full NAD reference for the VM spec. When we created the NAD ourselves the
+  # name is short (e.g. "rancher-network"); we prefix the namespace. When the
+  # caller owns a pre-existing NAD they must pass the full "<ns>/<name>" form.
+  bridge_network_name = (
+    var.network_type == "bridge" && var.create_bridge_network
+    ? "${var.harvester_namespace}/${var.network_name}"
+    : var.network_name
+  )
+}
+
 # ── Rancher server VM ─────────────────────────────────────────────────────────
 resource "harvester_virtualmachine" "rancher_server" {
   count                = var.node_count
@@ -138,9 +221,12 @@ resource "harvester_virtualmachine" "rancher_server" {
   namespace            = var.harvester_namespace
   restart_after_update = true
 
-  # Storage network must be configured before any VM starts; Harvester rejects
-  # storage-network changes while VMs are running.
-  depends_on = [null_resource.storage_network]
+  # Bridge NAD must exist before the VM; storage-network must be set before any
+  # VM starts (Harvester rejects storage-network changes while VMs are running).
+  depends_on = [
+    null_resource.storage_network,
+    harvester_network.bridge,
+  ]
 
   cpu    = var.vm_cpu
   memory = var.vm_memory
@@ -165,7 +251,7 @@ resource "harvester_virtualmachine" "rancher_server" {
     content {
       name         = var.network_interface_name
       type         = "bridge"
-      network_name = var.network_name
+      network_name = local.bridge_network_name
       mac_address  = var.network_mac_address != "" ? var.network_mac_address : null
     }
   }
@@ -206,7 +292,7 @@ resource "harvester_virtualmachine" "rancher_server" {
 # Set create_lb = false when the Rancher VM is reachable directly via its
 # bridge IP (no dedicated LB/IP-pool needed).
 resource "harvester_loadbalancer" "rancher_lb" {
-  count     = var.create_lb ? 1 : 0
+  count     = var.create_lb && !var.use_metallb ? 1 : 0
   name      = "${var.vm_name}-lb"
   namespace = var.harvester_namespace
 
@@ -248,17 +334,30 @@ resource "harvester_loadbalancer" "rancher_lb" {
     values = harvester_virtualmachine.rancher_server[*].name
   }
 
-  healthcheck {
-    port              = 443
-    success_threshold = 1
-    failure_threshold = 3
-    period_seconds    = 10
-    timeout_seconds   = 5
+  # Health check on port 9345 is safe for masquerade mode: the VIP lives on
+  # mgmt-br which shares L2 with masquerade VM traffic, so probes succeed.
+  # In bridge mode the VIP is on mgmt-br (192.168.11.x) but backends are on
+  # the VLAN (172.24.0.x). The kube-vip probe goes out mgmt-br, hits the
+  # datacenter router, and reaches the VM — but only if inter-VLAN routing is
+  # configured at the switch/router level. When it is not, the probe returns
+  # no response and healthy=0, preventing ANY traffic from being forwarded.
+  # Omitting the healthcheck lets kube-vip treat all backends as healthy and
+  # forward traffic unconditionally, which is safe once the cluster is up, and
+  # lets secondary nodes reach node-0 for the initial join even before 443 is up.
+  dynamic "healthcheck" {
+    for_each = var.network_type == "masquerade" ? [1] : []
+    content {
+      port              = 9345
+      success_threshold = 1
+      failure_threshold = 3
+      period_seconds    = 10
+      timeout_seconds   = 5
+    }
   }
 }
 
 resource "harvester_ippool" "rancher_ips" {
-  count = var.create_lb ? 1 : 0
+  count = var.create_lb && !var.use_metallb ? 1 : 0
   name  = "${var.vm_name}-ips"
 
   range {

--- a/modules/platform/rancher/main.tf
+++ b/modules/platform/rancher/main.tf
@@ -24,10 +24,6 @@ terraform {
   }
 }
 
-# ── Harvester namespace ───────────────────────────────────────────────────────
-# Creates a dedicated namespace for bootstrap resources when harvester_namespace
-# is not "default". Labelled as infrastructure so the namespace-credential-
-# provisioner skips it (it only provisions credentials for tenant namespaces).
 resource "kubernetes_namespace" "harvester_ns" {
   count = var.harvester_namespace != "default" ? 1 : 0
   metadata {
@@ -36,15 +32,11 @@ resource "kubernetes_namespace" "harvester_ns" {
       "platform.wso2.com/role" = "infrastructure"
     }
   }
-
   lifecycle {
     ignore_changes = [metadata[0].annotations]
   }
 }
 
-# ── Cloud image ───────────────────────────────────────────────────────────────
-# Downloads and registers the image when image_url is provided.
-# Set ubuntu_image_id instead to reference a pre-existing image (brownfield).
 resource "harvester_image" "vm_image" {
   count        = var.image_url != "" ? 1 : 0
   name         = var.image_name
@@ -63,21 +55,9 @@ resource "harvester_image" "vm_image" {
 locals {
   image_id = var.image_url != "" ? harvester_image.vm_image[0].id : var.ubuntu_image_id
 
-  # Parse the Harvester kubeconfig so cloud-init can query the Kubernetes API from
-  # inside each VM to discover its virt-launcher pod IP.  In masquerade mode every
-  # VM gets the same internal address (10.0.2.2), so without the pod IP etcd peer
-  # URLs conflict and the secondary nodes can never join.  The pod IPs are unique
-  # and reachable between VMs via the Calico overlay (10.52.x.x range).
-  #
-  # Only parsed when kubeconfig_path is set AND node_count > 1 (single-node has no
-  # etcd peers so the default 10.0.2.2 node-ip is fine).
-  #
-  # try() guards against file("") when kubeconfig_path is empty — Terraform
-  # evaluates both branches of a ternary for errors, so a plain file() call
-  # with an empty-string path would fail even when the condition is false.
   _kc_content = try(file(var.harvester_kubeconfig_path), "")
   _kc = (
-    var.node_count > 1 && local._kc_content != ""
+    var.node_count > 1 && length(var.node_pools) == 0 && local._kc_content != ""
     ? yamldecode(local._kc_content)
     : null
   )
@@ -85,25 +65,93 @@ locals {
   harvester_ca_b64   = try(local._kc.clusters[0].cluster["certificate-authority-data"], "")
   harvester_cert_b64 = try(local._kc.users[0].user["client-certificate-data"], "")
   harvester_key_b64  = try(local._kc.users[0].user["client-key-data"], "")
+
+  # ── Static node pool helpers ─────────────────────────────────────────────────
+  _static_nodes_flat = flatten([
+    for pool_idx, pool in var.node_pools : [
+      for ip_idx, ip in pool.ips : {
+        key           = "${pool.name}-${ip_idx}"
+        pool_name     = pool.name
+        pool_idx      = pool_idx
+        ip            = ip
+        ip_idx        = ip_idx
+        control_plane = pool.control_plane
+        etcd          = pool.etcd
+        worker        = pool.worker
+      }
+    ]
+  ])
+
+  _cp_nodes     = [for n in local._static_nodes_flat : n if n.control_plane]
+  _first_cp_key = length(local._cp_nodes) > 0 ? local._cp_nodes[0].key : ""
+  _first_cp_ip  = length(local._cp_nodes) > 0 ? local._cp_nodes[0].ip : ""
+
+  static_node_map = {
+    for n in local._static_nodes_flat : n.key => merge(n, {
+      is_init = n.key == local._first_cp_key
+    })
+  }
+
+  use_static_nodes = length(var.node_pools) > 0
+  cp_node_count    = length(local._cp_nodes)
+  total_node_count = local.use_static_nodes ? length(local._static_nodes_flat) : var.node_count
+
+  # Join address for secondary nodes: nginx LB or first CP node IP
+  join_address = var.use_nginx_lb ? var.nginx_lb_ip : local._first_cp_ip
+
+  # Effective LB IP for tls-san and rancher_lb_ip output
+  effective_lb_ip = (
+    var.use_nginx_lb ? var.nginx_lb_ip :
+    var.create_lb ? var.ippool_start :
+    var.static_rancher_ip
+  )
+
+  bridge_network_name = (
+    var.network_type == "bridge" && var.create_bridge_network
+    ? "${var.harvester_namespace}/${var.network_name}"
+    : var.network_name
+  )
+
+  ssh_key_ids = var.create_ssh_key ? [harvester_ssh_key.bootstrap_key[0].id] : var.ssh_key_ids
+
+  # Shared cloud-init template variables
+  _common_ci_vars = {
+    password           = var.vm_password
+    cluster_dns        = var.rancher_hostname
+    rancher_password   = var.bootstrap_password
+    ssh_public_key     = var.create_ssh_key ? tls_private_key.bootstrap_key[0].public_key_openssh : ""
+    rke2_version       = var.rke2_version
+    rancher_version    = var.rancher_version
+    tls_source         = var.use_nginx_lb ? "rancher" : var.tls_source
+    tls_cert_b64       = (!var.use_nginx_lb && var.tls_source == "secret") ? base64encode(var.tls_cert) : ""
+    tls_key_b64        = (!var.use_nginx_lb && var.tls_source == "secret") ? base64encode(var.tls_key) : ""
+    rke2_cluster_token = random_password.rke2_token.result
+    dns_servers        = var.dns_servers
+    lb_ip              = local.effective_lb_ip
+    use_nginx_lb       = var.use_nginx_lb
+    use_rancher_prime  = var.use_rancher_prime
+  }
 }
 
 check "image_source_required" {
   assert {
     condition     = var.image_url != "" || var.ubuntu_image_id != ""
-    error_message = "Either image_url (to download a new image) or ubuntu_image_id (to reference an existing one) must be set."
+    error_message = "Either image_url or ubuntu_image_id must be set."
   }
 }
 
-# ── RKE2 cluster join token ───────────────────────────────────────────────────
-# Generated once and stored in Terraform state. All nodes receive the same token
-# via their individual cloud-init secrets so they can form a cluster.
+check "node_gateway_required_for_static" {
+  assert {
+    condition     = !local.use_static_nodes || var.node_gateway != ""
+    error_message = "node_gateway is required when node_pools is set."
+  }
+}
+
 resource "random_password" "rke2_token" {
   length  = 64
   special = false
 }
 
-# ── SSH key pair (greenfield only) ────────────────────────────────────────────
-# Set create_ssh_key = false to attach existing ssh_key_ids instead.
 resource "tls_private_key" "bootstrap_key" {
   count     = var.create_ssh_key ? 1 : 0
   algorithm = "RSA"
@@ -118,64 +166,13 @@ resource "harvester_ssh_key" "bootstrap_key" {
   depends_on = [kubernetes_namespace.harvester_ns]
 }
 
-# ── Cloud-init secret (greenfield only) ──────────────────────────────────────
-# Set create_cloudinit_secret = false and provide existing_cloudinit_secret_name instead.
-resource "harvester_cloudinit_secret" "cloudinit" {
-  count      = var.create_cloudinit_secret ? var.node_count : 0
-  name       = var.node_count > 1 ? "${var.vm_name}-cloudinit-${count.index}" : "${var.vm_name}-cloudinit"
-  namespace  = var.harvester_namespace
-  depends_on = [kubernetes_namespace.harvester_ns]
-
-  user_data = templatefile("${path.module}/templates/cloud-init.yaml.tpl", {
-    password           = var.vm_password
-    cluster_dns        = var.rancher_hostname
-    rancher_password   = var.bootstrap_password
-    ssh_public_key     = tls_private_key.bootstrap_key[0].public_key_openssh
-    node_index         = count.index
-    node_count         = var.node_count
-    lb_ip              = var.ippool_start
-    rke2_version       = var.rke2_version
-    rancher_version    = var.rancher_version
-    tls_source         = var.tls_source
-    tls_cert_b64       = var.tls_source == "secret" ? base64encode(var.tls_cert) : ""
-    tls_key_b64        = var.tls_source == "secret" ? base64encode(var.tls_key) : ""
-    rke2_cluster_token = random_password.rke2_token.result
-    primary_dns        = var.primary_dns
-    # Pod IP discovery (masquerade) / ConfigMap join coordination (bridge+MetalLB):
-    # both paths use the Harvester Kubernetes API with the embedded kubeconfig creds.
-    harvester_api_url   = local.harvester_api_url
-    harvester_ca_b64    = local.harvester_ca_b64
-    harvester_cert_b64  = local.harvester_cert_b64
-    harvester_key_b64   = local.harvester_key_b64
-    harvester_namespace = var.harvester_namespace
-    # MetalLB: when use_metallb = true, MetalLB is installed on node 0 and the
-    # VIP (ippool_start) is announced via L2 on the VM VLAN instead of using
-    # the Harvester LB controller (which cannot reach bridge-mode VM backends
-    # without inter-VLAN routing from Harvester host nodes to the guest VLAN).
-    use_metallb     = var.use_metallb
-    metallb_version = var.metallb_version
-    metallb_ip      = var.ippool_start
-    vm_name         = var.vm_name
-  })
-}
-
-locals {
-  # Resolve the SSH key IDs: either freshly generated or caller-supplied
-  ssh_key_ids = var.create_ssh_key ? [harvester_ssh_key.bootstrap_key[0].id] : var.ssh_key_ids
-}
-
-# ── Input validation ──────────────────────────────────────────────────────────
-
-# The cloud-init template embeds the generated SSH public key. If create_ssh_key
-# is false the tls_private_key resource is empty, causing an invalid-index error.
 check "ssh_key_required_for_cloudinit" {
   assert {
     condition     = !var.create_cloudinit_secret || var.create_ssh_key
-    error_message = "create_ssh_key must be true when create_cloudinit_secret is true (the cloud-init template embeds the generated SSH public key)."
+    error_message = "create_ssh_key must be true when create_cloudinit_secret is true."
   }
 }
 
-# When reusing an existing cloud-init secret, the name must be provided.
 check "existing_cloudinit_secret_name_required" {
   assert {
     condition     = var.create_cloudinit_secret || var.existing_cloudinit_secret_name != ""
@@ -183,11 +180,6 @@ check "existing_cloudinit_secret_name_required" {
   }
 }
 
-# ── Bridge network (greenfield) ───────────────────────────────────────────────
-# Creates a NetworkAttachmentDefinition in harvester_namespace so bridge-mode VMs
-# can attach to it. The NAD name is var.network_name; VMs reference it as
-# "<namespace>/<name>". Set create_bridge_network = false when the NAD already
-# exists (brownfield) and pass the full "<namespace>/<name>" as network_name.
 resource "harvester_network" "bridge" {
   count = var.network_type == "bridge" && var.create_bridge_network ? 1 : 0
 
@@ -203,26 +195,28 @@ resource "harvester_network" "bridge" {
   depends_on = [kubernetes_namespace.harvester_ns]
 }
 
-locals {
-  # Full NAD reference for the VM spec. When we created the NAD ourselves the
-  # name is short (e.g. "rancher-network"); we prefix the namespace. When the
-  # caller owns a pre-existing NAD they must pass the full "<ns>/<name>" form.
-  bridge_network_name = (
-    var.network_type == "bridge" && var.create_bridge_network
-    ? "${var.harvester_namespace}/${var.network_name}"
-    : var.network_name
-  )
+# ── Legacy count-based cloud-init + VMs (when node_pools is empty) ────────────
+resource "harvester_cloudinit_secret" "cloudinit" {
+  count      = var.create_cloudinit_secret && !local.use_static_nodes ? var.node_count : 0
+  name       = var.node_count > 1 ? "${var.vm_name}-cloudinit-${count.index}" : "${var.vm_name}-cloudinit"
+  namespace  = var.harvester_namespace
+  depends_on = [kubernetes_namespace.harvester_ns]
+
+  user_data = templatefile("${path.module}/templates/cloud-init.yaml.tpl", merge(local._common_ci_vars, {
+    is_init_node     = count.index == 0
+    is_control_plane = true
+    join_ip          = ""
+    total_node_count = var.node_count
+    cp_node_count    = var.node_count
+  }))
 }
 
-# ── Rancher server VM ─────────────────────────────────────────────────────────
 resource "harvester_virtualmachine" "rancher_server" {
-  count                = var.node_count
+  count                = !local.use_static_nodes ? var.node_count : 0
   name                 = var.node_count > 1 ? "${var.vm_name}-${count.index}" : var.vm_name
   namespace            = var.harvester_namespace
   restart_after_update = true
 
-  # Bridge NAD must exist before the VM; storage-network must be set before any
-  # VM starts (Harvester rejects storage-network changes while VMs are running).
   depends_on = [
     null_resource.storage_network,
     harvester_network.bridge,
@@ -236,7 +230,6 @@ resource "harvester_virtualmachine" "rancher_server" {
 
   ssh_keys = local.ssh_key_ids
 
-  # Masquerade (NAT): default for greenfield; no external network required
   dynamic "network_interface" {
     for_each = var.network_type == "masquerade" ? [1] : []
     content {
@@ -245,7 +238,6 @@ resource "harvester_virtualmachine" "rancher_server" {
     }
   }
 
-  # Bridge: for VMs that need direct VLAN access (e.g. existing production VMs)
   dynamic "network_interface" {
     for_each = var.network_type == "bridge" ? [1] : []
     content {
@@ -267,8 +259,6 @@ resource "harvester_virtualmachine" "rancher_server" {
     auto_delete = var.vm_disk_auto_delete
   }
 
-  # USB tablet input device — some VMs require this for correct cursor behaviour
-  # in the Harvester console; set enable_usb_tablet = true to include it.
   dynamic "input" {
     for_each = var.enable_usb_tablet ? [1] : []
     content {
@@ -288,11 +278,97 @@ resource "harvester_virtualmachine" "rancher_server" {
   }
 }
 
-# ── Load Balancer + IP Pool (greenfield only) ─────────────────────────────────
-# Set create_lb = false when the Rancher VM is reachable directly via its
-# bridge IP (no dedicated LB/IP-pool needed).
+# ── Static node pool cloud-init + VMs (when node_pools is set) ───────────────
+resource "harvester_cloudinit_secret" "cloudinit_static" {
+  for_each = local.use_static_nodes && var.create_cloudinit_secret ? local.static_node_map : {}
+
+  name       = "${var.vm_name}-cloudinit-${each.key}"
+  namespace  = var.harvester_namespace
+  depends_on = [kubernetes_namespace.harvester_ns]
+
+  user_data = templatefile("${path.module}/templates/cloud-init.yaml.tpl", merge(local._common_ci_vars, {
+    is_init_node     = each.value.is_init
+    is_control_plane = each.value.control_plane
+    join_ip          = local.join_address
+    total_node_count = local.total_node_count
+    cp_node_count    = local.cp_node_count
+  }))
+
+  network_data = templatefile("${path.module}/templates/network-config.yaml.tpl", {
+    static_ip     = each.value.ip
+    gateway       = var.node_gateway
+    subnet_prefix = var.node_subnet_prefix
+    dns_servers   = length(var.dns_servers) > 0 ? var.dns_servers : ["8.8.8.8"]
+  })
+}
+
+resource "harvester_virtualmachine" "rancher_server_static" {
+  for_each = local.use_static_nodes ? local.static_node_map : {}
+
+  name                 = "${var.vm_name}-${each.key}"
+  namespace            = var.harvester_namespace
+  restart_after_update = true
+
+  depends_on = [
+    null_resource.storage_network,
+    harvester_network.bridge,
+  ]
+
+  cpu    = var.vm_cpu
+  memory = var.vm_memory
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  ssh_keys = local.ssh_key_ids
+
+  dynamic "network_interface" {
+    for_each = var.network_type == "masquerade" ? [1] : []
+    content {
+      name = var.network_interface_name
+      type = "masquerade"
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_type == "bridge" ? [1] : []
+    content {
+      name         = var.network_interface_name
+      type         = "bridge"
+      network_name = local.bridge_network_name
+      mac_address  = var.network_mac_address != "" ? var.network_mac_address : null
+    }
+  }
+
+  disk {
+    name       = var.vm_disk_name
+    type       = "disk"
+    size       = var.vm_disk_size
+    bus        = "virtio"
+    boot_order = 1
+
+    image       = local.image_id
+    auto_delete = var.vm_disk_auto_delete
+  }
+
+  dynamic "input" {
+    for_each = var.enable_usb_tablet ? [1] : []
+    content {
+      name = "tablet"
+      type = "tablet"
+      bus  = "usb"
+    }
+  }
+
+  cloudinit {
+    user_data_secret_name    = harvester_cloudinit_secret.cloudinit_static[each.key].name
+    network_data_secret_name = harvester_cloudinit_secret.cloudinit_static[each.key].name
+  }
+}
+
+# ── Harvester LoadBalancer + IP Pool (for lk-dev and similar environments) ────
 resource "harvester_loadbalancer" "rancher_lb" {
-  count     = var.create_lb && !var.use_metallb ? 1 : 0
+  count     = var.create_lb ? 1 : 0
   name      = "${var.vm_name}-lb"
   namespace = var.harvester_namespace
 
@@ -319,9 +395,6 @@ resource "harvester_loadbalancer" "rancher_lb" {
     backend_port = 80
   }
 
-  # Required for HA (node_count > 1): secondary nodes join by dialling the LB
-  # supervisor port (9345) so the join address is stable regardless of which
-  # node is currently the active RKE2 init server.
   listener {
     name         = "rke2-supervisor"
     port         = 9345
@@ -334,16 +407,6 @@ resource "harvester_loadbalancer" "rancher_lb" {
     values = harvester_virtualmachine.rancher_server[*].name
   }
 
-  # Health check on port 9345 is safe for masquerade mode: the VIP lives on
-  # mgmt-br which shares L2 with masquerade VM traffic, so probes succeed.
-  # In bridge mode the VIP is on mgmt-br (192.168.11.x) but backends are on
-  # the VLAN (172.24.0.x). The kube-vip probe goes out mgmt-br, hits the
-  # datacenter router, and reaches the VM — but only if inter-VLAN routing is
-  # configured at the switch/router level. When it is not, the probe returns
-  # no response and healthy=0, preventing ANY traffic from being forwarded.
-  # Omitting the healthcheck lets kube-vip treat all backends as healthy and
-  # forward traffic unconditionally, which is safe once the cluster is up, and
-  # lets secondary nodes reach node-0 for the initial join even before 443 is up.
   dynamic "healthcheck" {
     for_each = var.network_type == "masquerade" ? [1] : []
     content {
@@ -357,7 +420,7 @@ resource "harvester_loadbalancer" "rancher_lb" {
 }
 
 resource "harvester_ippool" "rancher_ips" {
-  count = var.create_lb && !var.use_metallb ? 1 : 0
+  count = var.create_lb ? 1 : 0
   name  = "${var.vm_name}-ips"
 
   range {
@@ -376,16 +439,8 @@ resource "harvester_ippool" "rancher_ips" {
 }
 
 # ── Storage class ─────────────────────────────────────────────────────────────
-# Creates a Longhorn StorageClass with a reduced replica count and marks it as
-# the cluster default. The built-in harvester-longhorn (3 replicas) is unset as
-# default so only one default exists at a time.
-# Set manage_storage_class = false to skip (brownfield clusters where the SC
-# already exists, or single-node setups where 3 replicas cannot be satisfied).
 resource "kubernetes_storage_class_v1" "default" {
-  count = var.manage_storage_class ? 1 : 0
-
-  # Must run after harvester-longhorn loses its default annotation, otherwise
-  # the Harvester admission webhook rejects creating a second default SC.
+  count      = var.manage_storage_class ? 1 : 0
   depends_on = [kubernetes_annotations.harvester_longhorn_not_default]
 
   metadata {
@@ -409,8 +464,6 @@ resource "kubernetes_storage_class_v1" "default" {
   }
 }
 
-# Remove the default annotation from the built-in harvester-longhorn StorageClass
-# so there is exactly one cluster default after the new SC is created.
 resource "kubernetes_annotations" "harvester_longhorn_not_default" {
   count       = var.manage_storage_class ? 1 : 0
   api_version = "storage.k8s.io/v1"
@@ -450,9 +503,6 @@ resource "kubernetes_storage_class_v1" "longhorn_rwx" {
 }
 
 # ── Storage network ───────────────────────────────────────────────────────────
-# Configures the Harvester storage-network Setting so Longhorn replication
-# traffic is isolated on a dedicated VLAN rather than sharing the management NIC.
-# Harvester stores the value as a JSON string inside the Setting CRD.
 resource "null_resource" "storage_network" {
   count = var.manage_storage_network ? 1 : 0
 
@@ -475,7 +525,6 @@ resource "null_resource" "storage_network" {
         exclude        = var.storage_network_exclude_ranges
       })
     }
-    # Harvester pre-creates an empty storage-network Setting; patch rather than create.
     command = <<-EOT
       python3 -c "
 import subprocess, json, os
@@ -490,10 +539,6 @@ print('storage-network patched:', patch)
   }
 }
 
-# Patch the built-in longhorn StorageClass replica count.
-# StorageClass parameters are immutable in the Kubernetes API, so the only way
-# to change numberOfReplicas is delete + recreate. kubectl handles this; the
-# kubernetes provider cannot update parameters in-place.
 resource "null_resource" "patch_longhorn_sc" {
   count = var.manage_storage_class ? 1 : 0
 
@@ -505,12 +550,6 @@ resource "null_resource" "patch_longhorn_sc" {
     environment = {
       KUBECONFIG = var.harvester_kubeconfig_path
     }
-    # The longhorn SC is owned by the Longhorn operator, which reconciles it from
-    # the longhorn-storageclass ConfigMap. Patching the SC directly fails because:
-    #   1. parameters are immutable in the Kubernetes API
-    #   2. Longhorn recreates the SC faster than a delete+apply can run
-    # Correct approach: patch the ConfigMap (source of truth), then delete the SC
-    # so Longhorn recreates it from the updated ConfigMap with the new replica count.
     command = <<-EOT
       python3 -c "
 import subprocess, json, re, os

--- a/modules/platform/rancher/main.tf
+++ b/modules/platform/rancher/main.tf
@@ -143,9 +143,9 @@ locals {
     ssh_public_key     = var.create_ssh_key ? tls_private_key.bootstrap_key[0].public_key_openssh : ""
     rke2_version       = var.rke2_version
     rancher_version    = var.rancher_version
-    tls_source         = var.use_nginx_lb ? "rancher" : var.tls_source
-    tls_cert_b64       = (!var.use_nginx_lb && var.tls_source == "secret") ? base64encode(var.tls_cert) : ""
-    tls_key_b64        = (!var.use_nginx_lb && var.tls_source == "secret") ? base64encode(var.tls_key) : ""
+    tls_source         = var.tls_source
+    tls_cert_b64       = var.tls_source == "secret" ? base64encode(var.tls_cert) : ""
+    tls_key_b64        = var.tls_source == "secret" ? base64encode(var.tls_key) : ""
     rke2_cluster_token = random_password.rke2_token.result
     dns_servers        = var.dns_servers
     lb_ip              = local.effective_lb_ip

--- a/modules/platform/rancher/main.tf
+++ b/modules/platform/rancher/main.tf
@@ -24,6 +24,10 @@ terraform {
   }
 }
 
+# ── Harvester namespace ───────────────────────────────────────────────────────
+# Creates a dedicated namespace for bootstrap resources when harvester_namespace
+# is not "default". Labelled as infrastructure so the namespace-credential-
+# provisioner skips it (it only provisions credentials for tenant namespaces).
 resource "kubernetes_namespace" "harvester_ns" {
   count = var.harvester_namespace != "default" ? 1 : 0
   metadata {
@@ -32,11 +36,15 @@ resource "kubernetes_namespace" "harvester_ns" {
       "platform.wso2.com/role" = "infrastructure"
     }
   }
+
   lifecycle {
     ignore_changes = [metadata[0].annotations]
   }
 }
 
+# ── Cloud image ───────────────────────────────────────────────────────────────
+# Downloads and registers the image when image_url is provided.
+# Set ubuntu_image_id instead to reference a pre-existing image (brownfield).
 resource "harvester_image" "vm_image" {
   count        = var.image_url != "" ? 1 : 0
   name         = var.image_name
@@ -55,6 +63,18 @@ resource "harvester_image" "vm_image" {
 locals {
   image_id = var.image_url != "" ? harvester_image.vm_image[0].id : var.ubuntu_image_id
 
+  # Parse the Harvester kubeconfig so cloud-init can query the Kubernetes API from
+  # inside each VM to discover its virt-launcher pod IP.  In masquerade mode every
+  # VM gets the same internal address (10.0.2.2), so without the pod IP etcd peer
+  # URLs conflict and the secondary nodes can never join.  The pod IPs are unique
+  # and reachable between VMs via the Calico overlay (10.52.x.x range).
+  #
+  # Only parsed when kubeconfig_path is set AND node_count > 1 (single-node has no
+  # etcd peers so the default 10.0.2.2 node-ip is fine).
+  #
+  # try() guards against file("") when kubeconfig_path is empty — Terraform
+  # evaluates both branches of a ternary for errors, so a plain file() call
+  # with an empty-string path would fail even when the condition is false.
   _kc_content = try(file(var.harvester_kubeconfig_path), "")
   _kc = (
     var.node_count > 1 && length(var.node_pools) == 0 && local._kc_content != ""
@@ -112,6 +132,7 @@ locals {
     : var.network_name
   )
 
+  # Resolve the SSH key IDs: either freshly generated or caller-supplied
   ssh_key_ids = var.create_ssh_key ? [harvester_ssh_key.bootstrap_key[0].id] : var.ssh_key_ids
 
   # Shared cloud-init template variables
@@ -136,7 +157,7 @@ locals {
 check "image_source_required" {
   assert {
     condition     = var.image_url != "" || var.ubuntu_image_id != ""
-    error_message = "Either image_url or ubuntu_image_id must be set."
+    error_message = "Either image_url (to download a new image) or ubuntu_image_id (to reference an existing one) must be set."
   }
 }
 
@@ -147,11 +168,16 @@ check "node_gateway_required_for_static" {
   }
 }
 
+# ── RKE2 cluster join token ───────────────────────────────────────────────────
+# Generated once and stored in Terraform state. All nodes receive the same token
+# via their individual cloud-init secrets so they can form a cluster.
 resource "random_password" "rke2_token" {
   length  = 64
   special = false
 }
 
+# ── SSH key pair (greenfield only) ────────────────────────────────────────────
+# Set create_ssh_key = false to attach existing ssh_key_ids instead.
 resource "tls_private_key" "bootstrap_key" {
   count     = var.create_ssh_key ? 1 : 0
   algorithm = "RSA"
@@ -166,13 +192,18 @@ resource "harvester_ssh_key" "bootstrap_key" {
   depends_on = [kubernetes_namespace.harvester_ns]
 }
 
+# ── Input validation ──────────────────────────────────────────────────────────
+
+# The cloud-init template embeds the generated SSH public key. If create_ssh_key
+# is false the tls_private_key resource is empty, causing an invalid-index error.
 check "ssh_key_required_for_cloudinit" {
   assert {
     condition     = !var.create_cloudinit_secret || var.create_ssh_key
-    error_message = "create_ssh_key must be true when create_cloudinit_secret is true."
+    error_message = "create_ssh_key must be true when create_cloudinit_secret is true (the cloud-init template embeds the generated SSH public key)."
   }
 }
 
+# When reusing an existing cloud-init secret, the name must be provided.
 check "existing_cloudinit_secret_name_required" {
   assert {
     condition     = var.create_cloudinit_secret || var.existing_cloudinit_secret_name != ""
@@ -180,6 +211,11 @@ check "existing_cloudinit_secret_name_required" {
   }
 }
 
+# ── Bridge network (greenfield) ───────────────────────────────────────────────
+# Creates a NetworkAttachmentDefinition in harvester_namespace so bridge-mode VMs
+# can attach to it. The NAD name is var.network_name; VMs reference it as
+# "<namespace>/<name>". Set create_bridge_network = false when the NAD already
+# exists (brownfield) and pass the full "<namespace>/<name>" as network_name.
 resource "harvester_network" "bridge" {
   count = var.network_type == "bridge" && var.create_bridge_network ? 1 : 0
 
@@ -196,6 +232,7 @@ resource "harvester_network" "bridge" {
 }
 
 # ── Legacy count-based cloud-init + VMs (when node_pools is empty) ────────────
+# Set create_cloudinit_secret = false and provide existing_cloudinit_secret_name instead.
 resource "harvester_cloudinit_secret" "cloudinit" {
   count      = var.create_cloudinit_secret && !local.use_static_nodes ? var.node_count : 0
   name       = var.node_count > 1 ? "${var.vm_name}-cloudinit-${count.index}" : "${var.vm_name}-cloudinit"
@@ -211,12 +248,15 @@ resource "harvester_cloudinit_secret" "cloudinit" {
   }))
 }
 
+# ── Rancher server VM (legacy path) ──────────────────────────────────────────
 resource "harvester_virtualmachine" "rancher_server" {
   count                = !local.use_static_nodes ? var.node_count : 0
   name                 = var.node_count > 1 ? "${var.vm_name}-${count.index}" : var.vm_name
   namespace            = var.harvester_namespace
   restart_after_update = true
 
+  # Bridge NAD must exist before the VM; storage-network must be set before any
+  # VM starts (Harvester rejects storage-network changes while VMs are running).
   depends_on = [
     null_resource.storage_network,
     harvester_network.bridge,
@@ -230,6 +270,7 @@ resource "harvester_virtualmachine" "rancher_server" {
 
   ssh_keys = local.ssh_key_ids
 
+  # Masquerade (NAT): default for greenfield; no external network required
   dynamic "network_interface" {
     for_each = var.network_type == "masquerade" ? [1] : []
     content {
@@ -238,6 +279,7 @@ resource "harvester_virtualmachine" "rancher_server" {
     }
   }
 
+  # Bridge: for VMs that need direct VLAN access (e.g. existing production VMs)
   dynamic "network_interface" {
     for_each = var.network_type == "bridge" ? [1] : []
     content {
@@ -259,6 +301,8 @@ resource "harvester_virtualmachine" "rancher_server" {
     auto_delete = var.vm_disk_auto_delete
   }
 
+  # USB tablet input device — some VMs require this for correct cursor behaviour
+  # in the Harvester console; set enable_usb_tablet = true to include it.
   dynamic "input" {
     for_each = var.enable_usb_tablet ? [1] : []
     content {
@@ -322,6 +366,7 @@ resource "harvester_virtualmachine" "rancher_server_static" {
 
   ssh_keys = local.ssh_key_ids
 
+  # Masquerade (NAT): default for greenfield; no external network required
   dynamic "network_interface" {
     for_each = var.network_type == "masquerade" ? [1] : []
     content {
@@ -330,6 +375,7 @@ resource "harvester_virtualmachine" "rancher_server_static" {
     }
   }
 
+  # Bridge: for VMs that need direct VLAN access (e.g. existing production VMs)
   dynamic "network_interface" {
     for_each = var.network_type == "bridge" ? [1] : []
     content {
@@ -351,6 +397,8 @@ resource "harvester_virtualmachine" "rancher_server_static" {
     auto_delete = var.vm_disk_auto_delete
   }
 
+  # USB tablet input device — some VMs require this for correct cursor behaviour
+  # in the Harvester console; set enable_usb_tablet = true to include it.
   dynamic "input" {
     for_each = var.enable_usb_tablet ? [1] : []
     content {
@@ -395,6 +443,9 @@ resource "harvester_loadbalancer" "rancher_lb" {
     backend_port = 80
   }
 
+  # Required for HA (node_count > 1): secondary nodes join by dialling the LB
+  # supervisor port (9345) so the join address is stable regardless of which
+  # node is currently the active RKE2 init server.
   listener {
     name         = "rke2-supervisor"
     port         = 9345
@@ -439,8 +490,16 @@ resource "harvester_ippool" "rancher_ips" {
 }
 
 # ── Storage class ─────────────────────────────────────────────────────────────
+# Creates a Longhorn StorageClass with a reduced replica count and marks it as
+# the cluster default. The built-in harvester-longhorn (3 replicas) is unset as
+# default so only one default exists at a time.
+# Set manage_storage_class = false to skip (brownfield clusters where the SC
+# already exists, or single-node setups where 3 replicas cannot be satisfied).
 resource "kubernetes_storage_class_v1" "default" {
-  count      = var.manage_storage_class ? 1 : 0
+  count = var.manage_storage_class ? 1 : 0
+
+  # Must run after harvester-longhorn loses its default annotation, otherwise
+  # the Harvester admission webhook rejects creating a second default SC.
   depends_on = [kubernetes_annotations.harvester_longhorn_not_default]
 
   metadata {
@@ -464,6 +523,8 @@ resource "kubernetes_storage_class_v1" "default" {
   }
 }
 
+# Remove the default annotation from the built-in harvester-longhorn StorageClass
+# so there is exactly one cluster default after the new SC is created.
 resource "kubernetes_annotations" "harvester_longhorn_not_default" {
   count       = var.manage_storage_class ? 1 : 0
   api_version = "storage.k8s.io/v1"
@@ -503,6 +564,9 @@ resource "kubernetes_storage_class_v1" "longhorn_rwx" {
 }
 
 # ── Storage network ───────────────────────────────────────────────────────────
+# Configures the Harvester storage-network Setting so Longhorn replication
+# traffic is isolated on a dedicated VLAN rather than sharing the management NIC.
+# Harvester stores the value as a JSON string inside the Setting CRD.
 resource "null_resource" "storage_network" {
   count = var.manage_storage_network ? 1 : 0
 
@@ -525,6 +589,7 @@ resource "null_resource" "storage_network" {
         exclude        = var.storage_network_exclude_ranges
       })
     }
+    # Harvester pre-creates an empty storage-network Setting; patch rather than create.
     command = <<-EOT
       python3 -c "
 import subprocess, json, os
@@ -539,6 +604,10 @@ print('storage-network patched:', patch)
   }
 }
 
+# Patch the built-in longhorn StorageClass replica count.
+# StorageClass parameters are immutable in the Kubernetes API, so the only way
+# to change numberOfReplicas is delete + recreate. kubectl handles this; the
+# kubernetes provider cannot update parameters in-place.
 resource "null_resource" "patch_longhorn_sc" {
   count = var.manage_storage_class ? 1 : 0
 
@@ -550,6 +619,12 @@ resource "null_resource" "patch_longhorn_sc" {
     environment = {
       KUBECONFIG = var.harvester_kubeconfig_path
     }
+    # The longhorn SC is owned by the Longhorn operator, which reconciles it from
+    # the longhorn-storageclass ConfigMap. Patching the SC directly fails because:
+    #   1. parameters are immutable in the Kubernetes API
+    #   2. Longhorn recreates the SC faster than a delete+apply can run
+    # Correct approach: patch the ConfigMap (source of truth), then delete the SC
+    # so Longhorn recreates it from the updated ConfigMap with the new replica count.
     command = <<-EOT
       python3 -c "
 import subprocess, json, re, os

--- a/modules/platform/rancher/main.tf
+++ b/modules/platform/rancher/main.tf
@@ -312,9 +312,28 @@ resource "harvester_virtualmachine" "rancher_server" {
     }
   }
 
+  # Harvester auto-creates a cloudinitdisk when a cloud-init secret is attached.
+  # Declare it here so the provider does not try to remove it on every plan.
+  dynamic "disk" {
+    for_each = [1]
+    content {
+      name = "cloudinitdisk"
+      type = "disk"
+      bus  = "virtio"
+      size = "0Gi"
+    }
+  }
+
   cloudinit {
     user_data_secret_name    = var.create_cloudinit_secret ? harvester_cloudinit_secret.cloudinit[count.index].name : var.existing_cloudinit_secret_name
     network_data_secret_name = var.create_cloudinit_secret ? null : var.existing_cloudinit_secret_name
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Harvester manages the cloudinitdisk size automatically; ignore it to prevent perpetual drift.
+      disk[1].size,
+    ]
   }
 
   provisioner "local-exec" {
@@ -408,9 +427,28 @@ resource "harvester_virtualmachine" "rancher_server_static" {
     }
   }
 
+  # Harvester auto-creates a cloudinitdisk when a cloud-init secret is attached.
+  # Declare it here so the provider does not try to remove it on every plan.
+  dynamic "disk" {
+    for_each = [1]
+    content {
+      name = "cloudinitdisk"
+      type = "disk"
+      bus  = "virtio"
+      size = "0Gi"
+    }
+  }
+
   cloudinit {
     user_data_secret_name    = harvester_cloudinit_secret.cloudinit_static[each.key].name
     network_data_secret_name = harvester_cloudinit_secret.cloudinit_static[each.key].name
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Harvester manages the cloudinitdisk size automatically; ignore it to prevent perpetual drift.
+      disk[1].size,
+    ]
   }
 }
 

--- a/modules/platform/rancher/outputs.tf
+++ b/modules/platform/rancher/outputs.tf
@@ -1,31 +1,58 @@
 locals {
-  # When use_metallb = true the Harvester LB resource is not created even though
-  # create_lb = true; use ippool_start (the MetalLB VIP) as the canonical IP instead.
   rancher_lb_ip = (
-    var.create_lb && !var.use_metallb
+    var.create_lb
     ? harvester_loadbalancer.rancher_lb[0].ip_address
-    : var.use_metallb
-    ? var.ippool_start
+    : var.use_nginx_lb
+    ? var.nginx_lb_ip
     : var.static_rancher_ip
+  )
+
+  # VM ID of the init/primary node for downstream references
+  _init_vm_id = (
+    local.use_static_nodes
+    ? (local._first_cp_key != "" ? harvester_virtualmachine.rancher_server_static[local._first_cp_key].id : "")
+    : harvester_virtualmachine.rancher_server[0].id
+  )
+
+  _ssh_key_id = var.create_ssh_key ? harvester_ssh_key.bootstrap_key[0].id : (
+    length(var.ssh_key_ids) > 0 ? var.ssh_key_ids[0] : ""
   )
 }
 
 output "rancher_hostname" {
-  value       = var.rancher_hostname
-  description = "FQDN of the Rancher server"
+  value = var.rancher_hostname
+}
+
+output "rancher_url" {
+  value = "https://${var.rancher_hostname}"
 }
 
 output "rancher_lb_ip" {
   value       = local.rancher_lb_ip
-  description = "IP used to reach Rancher: LoadBalancer IP (greenfield) or bridge VM IP (brownfield)"
+  description = "IP used to reach Rancher: Harvester LB, nginx LB, or bridge VM IP"
 }
 
 output "vm_id" {
-  value       = harvester_virtualmachine.rancher_server[0].id
-  description = "Harvester resource ID of the Rancher server VM (namespace/name)"
+  value       = local._init_vm_id
+  description = "Harvester resource ID of the primary Rancher node"
 }
 
 output "vm_image_id" {
   value       = var.image_url != "" ? "${harvester_image.vm_image[0].namespace}/${harvester_image.vm_image[0].name}" : var.ubuntu_image_id
-  description = "Harvester image reference (namespace/name) for the OS image downloaded by this module. Re-use in downstream layers to avoid downloading the same image twice."
+  description = "Harvester image reference (namespace/name) — re-use in downstream layers"
+}
+
+output "ssh_key_id" {
+  value       = local._ssh_key_id
+  description = "Harvester SSH key ID attached to the Rancher VMs"
+}
+
+output "ssh_public_key" {
+  value       = var.create_ssh_key ? tls_private_key.bootstrap_key[0].public_key_openssh : ""
+  description = "OpenSSH public key text — pass to nginx_lb_vm so the Harvester webhook can match it against ssh_key_ids"
+}
+
+output "node_ips" {
+  value       = local.use_static_nodes ? [for n in values(local.static_node_map) : n.ip] : []
+  description = "Static IPs of the RKE2 nodes (empty when using DHCP/legacy mode)"
 }

--- a/modules/platform/rancher/outputs.tf
+++ b/modules/platform/rancher/outputs.tf
@@ -1,5 +1,13 @@
 locals {
-  rancher_lb_ip = var.create_lb ? harvester_loadbalancer.rancher_lb[0].ip_address : var.static_rancher_ip
+  # When use_metallb = true the Harvester LB resource is not created even though
+  # create_lb = true; use ippool_start (the MetalLB VIP) as the canonical IP instead.
+  rancher_lb_ip = (
+    var.create_lb && !var.use_metallb
+    ? harvester_loadbalancer.rancher_lb[0].ip_address
+    : var.use_metallb
+    ? var.ippool_start
+    : var.static_rancher_ip
+  )
 }
 
 output "rancher_hostname" {

--- a/modules/platform/rancher/templates/cloud-init.yaml.tpl
+++ b/modules/platform/rancher/templates/cloud-init.yaml.tpl
@@ -7,21 +7,11 @@ chpasswd:
 
 ssh_authorized_keys:
   - ${ssh_public_key}
-%{~ if primary_dns != "" }
-
-bootcmd:
-  - mkdir -p /etc/systemd/resolved.conf.d
-  - "echo '[Resolve]' > /etc/systemd/resolved.conf.d/primary-dns.conf"
-  - "echo 'DNS=${primary_dns}' >> /etc/systemd/resolved.conf.d/primary-dns.conf"
-  - systemctl restart systemd-resolved
-%{~ endif }
 
 packages:
   - qemu-guest-agent
   - curl
-  - avahi-daemon
-  - avahi-utils
-%{~ if tls_source == "secret" }
+%{~ if tls_source == "secret" && !use_nginx_lb }
 
 write_files:
   - path: /tmp/rancher-tls.crt
@@ -36,15 +26,26 @@ write_files:
 
 runcmd:
   - systemctl enable --now qemu-guest-agent
+%{~ if length(dns_servers) > 0 }
+  - mkdir -p /etc/systemd/resolved.conf.d
+  - "echo '[Resolve]' > /etc/systemd/resolved.conf.d/dns.conf"
+  - "echo 'DNS=${join(" ", dns_servers)}' >> /etc/systemd/resolved.conf.d/dns.conf"
+  - systemctl restart systemd-resolved
+%{~ endif }
   - |
     (
       until curl -s --connect-timeout 5 http://1.1.1.1 > /dev/null; do
         sleep 5
       done
+%{~ if is_control_plane }
 
       curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=${rke2_version} sh -
+%{~ else }
+
+      curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=${rke2_version} INSTALL_RKE2_TYPE=agent sh -
+%{~ endif }
       mkdir -p /etc/rancher/rke2
-%{~ if node_index == 0 }
+%{~ if is_init_node }
 
       cat > /etc/rancher/rke2/config.yaml <<'RKCFG'
       token: ${rke2_cluster_token}
@@ -54,23 +55,29 @@ runcmd:
     RKCFG
 %{~ else }
 
-      # Discover node-0's IP via mDNS — avahi-daemon on node-0 advertises
-      # its hostname (${vm_name}-0.local) on the local VLAN automatically.
-      JOIN_IP=""
-      until JOIN_IP=$(avahi-resolve-host-name -4 ${vm_name}-0.local 2>/dev/null | awk '{print $2}') && [ -n "$JOIN_IP" ]; do
-        sleep 5
-      done
-
-      cat > /etc/rancher/rke2/config.yaml <<RKCFG
+%{~ if is_control_plane }
+      cat > /etc/rancher/rke2/config.yaml <<'RKCFG'
       token: ${rke2_cluster_token}
-      server: https://$JOIN_IP:9345
+      server: https://${join_ip}:9345
       tls-san:
         - ${lb_ip}
     RKCFG
+%{~ else }
+      cat > /etc/rancher/rke2/config.yaml <<'RKCFG'
+      token: ${rke2_cluster_token}
+      server: https://${join_ip}:9345
+    RKCFG
+%{~ endif }
 %{~ endif }
 
+%{~ if is_control_plane }
       systemctl enable rke2-server
       systemctl start rke2-server
+%{~ else }
+      systemctl enable rke2-agent
+      systemctl start rke2-agent
+%{~ endif }
+%{~ if is_init_node }
 
       until [ -f /etc/rancher/rke2/rke2.yaml ]; do sleep 5; done
       ln -sf /var/lib/rancher/rke2/bin/kubectl /usr/local/bin/kubectl
@@ -79,67 +86,14 @@ runcmd:
       cp /etc/rancher/rke2/rke2.yaml /home/ubuntu/.kube/config
       chown -R ubuntu:ubuntu /home/ubuntu/.kube
       chmod 600 /home/ubuntu/.kube/config
-%{~ if node_index == 0 }
 
-      until [ "$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')" -ge "${node_count}" ]; do
+      until [ "$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')" -ge "${total_node_count}" ]; do
         sleep 15
       done
-%{~ if use_metallb }
-
-      kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${metallb_version}/config/manifests/metallb-native.yaml
-      kubectl -n metallb-system rollout status deployment/controller --timeout=300s
-      sleep 15
-
-      kubectl apply -f - <<'METALLB'
-      apiVersion: metallb.io/v1beta1
-      kind: IPAddressPool
-      metadata:
-        name: rancher-pool
-        namespace: metallb-system
-      spec:
-        addresses:
-          - ${metallb_ip}/32
-    METALLB
-
-      kubectl apply -f - <<'L2ADV'
-      apiVersion: metallb.io/v1beta1
-      kind: L2Advertisement
-      metadata:
-        name: rancher-l2
-        namespace: metallb-system
-      spec:
-        ipAddressPools:
-          - rancher-pool
-    L2ADV
-
-      until kubectl -n kube-system get ds rke2-ingress-nginx-controller &>/dev/null; do sleep 5; done
-      kubectl -n kube-system rollout status daemonset/rke2-ingress-nginx-controller --timeout=300s
-
-      kubectl apply -f - <<'INGRESSLB'
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: rke2-ingress-lb
-        namespace: kube-system
-        annotations:
-          metallb.universe.tf/loadBalancerIPs: ${metallb_ip}
-      spec:
-        type: LoadBalancer
-        selector:
-          app.kubernetes.io/name: rke2-ingress-nginx
-        ports:
-          - name: http
-            port: 80
-            targetPort: 80
-          - name: https
-            port: 443
-            targetPort: 443
-    INGRESSLB
-%{~ endif }
 
       kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
       kubectl -n cert-manager rollout status deployment/cert-manager-webhook --timeout=600s
-%{~ if tls_source == "secret" }
+%{~ if tls_source == "secret" && !use_nginx_lb }
 
       kubectl create namespace cattle-system --dry-run=client -o yaml | kubectl apply -f -
       kubectl create secret tls tls-rancher-ingress \
@@ -149,20 +103,30 @@ runcmd:
 %{~ endif }
 
       curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+%{~ if use_rancher_prime }
+      helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
+%{~ else }
       helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+%{~ endif }
       helm repo update
 
       for i in $(seq 1 10); do
+%{~ if use_rancher_prime }
+        helm upgrade --install rancher rancher-prime/rancher \
+%{~ else }
         helm upgrade --install rancher rancher-latest/rancher \
+%{~ endif }
           --namespace cattle-system --create-namespace \
 %{~ if rancher_version != "" }
           --version ${rancher_version} \
 %{~ endif }
           --set hostname=${cluster_dns} \
           --set bootstrapPassword=${rancher_password} \
-          --set replicas=${node_count} \
+          --set replicas=${cp_node_count} \
           --set global.cattle.psp.enabled=false \
+%{~ if !use_nginx_lb }
           --set ingress.tls.source=${tls_source} \
+%{~ endif }
           --wait --timeout 15m && break
         sleep 30
       done

--- a/modules/platform/rancher/templates/cloud-init.yaml.tpl
+++ b/modules/platform/rancher/templates/cloud-init.yaml.tpl
@@ -11,7 +11,7 @@ ssh_authorized_keys:
 packages:
   - qemu-guest-agent
   - curl
-%{~ if tls_source == "secret" && !use_nginx_lb }
+%{~ if tls_source == "secret" }
 
 write_files:
   - path: /tmp/rancher-tls.crt
@@ -93,9 +93,11 @@ runcmd:
         sleep 15
       done
 
+%{~ if tls_source != "secret" }
       kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
       kubectl -n cert-manager rollout status deployment/cert-manager-webhook --timeout=600s
-%{~ if tls_source == "secret" && !use_nginx_lb }
+%{~ endif }
+%{~ if tls_source == "secret" }
 
       kubectl create namespace cattle-system --dry-run=client -o yaml | kubectl apply -f -
       kubectl create secret tls tls-rancher-ingress \
@@ -126,9 +128,7 @@ runcmd:
           --set bootstrapPassword=${rancher_password} \
           --set replicas=${cp_node_count} \
           --set global.cattle.psp.enabled=false \
-%{~ if !use_nginx_lb }
           --set ingress.tls.source=${tls_source} \
-%{~ endif }
           --wait --timeout 15m && break
         sleep 30
       done

--- a/modules/platform/rancher/templates/cloud-init.yaml.tpl
+++ b/modules/platform/rancher/templates/cloud-init.yaml.tpl
@@ -26,6 +26,8 @@ write_files:
 
 runcmd:
   - systemctl enable --now qemu-guest-agent
+  - sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT=.*/GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0,115200n8 console=tty0"/' /etc/default/grub
+  - update-grub
 %{~ if length(dns_servers) > 0 }
   - mkdir -p /etc/systemd/resolved.conf.d
   - "echo '[Resolve]' > /etc/systemd/resolved.conf.d/dns.conf"

--- a/modules/platform/rancher/templates/cloud-init.yaml.tpl
+++ b/modules/platform/rancher/templates/cloud-init.yaml.tpl
@@ -7,11 +7,20 @@ chpasswd:
 
 ssh_authorized_keys:
   - ${ssh_public_key}
+%{~ if primary_dns != "" }
+
+bootcmd:
+  - mkdir -p /etc/systemd/resolved.conf.d
+  - "echo '[Resolve]' > /etc/systemd/resolved.conf.d/primary-dns.conf"
+  - "echo 'DNS=${primary_dns}' >> /etc/systemd/resolved.conf.d/primary-dns.conf"
+  - systemctl restart systemd-resolved
+%{~ endif }
 
 packages:
   - qemu-guest-agent
   - curl
-  - iptables
+  - avahi-daemon
+  - avahi-utils
 %{~ if tls_source == "secret" }
 
 write_files:
@@ -27,119 +36,135 @@ write_files:
 
 runcmd:
   - systemctl enable --now qemu-guest-agent
-  - sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT=.*/GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0,115200n8 console=tty0"/' /etc/default/grub
-  - update-grub
-
   - |
     (
-      echo "--- Waiting for internet connectivity ---" > /dev/console
-      until curl -s --connect-timeout 5 http://1.1.1.1 > /dev/null; do 
-        echo "Still waiting for internet (http://1.1.1.1)..." > /dev/console
+      until curl -s --connect-timeout 5 http://1.1.1.1 > /dev/null; do
         sleep 5
       done
 
-      echo "--- Starting RKE2 and Rancher Deployment ---" > /dev/console
-      
-      # 1. Install RKE2
       curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=${rke2_version} sh -
       mkdir -p /etc/rancher/rke2
+%{~ if node_index == 0 }
 
-      cat <<EOF > /etc/rancher/rke2/config.yaml
-      token: static-bootstrap-token-123
-      $( [ "${node_index}" != "0" ] && echo "server: https://${lb_ip}:9345" )
+      cat > /etc/rancher/rke2/config.yaml <<'RKCFG'
+      token: ${rke2_cluster_token}
+      cluster-init: true
       tls-san:
         - ${lb_ip}
-      etcd-heartbeat-interval: "500"
-      etcd-election-timeout: "5000"
-    EOF
+    RKCFG
+%{~ else }
 
-      systemctl enable rke2-server.service
-%{~ if node_index != 0 }
-
-      # Join nodes: wait until the LB is routing port 9345 before starting.
-      # The LB health check is on port 443 (ingress-nginx), which only passes
-      # once node-0's ingress is up. Waiting here avoids failed join attempts
-      # and the systemd restart loop that follows.
-      echo "Waiting for supervisor endpoint ${lb_ip}:9345 to be routable..."
-      until python3 -c "import socket,sys; s=socket.socket(); s.settimeout(5); s.connect(('${lb_ip}', 9345)); s.close()" 2>/dev/null; do
-        sleep 15
+      # Discover node-0's IP via mDNS — avahi-daemon on node-0 advertises
+      # its hostname (${vm_name}-0.local) on the local VLAN automatically.
+      JOIN_IP=""
+      until JOIN_IP=$(avahi-resolve-host-name -4 ${vm_name}-0.local 2>/dev/null | awk '{print $2}') && [ -n "$JOIN_IP" ]; do
+        sleep 5
       done
-      echo "Supervisor endpoint reachable, joining cluster..."
+
+      cat > /etc/rancher/rke2/config.yaml <<RKCFG
+      token: ${rke2_cluster_token}
+      server: https://$JOIN_IP:9345
+      tls-san:
+        - ${lb_ip}
+    RKCFG
 %{~ endif }
-      systemctl start rke2-server.service
 
-      # 2. IMMEDIATE kubectl download
-      echo "Downloading kubectl..."
-      curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-      install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+      systemctl enable rke2-server
+      systemctl start rke2-server
 
-      # 3. Wait for Config & API
-      echo "Waiting for rke2.yaml..."
-      until [ -f /etc/rancher/rke2/rke2.yaml ]; do sleep 10; done
+      until [ -f /etc/rancher/rke2/rke2.yaml ]; do sleep 5; done
+      ln -sf /var/lib/rancher/rke2/bin/kubectl /usr/local/bin/kubectl
       export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
-      
-      # 4. Setup User Context
       mkdir -p /home/ubuntu/.kube
       cp /etc/rancher/rke2/rke2.yaml /home/ubuntu/.kube/config
       chown -R ubuntu:ubuntu /home/ubuntu/.kube
       chmod 600 /home/ubuntu/.kube/config
+%{~ if node_index == 0 }
 
-      # 5. Wait for Node Readiness
-      echo "Waiting for nodes to be Ready..."
-      until /usr/local/bin/kubectl get nodes | grep -v "NotReady" | grep -q "Ready"; do sleep 10; done
+      until [ "$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')" -ge "${node_count}" ]; do
+        sleep 15
+      done
+%{~ if use_metallb }
 
-      if [ "${node_index}" -eq "0" ]; then
-        echo "Initializing Rancher..."
-        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-        /usr/local/bin/helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-        /usr/local/bin/helm repo update
-        
-        # 6. Two-Stage Ingress Wait (Corrected for DaemonSet)
-        echo "Waiting for Ingress DaemonSet existence..."
-        until /usr/local/bin/kubectl get ds rke2-ingress-nginx-controller -n kube-system; do sleep 10; done
-        
-        echo "Waiting for Ingress DaemonSet pods to be Ready..."
-        until [ "$(/usr/local/bin/kubectl get ds rke2-ingress-nginx-controller -n kube-system -o jsonpath='{.status.numberReady}')" = "$(/usr/local/bin/kubectl get ds rke2-ingress-nginx-controller -n kube-system -o jsonpath='{.status.desiredNumberScheduled}')" ]; do
-          echo "Waiting for Ingress pods... (Ready vs Desired)"
-          sleep 10
-        done
-        
-        # Settle time for the Admission Webhook Service
-        sleep 30 
-        
-        # 7. Cert-Manager
-        /usr/local/bin/kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
-        /usr/local/bin/kubectl wait --for=condition=Available --timeout=600s deployment/cert-manager-webhook -n cert-manager
+      kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${metallb_version}/config/manifests/metallb-native.yaml
+      kubectl -n metallb-system rollout status deployment/controller --timeout=300s
+      sleep 15
+
+      kubectl apply -f - <<'METALLB'
+      apiVersion: metallb.io/v1beta1
+      kind: IPAddressPool
+      metadata:
+        name: rancher-pool
+        namespace: metallb-system
+      spec:
+        addresses:
+          - ${metallb_ip}/32
+    METALLB
+
+      kubectl apply -f - <<'L2ADV'
+      apiVersion: metallb.io/v1beta1
+      kind: L2Advertisement
+      metadata:
+        name: rancher-l2
+        namespace: metallb-system
+      spec:
+        ipAddressPools:
+          - rancher-pool
+    L2ADV
+
+      until kubectl -n kube-system get ds rke2-ingress-nginx-controller &>/dev/null; do sleep 5; done
+      kubectl -n kube-system rollout status daemonset/rke2-ingress-nginx-controller --timeout=300s
+
+      kubectl apply -f - <<'INGRESSLB'
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: rke2-ingress-lb
+        namespace: kube-system
+        annotations:
+          metallb.universe.tf/loadBalancerIPs: ${metallb_ip}
+      spec:
+        type: LoadBalancer
+        selector:
+          app.kubernetes.io/name: rke2-ingress-nginx
+        ports:
+          - name: http
+            port: 80
+            targetPort: 80
+          - name: https
+            port: 443
+            targetPort: 443
+    INGRESSLB
+%{~ endif }
+
+      kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
+      kubectl -n cert-manager rollout status deployment/cert-manager-webhook --timeout=600s
 %{~ if tls_source == "secret" }
 
-        # 8a. Pre-create TLS secret so Rancher Helm finds it on first install
-        /usr/local/bin/kubectl create namespace cattle-system --dry-run=client -o yaml | /usr/local/bin/kubectl apply -f -
-        /usr/local/bin/kubectl create secret tls tls-rancher-ingress \
-          --cert=/tmp/rancher-tls.crt \
-          --key=/tmp/rancher-tls.key \
-          -n cattle-system \
-          --dry-run=client -o yaml | /usr/local/bin/kubectl apply -f -
-        rm -f /tmp/rancher-tls.crt /tmp/rancher-tls.key
+      kubectl create namespace cattle-system --dry-run=client -o yaml | kubectl apply -f -
+      kubectl create secret tls tls-rancher-ingress \
+        --cert=/tmp/rancher-tls.crt --key=/tmp/rancher-tls.key \
+        -n cattle-system --dry-run=client -o yaml | kubectl apply -f -
+      rm -f /tmp/rancher-tls.crt /tmp/rancher-tls.key
 %{~ endif }
 
-        # 8. Rancher Installation Loop
-        i=1; while [ $i -le 10 ]; do
-          echo "Rancher install attempt $i..."
-          /usr/local/bin/helm upgrade --install rancher rancher-latest/rancher \
-            --namespace cattle-system \
-            --create-namespace \
+      curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+      helm repo update
+
+      for i in $(seq 1 10); do
+        helm upgrade --install rancher rancher-latest/rancher \
+          --namespace cattle-system --create-namespace \
 %{~ if rancher_version != "" }
-            --version ${rancher_version} \
+          --version ${rancher_version} \
 %{~ endif }
-            --set hostname=${cluster_dns} \
-            --set bootstrapPassword=${rancher_password} \
-            --set replicas=${node_count} \
-            --set global.cattle.psp.enabled=false \
-            --set startupProbe.failureThreshold=60 \
-            --set ingress.tls.source=${tls_source} \
-            --wait --timeout 15m && break
-          i=$((i+1)); sleep 30
-        done
-      fi
-      echo "--- Deployment Script Finished ---" > /dev/console
-    ) > /var/log/rancher-install.log 2>&1 &
+          --set hostname=${cluster_dns} \
+          --set bootstrapPassword=${rancher_password} \
+          --set replicas=${node_count} \
+          --set global.cattle.psp.enabled=false \
+          --set ingress.tls.source=${tls_source} \
+          --wait --timeout 15m && break
+        sleep 30
+      done
+%{~ endif }
+    ) >> /var/log/rancher-install.log 2>&1 &

--- a/modules/platform/rancher/templates/network-config.yaml.tpl
+++ b/modules/platform/rancher/templates/network-config.yaml.tpl
@@ -1,0 +1,14 @@
+version: 2
+ethernets:
+  enp1s0:
+    dhcp4: false
+    addresses:
+      - ${static_ip}/${subnet_prefix}
+    routes:
+      - to: default
+        via: ${gateway}
+    nameservers:
+      addresses:
+%{~ for dns in dns_servers }
+        - ${dns}
+%{~ endfor }

--- a/modules/platform/rancher/variables.tf
+++ b/modules/platform/rancher/variables.tf
@@ -1,88 +1,100 @@
 # ── VM identity ───────────────────────────────────────────────────────────────
 variable "vm_name" {
-  type        = string
-  description = "Name of the Rancher server VM"
-  default     = "rancher-bootstrap"
+  type    = string
+  default = "rancher-bootstrap"
 }
 
 variable "harvester_namespace" {
-  type        = string
-  description = "Harvester namespace to deploy into"
-  default     = "default"
+  type    = string
+  default = "default"
 }
 
 variable "node_count" {
   type        = number
-  description = "Number of VM instances (1 for single-node, 3 for HA)"
+  description = "Number of VM instances (legacy mode when node_pools is empty)"
   default     = 1
+}
+
+# ── Static node pools ─────────────────────────────────────────────────────────
+variable "node_pools" {
+  type = list(object({
+    name          = string
+    ips           = list(string)
+    control_plane = bool
+    etcd          = bool
+    worker        = bool
+  }))
+  description = "Static IP node pools. When non-empty, overrides node_count; each node gets a static IP."
+  default     = []
+}
+
+variable "node_gateway" {
+  type        = string
+  description = "Default gateway for static IP nodes. Required when node_pools is set."
+  default     = ""
+}
+
+variable "node_subnet_prefix" {
+  type        = number
+  description = "CIDR prefix length for static IP nodes (e.g. 25 for /25)"
+  default     = 24
 }
 
 # ── VM hardware ───────────────────────────────────────────────────────────────
 variable "vm_cpu" {
-  type        = number
-  description = "vCPU count for the Rancher VM"
-  default     = 4
+  type    = number
+  default = 4
 }
 
 variable "vm_memory" {
-  type        = string
-  description = "Memory size for the Rancher VM (e.g. '8Gi', '16Gi')"
-  default     = "8Gi"
+  type    = string
+  default = "8Gi"
 }
 
 variable "vm_disk_name" {
-  type        = string
-  description = "Name of the root disk in the VM spec"
-  default     = "disk-0"
+  type    = string
+  default = "disk-0"
 }
 
 variable "vm_disk_size" {
-  type        = string
-  description = "Root disk size for the Rancher VM"
-  default     = "40Gi"
+  type    = string
+  default = "40Gi"
 }
 
 variable "vm_disk_auto_delete" {
-  type        = bool
-  description = "Delete the root disk when the VM is destroyed. Set false for production VMs."
-  default     = true
+  type    = bool
+  default = true
 }
 
 variable "image_url" {
-  type        = string
-  description = "Download URL for the cloud image (e.g. Ubuntu 22.04 qcow2). The module fetches and registers it as a Harvester backing image. Mutually exclusive with ubuntu_image_id."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "image_name" {
-  type        = string
-  description = "Harvester resource name for the downloaded image. Only used when image_url is set."
-  default     = "ubuntu-22-04"
+  type    = string
+  default = "ubuntu-22-04"
 }
 
 variable "image_display_name" {
-  type        = string
-  description = "Human-readable display name shown in the Harvester UI. Only used when image_url is set."
-  default     = "ubuntu-22.04"
+  type    = string
+  default = "ubuntu-22.04"
 }
 
 variable "ubuntu_image_id" {
-  type        = string
-  description = "Harvester resource ID of a pre-existing cloud image (e.g. 'default/image-cwl4b'). Use this for brownfield clusters where the image already exists. Mutually exclusive with image_url."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "enable_usb_tablet" {
-  type        = bool
-  description = "Attach a USB tablet input device (required by some VMs for correct console cursor behaviour)"
-  default     = false
+  type    = bool
+  default = false
 }
 
 # ── Network ───────────────────────────────────────────────────────────────────
 variable "network_type" {
-  type        = string
-  description = "'masquerade' (NAT, default for greenfield) or 'bridge' (direct VLAN, for brownfield/production)"
-  default     = "masquerade"
+  type    = string
+  default = "masquerade"
 
   validation {
     condition     = contains(["masquerade", "bridge"], var.network_type)
@@ -91,15 +103,13 @@ variable "network_type" {
 }
 
 variable "network_interface_name" {
-  type        = string
-  description = "Name of the network interface inside the VM spec (e.g. 'nic-1' or 'default')"
-  default     = "nic-1"
+  type    = string
+  default = "nic-1"
 }
 
 variable "network_name" {
-  type        = string
-  description = "NetworkAttachmentDefinition name for bridge networks (e.g. 'iaas-net/vm-subnet-001'). Only used when network_type = 'bridge'."
-  default     = ""
+  type    = string
+  default = ""
   validation {
     condition     = var.network_type != "bridge" || var.network_name != ""
     error_message = "network_name is required when network_type = 'bridge'."
@@ -107,103 +117,87 @@ variable "network_name" {
 }
 
 variable "network_mac_address" {
-  type        = string
-  description = "MAC address to assign to the bridge NIC. Leave empty to auto-assign. Only used when network_type = 'bridge'."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "create_bridge_network" {
-  type        = bool
-  description = "When true, creates a harvester_network (NetworkAttachmentDefinition) named network_name in harvester_namespace before the VMs start. Set false when the NAD already exists (brownfield) — in that case network_name must be the full '<namespace>/<name>' reference."
-  default     = false
+  type    = bool
+  default = false
 }
 
 variable "cluster_network_name" {
-  type        = string
-  description = "Harvester cluster network the VLAN is attached to (e.g. 'mgmt'). Used when create_bridge_network = true."
-  default     = "mgmt"
+  type    = string
+  default = "mgmt"
 }
 
 variable "cluster_vlan_id" {
-  type        = number
-  description = "VLAN tag ID for the bridge network. Used when create_bridge_network = true."
-  default     = 100
+  type    = number
+  default = 100
 }
 
 variable "cluster_vlan_gateway" {
-  type        = string
-  description = "Default gateway IP for the bridge VLAN route. Leave empty to omit the route block. Used when create_bridge_network = true."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "cluster_vlan_cidr" {
-  type        = string
-  description = "CIDR for the bridge VLAN route (e.g. '0.0.0.0/0'). Required when cluster_vlan_gateway is set. Used when create_bridge_network = true."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 # ── SSH key ───────────────────────────────────────────────────────────────────
 variable "create_ssh_key" {
-  type        = bool
-  description = "If true, generate a new RSA key-pair and register it as a Harvester SSH key. Set false to use existing ssh_key_ids."
-  default     = true
+  type    = bool
+  default = true
 }
 
 variable "ssh_key_ids" {
-  type        = list(string)
-  description = "List of existing Harvester SSH key IDs to attach when create_ssh_key = false (e.g. ['default/madawa'])."
-  default     = []
+  type    = list(string)
+  default = []
 }
 
 # ── Cloud-init secret ─────────────────────────────────────────────────────────
 variable "create_cloudinit_secret" {
-  type        = bool
-  description = "If true, render and create a cloud-init secret from the built-in template. Set false to reference an existing secret."
-  default     = true
+  type    = bool
+  default = true
 }
 
 variable "existing_cloudinit_secret_name" {
-  type        = string
-  description = "Name of an existing cloud-init secret to attach when create_cloudinit_secret = false."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "vm_password" {
-  type        = string
-  description = "Default password for the ubuntu user (used in cloud-init template). Required when create_cloudinit_secret = true."
-  sensitive   = true
-  default     = ""
+  type      = string
+  sensitive = true
+  default   = ""
 }
 
 variable "rancher_hostname" {
-  type        = string
-  description = "FQDN for the Rancher UI (e.g. 'rancher-lk-prod.wso2.com')"
+  type = string
 }
 
 variable "bootstrap_password" {
-  type        = string
-  description = "Temporary Rancher admin password set by the Helm chart during cloud-init install. Required when create_cloudinit_secret = true."
-  sensitive   = true
-  default     = ""
+  type      = string
+  sensitive = true
+  default   = ""
 }
 
 # ── Load Balancer / IP Pool ───────────────────────────────────────────────────
 variable "create_lb" {
-  type        = bool
-  description = "If true, create a Harvester LoadBalancer and IP pool to expose Rancher. Set false when the VM is directly reachable via a bridge IP."
-  default     = true
+  type    = bool
+  default = true
 }
 
 variable "static_rancher_ip" {
-  type        = string
-  description = "IP of the Rancher VM on the internal bridge network when create_lb = false. Passed through as rancher_lb_ip output for CoreDNS."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "ippool_subnet" {
-  type        = string
-  description = "Subnet CIDR for the IP pool (e.g. '192.168.10.0/24'). Required when create_lb = true."
-  default     = ""
+  type    = string
+  default = ""
   validation {
     condition     = !var.create_lb || var.ippool_subnet != ""
     error_message = "ippool_subnet is required when create_lb = true."
@@ -211,9 +205,8 @@ variable "ippool_subnet" {
 }
 
 variable "ippool_gateway" {
-  type        = string
-  description = "Gateway for the IP pool. Required when create_lb = true."
-  default     = ""
+  type    = string
+  default = ""
   validation {
     condition     = !var.create_lb || var.ippool_gateway != ""
     error_message = "ippool_gateway is required when create_lb = true."
@@ -221,9 +214,8 @@ variable "ippool_gateway" {
 }
 
 variable "ippool_start" {
-  type        = string
-  description = "Start of the IP range for the pool. Required when create_lb = true."
-  default     = ""
+  type    = string
+  default = ""
   validation {
     condition     = !var.create_lb || var.ippool_start != ""
     error_message = "ippool_start is required when create_lb = true."
@@ -231,9 +223,8 @@ variable "ippool_start" {
 }
 
 variable "ippool_end" {
-  type        = string
-  description = "End of the IP range for the pool. Required when create_lb = true."
-  default     = ""
+  type    = string
+  default = ""
   validation {
     condition     = !var.create_lb || var.ippool_end != ""
     error_message = "ippool_end is required when create_lb = true."
@@ -241,72 +232,79 @@ variable "ippool_end" {
 }
 
 variable "ippool_network_name" {
+  type    = string
+  default = ""
+}
+
+# ── nginx LB ──────────────────────────────────────────────────────────────────
+variable "use_nginx_lb" {
+  type        = bool
+  description = "When true, an external nginx VM is the load balancer. Skips Harvester LB and MetalLB. Requires nginx_lb_ip to be set."
+  default     = false
+}
+
+variable "nginx_lb_ip" {
   type        = string
-  description = "NetworkAttachmentDefinition name to associate with the IP pool (e.g. 'default/vm-net-100'). Required when the LB VIP is on a VLAN network so kube-vip announces it on the correct interface."
+  description = "Static IP of the nginx LB VM. Required when use_nginx_lb = true."
   default     = ""
+
+  validation {
+    condition     = !var.use_nginx_lb || var.nginx_lb_ip != ""
+    error_message = "nginx_lb_ip is required when use_nginx_lb = true."
+  }
 }
 
 # ── Storage class ─────────────────────────────────────────────────────────────
 variable "manage_storage_class" {
-  type        = bool
-  description = "Create a custom Longhorn StorageClass, set it as the cluster default, and patch the built-in longhorn SC replica count. Set false for brownfield clusters."
-  default     = true
+  type    = bool
+  default = true
 }
 
 variable "harvester_kubeconfig_path" {
-  type        = string
-  description = "Filesystem path to the Harvester kubeconfig. Required when manage_storage_class = true so the longhorn StorageClass can be patched via kubectl (parameters are immutable in the Kubernetes API and cannot be updated in-place)."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "storage_class_name" {
-  type        = string
-  description = "Name of the custom StorageClass to create."
-  default     = "harvester-longhorn-2r"
+  type    = string
+  default = "harvester-longhorn-2r"
 }
 
 variable "storage_class_replicas" {
-  type        = number
-  description = "Longhorn replica count for the custom StorageClass."
-  default     = 2
+  type    = number
+  default = 2
 }
 
 # ── Storage network ───────────────────────────────────────────────────────────
 variable "manage_storage_network" {
-  type        = bool
-  description = "If true, configure the Harvester storage-network Setting (L2VlanNetwork for Longhorn replication traffic). Requires a dedicated storage cluster network to exist in Harvester."
-  default     = false
+  type    = bool
+  default = false
 }
 
 variable "storage_network_vlan" {
-  type        = number
-  description = "VLAN ID for the storage network (e.g. 699)."
-  default     = 0
+  type    = number
+  default = 0
 }
 
 variable "storage_network_cluster_network" {
-  type        = string
-  description = "Name of the Harvester cluster network to use for storage traffic (e.g. 'strg-network')."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "storage_network_range" {
-  type        = string
-  description = "IP CIDR range assigned to storage NICs (e.g. '172.23.0.0/19')."
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "storage_network_exclude_ranges" {
-  type        = list(string)
-  description = "CIDR blocks to exclude from the storage range (maps to the 'exclude' key in the Harvester storage-network JSON value)."
-  default     = []
+  type    = list(string)
+  default = []
 }
 
 # ── TLS certificate ───────────────────────────────────────────────────────────
 variable "tls_source" {
-  type        = string
-  description = "'rancher' (default — cert-manager issues a self-signed CA) or 'secret' (BYO public cert via tls_cert/tls_key). Use 'secret' when the domain has a publicly-trusted certificate so cattle-cluster-agent can verify Rancher without a CoreDNS override."
-  default     = "rancher"
+  type    = string
+  default = "rancher"
 
   validation {
     condition     = contains(["rancher", "secret"], var.tls_source)
@@ -315,46 +313,36 @@ variable "tls_source" {
 }
 
 variable "tls_cert" {
-  type        = string
-  description = "PEM-encoded TLS certificate (full chain: leaf + intermediates) for Rancher. Required when tls_source = 'secret'."
-  sensitive   = true
-  default     = ""
+  type      = string
+  sensitive = true
+  default   = ""
 }
 
 variable "tls_key" {
-  type        = string
-  description = "PEM-encoded private key matching tls_cert. Required when tls_source = 'secret'."
-  sensitive   = true
-  default     = ""
+  type      = string
+  sensitive = true
+  default   = ""
 }
 
 # ── RKE2 / Rancher versions ───────────────────────────────────────────────────
 variable "rke2_version" {
-  type        = string
-  description = "RKE2 release to install (e.g. 'v1.32.4+rke2r1'). Pin this to a version that is compatible with the Rancher chart selected by rancher_version."
-  default     = "v1.34.7+rke2r1"
+  type    = string
+  default = "v1.34.7+rke2r1"
 }
 
 variable "rancher_version" {
-  type        = string
-  description = "Rancher Helm chart version (e.g. '2.14.0'). Leave empty to install the latest stable release."
-  default     = ""
+  type    = string
+  default = ""
 }
 
-variable "primary_dns" {
-  type        = string
-  description = "Primary DNS server IP (e.g. '8.8.8.8'). When set, this server is configured as the primary resolver via systemd-resolved before any downloads start; DHCP-assigned nameservers remain as secondary. Leave empty to use DHCP DNS only."
-  default     = ""
+variable "dns_servers" {
+  type        = list(string)
+  description = "DNS servers for cluster nodes. Written as nameservers in netplan (static nodes) and as DNS= in systemd-resolved (DHCP nodes). 8.8.8.8 is always appended as FallbackDNS in systemd-resolved. Defaults to empty list (DHCP DNS only for DHCP nodes; 8.8.8.8 for static nodes)."
+  default     = []
 }
 
-variable "use_metallb" {
+variable "use_rancher_prime" {
   type        = bool
-  description = "When true, skip the Harvester LB/IPPool and instead install MetalLB inside the RKE2 cluster. The MetalLB VIP is taken from ippool_start. Designed for bridge-mode clusters where the Harvester LB controller cannot reach VM-network backends due to missing inter-VLAN routing."
+  description = "When true, install from the rancher-prime Helm chart repository instead of rancher-latest."
   default     = false
-}
-
-variable "metallb_version" {
-  type        = string
-  description = "MetalLB manifest version to install (e.g. 'v0.14.9'). Only used when use_metallb = true."
-  default     = "v0.14.9"
 }

--- a/modules/platform/rancher/variables.tf
+++ b/modules/platform/rancher/variables.tf
@@ -112,22 +112,33 @@ variable "network_mac_address" {
   default     = ""
 }
 
-# Kept for backwards-compatibility (used in VLAN creation — currently disabled in the module).
+variable "create_bridge_network" {
+  type        = bool
+  description = "When true, creates a harvester_network (NetworkAttachmentDefinition) named network_name in harvester_namespace before the VMs start. Set false when the NAD already exists (brownfield) — in that case network_name must be the full '<namespace>/<name>' reference."
+  default     = false
+}
+
 variable "cluster_network_name" {
   type        = string
-  description = "Name of the base cluster network in Harvester (e.g. 'mgmt')"
+  description = "Harvester cluster network the VLAN is attached to (e.g. 'mgmt'). Used when create_bridge_network = true."
   default     = "mgmt"
 }
 
 variable "cluster_vlan_id" {
   type        = number
-  description = "VLAN tag ID for the bootstrap node network"
+  description = "VLAN tag ID for the bridge network. Used when create_bridge_network = true."
   default     = 100
 }
 
 variable "cluster_vlan_gateway" {
   type        = string
-  description = "Gateway IP for the new VLAN (optional)"
+  description = "Default gateway IP for the bridge VLAN route. Leave empty to omit the route block. Used when create_bridge_network = true."
+  default     = ""
+}
+
+variable "cluster_vlan_cidr" {
+  type        = string
+  description = "CIDR for the bridge VLAN route (e.g. '0.0.0.0/0'). Required when cluster_vlan_gateway is set. Used when create_bridge_network = true."
   default     = ""
 }
 
@@ -328,4 +339,22 @@ variable "rancher_version" {
   type        = string
   description = "Rancher Helm chart version (e.g. '2.14.0'). Leave empty to install the latest stable release."
   default     = ""
+}
+
+variable "primary_dns" {
+  type        = string
+  description = "Primary DNS server IP (e.g. '8.8.8.8'). When set, this server is configured as the primary resolver via systemd-resolved before any downloads start; DHCP-assigned nameservers remain as secondary. Leave empty to use DHCP DNS only."
+  default     = ""
+}
+
+variable "use_metallb" {
+  type        = bool
+  description = "When true, skip the Harvester LB/IPPool and instead install MetalLB inside the RKE2 cluster. The MetalLB VIP is taken from ippool_start. Designed for bridge-mode clusters where the Harvester LB controller cannot reach VM-network backends due to missing inter-VLAN routing."
+  default     = false
+}
+
+variable "metallb_version" {
+  type        = string
+  description = "MetalLB manifest version to install (e.g. 'v0.14.9'). Only used when use_metallb = true."
+  default     = "v0.14.9"
 }

--- a/modules/platform/rancher/variables.tf
+++ b/modules/platform/rancher/variables.tf
@@ -1,17 +1,19 @@
 # ── VM identity ───────────────────────────────────────────────────────────────
 variable "vm_name" {
-  type    = string
-  default = "rancher-bootstrap"
+  type        = string
+  description = "Name of the Rancher server VM"
+  default     = "rancher-bootstrap"
 }
 
 variable "harvester_namespace" {
-  type    = string
-  default = "default"
+  type        = string
+  description = "Harvester namespace to deploy into"
+  default     = "default"
 }
 
 variable "node_count" {
   type        = number
-  description = "Number of VM instances (legacy mode when node_pools is empty)"
+  description = "Number of VM instances (legacy mode when node_pools is empty). Use node_pools for static-IP deployments."
   default     = 1
 }
 
@@ -24,7 +26,7 @@ variable "node_pools" {
     etcd          = bool
     worker        = bool
   }))
-  description = "Static IP node pools. When non-empty, overrides node_count; each node gets a static IP."
+  description = "Static IP node pools. When non-empty, overrides node_count; each node gets a static IP via cloud-init network_data."
   default     = []
 }
 
@@ -36,65 +38,76 @@ variable "node_gateway" {
 
 variable "node_subnet_prefix" {
   type        = number
-  description = "CIDR prefix length for static IP nodes (e.g. 25 for /25)"
+  description = "CIDR prefix length for static IP nodes (e.g. 25 for /25)."
   default     = 24
 }
 
 # ── VM hardware ───────────────────────────────────────────────────────────────
 variable "vm_cpu" {
-  type    = number
-  default = 4
+  type        = number
+  description = "vCPU count for the Rancher VM"
+  default     = 4
 }
 
 variable "vm_memory" {
-  type    = string
-  default = "8Gi"
+  type        = string
+  description = "Memory size for the Rancher VM (e.g. '8Gi', '16Gi')"
+  default     = "8Gi"
 }
 
 variable "vm_disk_name" {
-  type    = string
-  default = "disk-0"
+  type        = string
+  description = "Name of the root disk in the VM spec"
+  default     = "disk-0"
 }
 
 variable "vm_disk_size" {
-  type    = string
-  default = "40Gi"
+  type        = string
+  description = "Root disk size for the Rancher VM"
+  default     = "40Gi"
 }
 
 variable "vm_disk_auto_delete" {
-  type    = bool
-  default = true
+  type        = bool
+  description = "Delete the root disk when the VM is destroyed. Set false for production VMs."
+  default     = true
 }
 
 variable "image_url" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Download URL for the cloud image (e.g. Ubuntu 22.04 qcow2). The module fetches and registers it as a Harvester backing image. Mutually exclusive with ubuntu_image_id."
+  default     = ""
 }
 
 variable "image_name" {
-  type    = string
-  default = "ubuntu-22-04"
+  type        = string
+  description = "Harvester resource name for the downloaded image. Only used when image_url is set."
+  default     = "ubuntu-22-04"
 }
 
 variable "image_display_name" {
-  type    = string
-  default = "ubuntu-22.04"
+  type        = string
+  description = "Human-readable display name shown in the Harvester UI. Only used when image_url is set."
+  default     = "ubuntu-22.04"
 }
 
 variable "ubuntu_image_id" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Harvester resource ID of a pre-existing cloud image (e.g. 'default/image-cwl4b'). Use this for brownfield clusters where the image already exists. Mutually exclusive with image_url."
+  default     = ""
 }
 
 variable "enable_usb_tablet" {
-  type    = bool
-  default = false
+  type        = bool
+  description = "Attach a USB tablet input device (required by some VMs for correct console cursor behaviour)"
+  default     = false
 }
 
 # ── Network ───────────────────────────────────────────────────────────────────
 variable "network_type" {
-  type    = string
-  default = "masquerade"
+  type        = string
+  description = "'masquerade' (NAT, default for greenfield) or 'bridge' (direct VLAN, for brownfield/production)"
+  default     = "masquerade"
 
   validation {
     condition     = contains(["masquerade", "bridge"], var.network_type)
@@ -103,13 +116,15 @@ variable "network_type" {
 }
 
 variable "network_interface_name" {
-  type    = string
-  default = "nic-1"
+  type        = string
+  description = "Name of the network interface inside the VM spec (e.g. 'nic-1' or 'default')"
+  default     = "nic-1"
 }
 
 variable "network_name" {
-  type    = string
-  default = ""
+  type        = string
+  description = "NetworkAttachmentDefinition name for bridge networks (e.g. 'iaas-net/vm-subnet-001'). Only used when network_type = 'bridge'."
+  default     = ""
   validation {
     condition     = var.network_type != "bridge" || var.network_name != ""
     error_message = "network_name is required when network_type = 'bridge'."
@@ -117,87 +132,103 @@ variable "network_name" {
 }
 
 variable "network_mac_address" {
-  type    = string
-  default = ""
+  type        = string
+  description = "MAC address to assign to the bridge NIC. Leave empty to auto-assign. Only used when network_type = 'bridge'."
+  default     = ""
 }
 
 variable "create_bridge_network" {
-  type    = bool
-  default = false
+  type        = bool
+  description = "When true, creates a harvester_network (NetworkAttachmentDefinition) named network_name in harvester_namespace before the VMs start. Set false when the NAD already exists (brownfield) — in that case network_name must be the full '<namespace>/<name>' reference."
+  default     = false
 }
 
 variable "cluster_network_name" {
-  type    = string
-  default = "mgmt"
+  type        = string
+  description = "Harvester cluster network the VLAN is attached to (e.g. 'mgmt'). Used when create_bridge_network = true."
+  default     = "mgmt"
 }
 
 variable "cluster_vlan_id" {
-  type    = number
-  default = 100
+  type        = number
+  description = "VLAN tag ID for the bridge network. Used when create_bridge_network = true."
+  default     = 100
 }
 
 variable "cluster_vlan_gateway" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Default gateway IP for the bridge VLAN route. Leave empty to omit the route block. Used when create_bridge_network = true."
+  default     = ""
 }
 
 variable "cluster_vlan_cidr" {
-  type    = string
-  default = ""
+  type        = string
+  description = "CIDR for the bridge VLAN route (e.g. '0.0.0.0/0'). Required when cluster_vlan_gateway is set. Used when create_bridge_network = true."
+  default     = ""
 }
 
 # ── SSH key ───────────────────────────────────────────────────────────────────
 variable "create_ssh_key" {
-  type    = bool
-  default = true
+  type        = bool
+  description = "If true, generate a new RSA key-pair and register it as a Harvester SSH key. Set false to use existing ssh_key_ids."
+  default     = true
 }
 
 variable "ssh_key_ids" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  description = "List of existing Harvester SSH key IDs to attach when create_ssh_key = false (e.g. ['default/madawa'])."
+  default     = []
 }
 
 # ── Cloud-init secret ─────────────────────────────────────────────────────────
 variable "create_cloudinit_secret" {
-  type    = bool
-  default = true
+  type        = bool
+  description = "If true, render and create a cloud-init secret from the built-in template. Set false to reference an existing secret."
+  default     = true
 }
 
 variable "existing_cloudinit_secret_name" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Name of an existing cloud-init secret to attach when create_cloudinit_secret = false."
+  default     = ""
 }
 
 variable "vm_password" {
-  type      = string
-  sensitive = true
-  default   = ""
+  type        = string
+  description = "Default password for the ubuntu user (used in cloud-init template). Required when create_cloudinit_secret = true."
+  sensitive   = true
+  default     = ""
 }
 
 variable "rancher_hostname" {
-  type = string
+  type        = string
+  description = "FQDN for the Rancher UI (e.g. 'rancher-lk-prod.wso2.com')"
 }
 
 variable "bootstrap_password" {
-  type      = string
-  sensitive = true
-  default   = ""
+  type        = string
+  description = "Temporary Rancher admin password set by the Helm chart during cloud-init install. Required when create_cloudinit_secret = true."
+  sensitive   = true
+  default     = ""
 }
 
 # ── Load Balancer / IP Pool ───────────────────────────────────────────────────
 variable "create_lb" {
-  type    = bool
-  default = true
+  type        = bool
+  description = "If true, create a Harvester LoadBalancer and IP pool to expose Rancher. Set false when the VM is directly reachable via a bridge IP."
+  default     = true
 }
 
 variable "static_rancher_ip" {
-  type    = string
-  default = ""
+  type        = string
+  description = "IP of the Rancher VM on the internal bridge network when create_lb = false. Passed through as rancher_lb_ip output for CoreDNS."
+  default     = ""
 }
 
 variable "ippool_subnet" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Subnet CIDR for the IP pool (e.g. '192.168.10.0/24'). Required when create_lb = true."
+  default     = ""
   validation {
     condition     = !var.create_lb || var.ippool_subnet != ""
     error_message = "ippool_subnet is required when create_lb = true."
@@ -205,8 +236,9 @@ variable "ippool_subnet" {
 }
 
 variable "ippool_gateway" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Gateway for the IP pool. Required when create_lb = true."
+  default     = ""
   validation {
     condition     = !var.create_lb || var.ippool_gateway != ""
     error_message = "ippool_gateway is required when create_lb = true."
@@ -214,8 +246,9 @@ variable "ippool_gateway" {
 }
 
 variable "ippool_start" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Start of the IP range for the pool. Required when create_lb = true."
+  default     = ""
   validation {
     condition     = !var.create_lb || var.ippool_start != ""
     error_message = "ippool_start is required when create_lb = true."
@@ -223,8 +256,9 @@ variable "ippool_start" {
 }
 
 variable "ippool_end" {
-  type    = string
-  default = ""
+  type        = string
+  description = "End of the IP range for the pool. Required when create_lb = true."
+  default     = ""
   validation {
     condition     = !var.create_lb || var.ippool_end != ""
     error_message = "ippool_end is required when create_lb = true."
@@ -232,14 +266,15 @@ variable "ippool_end" {
 }
 
 variable "ippool_network_name" {
-  type    = string
-  default = ""
+  type        = string
+  description = "NetworkAttachmentDefinition name to associate with the IP pool (e.g. 'default/vm-net-100'). Required when the LB VIP is on a VLAN network so kube-vip announces it on the correct interface."
+  default     = ""
 }
 
 # ── nginx LB ──────────────────────────────────────────────────────────────────
 variable "use_nginx_lb" {
   type        = bool
-  description = "When true, an external nginx VM is the load balancer. Skips Harvester LB and MetalLB. Requires nginx_lb_ip to be set."
+  description = "When true, an external nginx VM is the load balancer. Skips the Harvester LB. Requires nginx_lb_ip to be set."
   default     = false
 }
 
@@ -256,55 +291,65 @@ variable "nginx_lb_ip" {
 
 # ── Storage class ─────────────────────────────────────────────────────────────
 variable "manage_storage_class" {
-  type    = bool
-  default = true
+  type        = bool
+  description = "Create a custom Longhorn StorageClass, set it as the cluster default, and patch the built-in longhorn SC replica count. Set false for brownfield clusters."
+  default     = true
 }
 
 variable "harvester_kubeconfig_path" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Filesystem path to the Harvester kubeconfig. Required when manage_storage_class = true so the longhorn StorageClass can be patched via kubectl (parameters are immutable in the Kubernetes API and cannot be updated in-place)."
+  default     = ""
 }
 
 variable "storage_class_name" {
-  type    = string
-  default = "harvester-longhorn-2r"
+  type        = string
+  description = "Name of the custom StorageClass to create."
+  default     = "harvester-longhorn-2r"
 }
 
 variable "storage_class_replicas" {
-  type    = number
-  default = 2
+  type        = number
+  description = "Longhorn replica count for the custom StorageClass."
+  default     = 2
 }
 
 # ── Storage network ───────────────────────────────────────────────────────────
 variable "manage_storage_network" {
-  type    = bool
-  default = false
+  type        = bool
+  description = "If true, configure the Harvester storage-network Setting (L2VlanNetwork for Longhorn replication traffic). Requires a dedicated storage cluster network to exist in Harvester."
+  default     = false
 }
 
 variable "storage_network_vlan" {
-  type    = number
-  default = 0
+  type        = number
+  description = "VLAN ID for the storage network (e.g. 699)."
+  default     = 0
 }
 
 variable "storage_network_cluster_network" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Name of the Harvester cluster network to use for storage traffic (e.g. 'strg-network')."
+  default     = ""
 }
 
 variable "storage_network_range" {
-  type    = string
-  default = ""
+  type        = string
+  description = "IP CIDR range assigned to storage NICs (e.g. '172.23.0.0/19')."
+  default     = ""
 }
 
 variable "storage_network_exclude_ranges" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  description = "CIDR blocks to exclude from the storage range (maps to the 'exclude' key in the Harvester storage-network JSON value)."
+  default     = []
 }
 
 # ── TLS certificate ───────────────────────────────────────────────────────────
 variable "tls_source" {
-  type    = string
-  default = "rancher"
+  type        = string
+  description = "'rancher' (default — cert-manager issues a self-signed CA) or 'secret' (BYO public cert via tls_cert/tls_key). Use 'secret' when the domain has a publicly-trusted certificate so cattle-cluster-agent can verify Rancher without a CoreDNS override."
+  default     = "rancher"
 
   validation {
     condition     = contains(["rancher", "secret"], var.tls_source)
@@ -313,31 +358,35 @@ variable "tls_source" {
 }
 
 variable "tls_cert" {
-  type      = string
-  sensitive = true
-  default   = ""
+  type        = string
+  description = "PEM-encoded TLS certificate (full chain: leaf + intermediates) for Rancher. Required when tls_source = 'secret'."
+  sensitive   = true
+  default     = ""
 }
 
 variable "tls_key" {
-  type      = string
-  sensitive = true
-  default   = ""
+  type        = string
+  description = "PEM-encoded private key matching tls_cert. Required when tls_source = 'secret'."
+  sensitive   = true
+  default     = ""
 }
 
 # ── RKE2 / Rancher versions ───────────────────────────────────────────────────
 variable "rke2_version" {
-  type    = string
-  default = "v1.34.7+rke2r1"
+  type        = string
+  description = "RKE2 release to install (e.g. 'v1.32.4+rke2r1'). Pin this to a version that is compatible with the Rancher chart selected by rancher_version."
+  default     = "v1.34.7+rke2r1"
 }
 
 variable "rancher_version" {
-  type    = string
-  default = ""
+  type        = string
+  description = "Rancher Helm chart version (e.g. '2.14.0'). Leave empty to install the latest stable release."
+  default     = ""
 }
 
 variable "dns_servers" {
   type        = list(string)
-  description = "DNS servers for cluster nodes. Written as nameservers in netplan (static nodes) and as DNS= in systemd-resolved (DHCP nodes). 8.8.8.8 is always appended as FallbackDNS in systemd-resolved. Defaults to empty list (DHCP DNS only for DHCP nodes; 8.8.8.8 for static nodes)."
+  description = "DNS servers for cluster nodes. Written as nameservers in netplan (static nodes) and as DNS= in systemd-resolved (DHCP nodes). Defaults to empty list (DHCP DNS only for DHCP nodes; 8.8.8.8 for static nodes)."
   default     = []
 }
 


### PR DESCRIPTION
## Summary

- **New module `platform/nginx-lb-vm`**: deploys an nginx VM for L4/L7 load balancing (ports 9345, 6443, 443) using the official nginx.org package repo. Accepts static IP, TLS cert/key, and upstream RKE2 node IPs as inputs. Replaces MetalLB and the Harvester LB controller for bridge-mode deployments where kube-vip cannot reach VM-network backends.

- **Static node pools (`node_pools`)**: new variable accepts a list of pools with per-node static IPs, roles (`control_plane`, `etcd`, `worker`), gateway, and subnet prefix. When set, creates per-node `harvester_cloudinit_secret` resources (`for_each`) with Netplan v2 `network_data` for static IP assignment — no DHCP leases taken. Legacy `node_count` path (`count`) is preserved for existing masquerade/single-node environments.

- **nginx LB toggle (`use_nginx_lb` / `nginx_lb_ip`)**: when enabled, skips the Harvester LB and IP pool; TLS termination moves to the nginx VM; `ingress.tls.source` is omitted from the Rancher Helm install.

- **Rancher Prime toggle (`use_rancher_prime`)**: switches the Helm repo between `rancher-latest` and `rancher-prime` at install time.

- **DNS servers (`dns_servers`)**: list of DNS IPs written as Netplan `nameservers` on static nodes and as `DNS=` in `systemd-resolved` on DHCP nodes.

- **Bridge network creation (`create_bridge_network`, `cluster_vlan_cidr`)**: optional managed `harvester_network` (NAD) created before VMs start; existing brownfield NADs can still be referenced by full `<namespace>/<name>`.

- **Cloud-init security and HA fixes**:
  - Replaced hardcoded `static-bootstrap-token-123` with a Terraform-generated random token stored in state
  - Added `cluster-init: true` for the init control-plane node
  - Added `INSTALL_RKE2_TYPE=agent` path for worker-only nodes
  - Node readiness wait now counts all nodes (`total_node_count`) instead of any one node being Ready
  - kubectl sourced from RKE2's own bundled binary (`/var/lib/rancher/rke2/bin/kubectl`) — version-matched, no separate download
  - Removed ingress DaemonSet wait + 30 s sleep before cert-manager (cert-manager has no ingress dependency)
  - Removed `python3` socket LB-reachability wait before join — not needed with static IPs; RKE2 retries natively
  - Log output changed from overwrite (`>`) to append (`>>`) so re-runs preserve history
  - Restored GRUB serial console config (`ttyS0,115200n8 console=tty0`) for Harvester web console access

- **New outputs**: `ssh_key_id`, `ssh_public_key` (for Harvester webhook compliance on downstream VMs), `node_ips`, `rancher_url`.

## Backward compatibility

- `lk` (brownfield): `create_cloudinit_secret = false` — cloud-init template is never rendered; no impact.
- `lk-dev` (masquerade, single node): `node_pools = []`, `node_count = 1` — uses the existing `count`-based path unchanged. `create_lb = true` and `ippool_*` variables continue to work.

