### PR TITLE
Add IdP directory reads, email invites, and a member picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,6 +169,45 @@ export DCAPI_BFF_POST_LOGOUT_REDIRECT="http://localhost:5173/"
 export DCAPI_BFF_COOKIE_DOMAIN=""
 export DCAPI_BFF_COOKIE_SECURE="false"
 
+# ── IdP SCIM2 directory (optional, read-only) ────────────────────────────────
+# OPTIONAL. Leave all four unset to disable. When set, dc-api proxies live,
+# read-only SCIM2 lookups against your IdP to power the invite picker
+# (GET /v1/tenants/{tid}/directory/{users,groups}) and invite-by-email
+# (user_email on POST .../role-assignments). Nothing from the IdP is stored
+# — only the resolved OIDC `sub` lands on the
+# role_assignments row.
+#
+# The four below must be set together: dc-api refuses to start on a partial
+# set (catches "the secret didn't reach the deployment" early). DCAPI_IDP_SCOPES
+# is optional and excluded from that check.
+#
+# The OAuth2 client_credentials app MUST hold user/group VIEW scopes only
+# (Asgardeo: internal_user_mgt_view + internal_group_mgt_view) — dc-api never
+# writes to the IdP.
+#
+# Asgardeo examples:
+# export DCAPI_IDP_SCIM_BASE_URL="https://api.asgardeo.io/t/<org>/scim2"
+# export DCAPI_IDP_TOKEN_URL="https://api.asgardeo.io/t/<org>/oauth2/token"
+# export DCAPI_IDP_CLIENT_ID="<m2m-app-client-id>"
+# export DCAPI_IDP_CLIENT_SECRET="<m2m-app-client-secret>"
+#
+# DCAPI_IDP_SCOPES — OAuth2 scopes requested with the client_credentials grant
+# (space- or comma-separated). REQUIRED for Asgardeo / WSO2 Identity Server:
+# they only attach SCIM permissions to the token when scopes are requested, so
+# without these every SCIM call returns 403. Other IdPs may need none (leave
+# unset). WARNING: grant LIST/VIEW scopes ONLY — never write scopes; dc-api is
+# read-only against the IdP.
+# export DCAPI_IDP_SCOPES="internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view"
+#
+# DCAPI_IDP_USERSTORE_DOMAIN — restricts directory reads to one userstore via
+# the WSO2 SCIM2 `domain` query parameter. Without it the IdP returns EVERY
+# account in the organization — including console administrators and
+# collaborators, who are not invite candidates. Default "DEFAULT" (Asgardeo's
+# consumer-user store); on-prem WSO2 Identity Server typically wants
+# "PRIMARY". Set explicitly empty to list all stores; non-WSO2 SCIM servers
+# ignore the parameter.
+# export DCAPI_IDP_USERSTORE_DOMAIN="DEFAULT"
+
 # ── Server ───────────────────────────────────────────────────────────────────
 export DCAPI_LOG_LEVEL="debug"      # debug for local dev; info for prod
 export DCAPI_LISTEN_ADDR=":8080"

--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ make `dc-api` exit at startup if missing or invalid.
 | `DCAPI_ADMIN_GROUP`                   |          | `dc-admin`               | IdP group that maps to platform admin.                                  |
 | `DCAPI_PLATFORM_ADMIN_SUBS`           |          |                          | Comma-separated `sub` values for break-glass platform admins.           |
 | `DCAPI_RBAC_AUTOPROVISION`            |          | `false`                  | Auto-grant `member` on first login with a valid tenant group.           |
+| **IdP Directory (optional)**          |          |                          | Leave all four unset to disable. When set, enable live directory browsing and email-based invites (see [rbac.md](docs/rbac.md#idp-directory-configuration-optional)). |
+| `DCAPI_IDP_SCIM_BASE_URL`             |          |                          | SCIM2 endpoint URL of your IdP. The four required `DCAPI_IDP_*` vars must be set together or all unset. |
+| `DCAPI_IDP_TOKEN_URL`                 |          |                          | OAuth2 token endpoint for m2m credential (read-only user/group VIEW scopes). |
+| `DCAPI_IDP_CLIENT_ID`                 |          |                          | Client ID of machine-to-machine OAuth2 app. |
+| `DCAPI_IDP_CLIENT_SECRET`             |          |                          | Client secret for the m2m app. |
+| `DCAPI_IDP_SCOPES`                    |          |                          | OAuth2 scopes for the client_credentials grant (space/comma-separated). Required for Asgardeo/WSO2 IS (else SCIM 403s); optional elsewhere. LIST/VIEW only. Asgardeo: `internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view`. |
 | **Harvester**                         |          |                          |                                                                         |
 | `DCAPI_HARVESTER_KUBECONFIG`          | ✅       |                          | Base64-encoded Harvester kubeconfig.                                    |
 | `DCAPI_HARVESTER_NAMESPACE`           |          | `default`                | Fallback Harvester namespace.                                           |

--- a/cloud-ui/src/pages/MembersPage.tsx
+++ b/cloud-ui/src/pages/MembersPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Button,
   Card,
   Dialog,
@@ -17,6 +18,13 @@ import {
   MenuPopover,
   MenuTrigger,
   Option,
+  OverlayDrawer,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerHeaderTitle,
+  SearchBox,
+  Spinner,
   Subtitle1,
   Table,
   TableBody,
@@ -36,11 +44,14 @@ import {
 import {
   Add20Regular,
   ArrowClockwise20Regular,
+  Checkmark20Filled,
+  Dismiss24Regular,
   MoreHorizontal20Regular,
+  PersonAdd20Regular,
   ShieldPerson20Regular,
 } from '@fluentui/react-icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useApi } from '../api/useApi';
 import { useConfirmDialog } from '../components/useConfirmDialog';
@@ -77,7 +88,8 @@ const usePageStyles = makeStyles({
     flexDirection: 'column',
     gap: tokens.spacingVerticalL,
   },
-  /** Two-line role option: display name on top, description underneath. */
+  /** Two-line dropdown option (role picker + directory suggestions):
+   *  primary text on top, secondary text underneath. */
   roleOption: {
     display: 'flex',
     flexDirection: 'column',
@@ -86,6 +98,12 @@ const usePageStyles = makeStyles({
   roleOptionDesc: {
     fontSize: tokens.fontSizeBase200,
     color: tokens.colorNeutralForeground3,
+  },
+  /** API error surfaced verbatim inside the invite dialog (422 copy is
+   *  written for end users). */
+  inviteError: {
+    color: tokens.colorPaletteRedForeground1,
+    fontSize: tokens.fontSizeBase200,
   },
   /** Two-line principal cell: alias on top, sub underneath in muted mono. */
   principalCell: {
@@ -102,6 +120,139 @@ const usePageStyles = makeStyles({
     color: tokens.colorNeutralForeground3,
     fontFamily: tokens.fontFamilyMonospace,
   },
+
+  // ── Member-picker Drawer (Azure "Select members" pattern) ──────────────
+  picker: { width: '420px' },
+  /** The selected-identity row inside the dialog: avatar + email/sub, with a
+   *  "Select member" / "Change" button on the right. Reads like a chip. */
+  identityRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalM,
+    padding: tokens.spacingHorizontalS,
+    border: `1px solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  identityRowEmpty: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase300,
+  },
+  identityText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    flex: 1,
+    minWidth: 0,
+  },
+  identityPrimary: {
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  identitySecondary: {
+    fontSize: tokens.fontSizeBase100,
+    color: tokens.colorNeutralForeground3,
+    fontFamily: tokens.fontFamilyMonospace,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  pickerBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalM,
+    height: '100%',
+  },
+  pickerList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalXXS,
+    overflowY: 'auto',
+    // Fill the Drawer body; header (search) and footer stay fixed.
+    flex: 1,
+    minHeight: 0,
+  },
+  /** A single selectable directory user — a full-width radio-style button. */
+  userRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalM,
+    width: '100%',
+    padding: tokens.spacingHorizontalS,
+    border: '1px solid transparent',
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    textAlign: 'left',
+    ':hover': { backgroundColor: tokens.colorNeutralBackground1Hover },
+    ':focus-visible': {
+      outline: `2px solid ${tokens.colorStrokeFocus2}`,
+      outlineOffset: '-2px',
+    },
+  },
+  userRowSelected: {
+    backgroundColor: tokens.colorBrandBackground2,
+    border: `1px solid ${tokens.colorBrandStroke1}`,
+    ':hover': { backgroundColor: tokens.colorBrandBackground2Hover },
+  },
+  userRowText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    flex: 1,
+    minWidth: 0,
+  },
+  userRowName: {
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+    color: tokens.colorNeutralForeground1,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  userRowEmail: {
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  userRowCheck: { color: tokens.colorBrandForeground1, flexShrink: 0 },
+  pickerStatus: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: tokens.spacingVerticalS,
+    padding: tokens.spacingVerticalXXL,
+    textAlign: 'center',
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  pickerError: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalS,
+    padding: tokens.spacingVerticalL,
+    textAlign: 'center',
+    color: tokens.colorPaletteRedForeground1,
+    fontSize: tokens.fontSizeBase200,
+  },
+  pickerCount: {
+    fontSize: tokens.fontSizeBase100,
+    color: tokens.colorNeutralForeground3,
+    padding: `0 ${tokens.spacingHorizontalXS}`,
+  },
+  pickerFooter: {
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
+  },
+  pickerLoadMore: { alignSelf: 'center', marginTop: tokens.spacingVerticalXS },
 });
 
 interface RoleAssignment {
@@ -121,6 +272,13 @@ interface RoleDefinition {
   key: string;
   display_name: string;
   description: string;
+}
+
+/** Minimal user record from GET /v1/tenants/{id}/directory/users. */
+interface DirectoryUser {
+  sub: string;
+  email: string;
+  display_name?: string;
 }
 
 /** Colour a role pill by its broad shape: Owner, read-only Reader, or anything
@@ -188,9 +346,36 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
   const confirmDialog = useConfirmDialog();
 
   const [inviteOpen, setInviteOpen] = useState(false);
-  const [userSub, setUserSub] = useState('');
-  const [displayAlias, setDisplayAlias] = useState('');
+  // Identity to grant. When a directory is configured the picker resolves it to
+  // a sub (`pickedSub`) plus the chip's email/alias. In directory-dark
+  // deployments (probe 501) there is no directory to browse, so the field is a
+  // plain dual-mode Input: an email (contains "@") or a raw OIDC sub.
+  const [identity, setIdentity] = useState('');
+  const [pickedSub, setPickedSub] = useState<string | null>(null);
+  // Alias to send with a directory pick: the IdP display_name (falls back to
+  // the email). Cleared in directory-dark mode, where no alias is sent.
+  const [pickedAlias, setPickedAlias] = useState('');
   const [roleDefinition, setRoleDefinition] = useState('Contributor');
+
+  // Member-picker Drawer (Azure "Select members"). Opens from inside the
+  // dialog; rendered as a sibling so its overlay sits above the modal dialog
+  // rather than fighting its focus trap.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  // The row highlighted inside the Drawer, confirmed on "Select".
+  const [draftUser, setDraftUser] = useState<DirectoryUser | null>(null);
+  // Search box value, debounced into the browse query's filter.
+  const [pickerSearch, setPickerSearch] = useState('');
+  const [pickerFilter, setPickerFilter] = useState('');
+  // How many pages are loaded; reset to 1 whenever the filter changes.
+  const [pickerPages, setPickerPages] = useState(1);
+  const PICKER_PAGE_SIZE = 20;
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setPickerFilter(pickerSearch.trim());
+      setPickerPages(1);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [pickerSearch]);
 
   // The assignable role catalog — drives the picker and resolves keys to display
   // names. The UI never invents role logic; dc-api owns the catalog.
@@ -245,6 +430,62 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
     (r) => r.action === ACTION_ROLE_WRITE && r.allowed,
   );
 
+  // Feature-detect the IdP directory once per tenant when the dialog opens.
+  // 501 is the stable "no directory provider configured" signal — only that
+  // hides the type-ahead. A 502 (transient IdP failure) keeps it enabled.
+  // Directory listing is tenant-level even when this dialog grants at
+  // project/resource scope, so this always hits the tenant path.
+  const directoryProbe = useQuery({
+    queryKey: ['directory-probe', tenantId],
+    enabled: inviteOpen && Boolean(tenantId),
+    staleTime: Infinity,
+    retry: false,
+    queryFn: async () => {
+      const { response } = await api.GET('/v1/tenants/{tenant_id}/directory/users', {
+        params: { path: { tenant_id: tenantId! }, query: { limit: 1 } },
+      });
+      return response.status !== 501;
+    },
+  });
+  const directoryDark = directoryProbe.data === false; // confirmed 501
+  const directoryAvailable = directoryProbe.data === true;
+
+  // Browse the tenant directory inside the picker Drawer. Pagination uses a
+  // growing window from offset 0 (limit = pages * pageSize): a fresh fetch
+  // returns the full prefix the list should show, so "Load more" can never
+  // interleave or clobber, and react-query's per-key cache makes back-paging
+  // free. The key carries tenantId + filter + the effective offset/limit, so a
+  // stale page can never overwrite a newer filter's results.
+  const pickerLimit = pickerPages * PICKER_PAGE_SIZE;
+  const browseQuery = useQuery({
+    queryKey: ['directory-users', tenantId, pickerFilter, 0, pickerLimit],
+    enabled: pickerOpen && directoryAvailable && Boolean(tenantId),
+    retry: false,
+    // Keep the previous window visible while the next one loads ("Load more"
+    // and filter changes don't flash the list empty).
+    placeholderData: (prev) => prev,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        '/v1/tenants/{tenant_id}/directory/users',
+        {
+          params: {
+            path: { tenant_id: tenantId! },
+            query: { filter: pickerFilter || undefined, limit: pickerLimit, offset: 0 },
+          },
+        },
+      );
+      if (response.status === 502) throw new Error('directory temporarily unavailable');
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      return {
+        users: (data?.users ?? []) as DirectoryUser[],
+        total: data?.total_results ?? 0,
+      };
+    },
+  });
+  const browseUsers = browseQuery.data?.users ?? [];
+  const browseTotal = browseQuery.data?.total ?? 0;
+  const hasMore = browseUsers.length < browseTotal;
+
   const membersQuery = useQuery({
     queryKey: ['role-assignments', tenantId, scopeKey],
     enabled: Boolean(tenantId),
@@ -272,11 +513,26 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
 
   const inviteMutation = useMutation({
     mutationFn: async () => {
-      const body: { user_sub: string; role_definition: string; display_alias?: string } = {
-        user_sub: userSub.trim(),
-        role_definition: roleDefinition,
-      };
-      if (displayAlias.trim()) body.display_alias = displayAlias.trim();
+      const id = identity.trim();
+      const body: {
+        user_sub?: string;
+        user_email?: string;
+        role_definition: string;
+        display_alias?: string;
+      } = { role_definition: roleDefinition };
+      if (pickedSub) {
+        // A directory pick already resolved the sub — send it directly and skip
+        // server-side email re-resolution. The alias comes from the IdP
+        // display_name (falling back to the email when display_name is empty).
+        body.user_sub = pickedSub;
+        if (pickedAlias) body.display_alias = pickedAlias;
+      } else if (id.includes('@')) {
+        // Directory-dark: raw email entry, no alias (server defaults it).
+        body.user_email = id;
+      } else {
+        // Directory-dark: raw OIDC sub, no alias.
+        body.user_sub = id;
+      }
 
       if (resourceBase) {
         await scopedJson(`${resourceBase}/role-assignments`, {
@@ -307,14 +563,44 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
       dispatchToast(<Toast><ToastTitle>Member invited</ToastTitle></Toast>, { intent: 'success' });
       queryClient.invalidateQueries({ queryKey: ['role-assignments', tenantId, scopeKey] });
       setInviteOpen(false);
-      setUserSub('');
-      setDisplayAlias('');
-      setRoleDefinition('Contributor');
+      resetInviteForm();
     },
-    onError: (e: Error) => {
-      dispatchToast(<Toast><ToastTitle>Invite failed: {e.message}</ToastTitle></Toast>, { intent: 'error' });
-    },
+    // No error toast: failures (incl. the user-facing 422 copy for email
+    // resolution) render verbatim inside the dialog, next to the form.
   });
+
+  // Hoisted so `inviteMutation.onSuccess` (defined above) can call it. Clears
+  // every field plus the picker's transient state back to the default.
+  function resetInviteForm() {
+    setIdentity('');
+    setPickedSub(null);
+    setPickedAlias('');
+    setRoleDefinition('Contributor');
+    setDraftUser(null);
+    setPickerSearch('');
+    setPickerFilter('');
+    setPickerPages(1);
+  }
+
+  // Open the picker pre-seeded with the currently selected user (if any), so
+  // re-opening "Change" keeps the highlight.
+  const openPicker = () => {
+    setDraftUser(pickedSub ? { sub: pickedSub, email: identity, display_name: pickedAlias } : null);
+    setPickerSearch('');
+    setPickerFilter('');
+    setPickerPages(1);
+    setPickerOpen(true);
+  };
+
+  // Confirm the Drawer selection: pin the sub, show the email in the dialog
+  // chip, and carry the IdP display_name (or email fallback) as the alias.
+  const confirmPicker = () => {
+    if (!draftUser) return;
+    setIdentity(draftUser.email);
+    setPickedSub(draftUser.sub);
+    setPickedAlias(draftUser.display_name?.trim() || draftUser.email);
+    setPickerOpen(false);
+  };
 
   const removeMutation = useMutation({
     mutationFn: async (principalId: string) => {
@@ -419,7 +705,7 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
           title={isResource
             ? `No roles granted on ${scopeLabel ?? 'this resource'} yet`
             : `No members in ${(isProject ? projectId : tenantId) ?? (isProject ? 'this project' : 'this tenant')} yet`}
-          description="Add a principal by their OIDC subject and grant them a role from the catalog. Roles range from Owner down to per-resource-type roles like Virtual Machine Contributor."
+          description="Add a teammate by email (or by their OIDC subject) and grant them a role from the catalog. Roles range from Owner down to per-resource-type roles like Virtual Machine Contributor."
           action={
             canManageAccess ? (
               <Button
@@ -499,28 +785,73 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
         </Card>
       )}
 
-      <Dialog open={inviteOpen} onOpenChange={(_, d) => setInviteOpen(d.open)}>
+      <Dialog
+        open={inviteOpen}
+        onOpenChange={(_, d) => {
+          setInviteOpen(d.open);
+          if (!d.open) {
+            inviteMutation.reset();
+            setPickerOpen(false);
+            resetInviteForm();
+          }
+        }}
+      >
         <DialogSurface>
           <DialogBody>
             <DialogTitle>Add role assignment</DialogTitle>
             <DialogContent>
               <div className={pageStyles.dialogForm}>
-                <Field label="User subject (OIDC sub)" required hint="The user's OIDC `sub` claim — find it on their JWT.">
-                  <Input
-                    value={userSub}
-                    onChange={(_, d) => setUserSub(d.value)}
-                    placeholder="01abc123-0000-0000-0000-user000000001"
-                  />
-                </Field>
                 <Field
-                  label="Display name (optional)"
-                  hint="Mnemonic shown in the members list. Not visible to the user, not synced to the IdP."
+                  label="User"
+                  required
+                  hint={
+                    pickedSub ? (
+                      <>Selected from the directory · <code>{pickedSub}</code>.</>
+                    ) : directoryDark ? (
+                      <>Enter an email (looked up in the directory) or paste a raw OIDC `sub` — find it on the user&apos;s JWT.</>
+                    ) : (
+                      'Pick a teammate from the directory.'
+                    )
+                  }
                 >
-                  <Input
-                    value={displayAlias}
-                    onChange={(_, d) => setDisplayAlias(d.value)}
-                    placeholder="e.g. alice-wso2"
-                  />
+                  {directoryDark ? (
+                    // Directory-dark (probe 501): no directory to browse, so the
+                    // only path is a plain dual-mode Input (email or raw sub).
+                    <Input
+                      value={identity}
+                      onChange={(_, d) => {
+                        setIdentity(d.value);
+                        setPickedSub(null);
+                      }}
+                      placeholder="01abc123-0000-0000-0000-user000000001"
+                    />
+                  ) : pickedSub ? (
+                    // A directory member is selected — show it as a chip-like row.
+                    <div className={pageStyles.identityRow}>
+                      <Avatar name={identity} color="colorful" aria-hidden />
+                      <div className={pageStyles.identityText}>
+                        <span className={pageStyles.identityPrimary}>{identity}</span>
+                        <span className={pageStyles.identitySecondary}>{pickedSub}</span>
+                      </div>
+                      <Button appearance="subtle" size="small" onClick={openPicker}>
+                        Change
+                      </Button>
+                    </div>
+                  ) : (
+                    // Nothing chosen yet — the affordance to open the picker.
+                    <div className={pageStyles.identityRow}>
+                      <span className={pageStyles.identityRowEmpty}>No member selected</span>
+                      <Button
+                        appearance="primary"
+                        size="small"
+                        icon={<PersonAdd20Regular />}
+                        style={{ marginLeft: 'auto' }}
+                        onClick={openPicker}
+                      >
+                        Select member
+                      </Button>
+                    </div>
+                  )}
                 </Field>
                 <Field
                   label="Role"
@@ -545,6 +876,11 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
                     ))}
                   </Dropdown>
                 </Field>
+                {inviteMutation.isError && (
+                  <div className={pageStyles.inviteError} role="alert">
+                    {(inviteMutation.error as Error).message}
+                  </div>
+                )}
               </div>
             </DialogContent>
             <DialogActions>
@@ -556,7 +892,7 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
               <Button
                 appearance="primary"
                 onClick={() => inviteMutation.mutate()}
-                disabled={!userSub.trim() || !roleDefinition || inviteMutation.isPending}
+                disabled={!identity.trim() || !roleDefinition || inviteMutation.isPending}
               >
                 {inviteMutation.isPending ? 'Assigning…' : 'Assign role'}
               </Button>
@@ -564,6 +900,124 @@ export default function MembersPage({ resourceBase, scopeLabel }: MembersPagePro
           </DialogBody>
         </DialogSurface>
       </Dialog>
+
+      {/* Member picker — Azure "Select members" panel. Rendered as a sibling of
+          the dialog (not nested inside it) so its overlay layers above the modal
+          dialog cleanly. It only ever opens from the dialog's "Select member"
+          button, which is itself behind the page's permission gate. */}
+      <OverlayDrawer
+        open={pickerOpen}
+        onOpenChange={(_, d) => setPickerOpen(d.open)}
+        position="end"
+        className={pageStyles.picker}
+        aria-label="Select a member from the directory"
+      >
+        <DrawerHeader>
+          <DrawerHeaderTitle
+            action={
+              <Button
+                appearance="subtle"
+                icon={<Dismiss24Regular />}
+                onClick={() => setPickerOpen(false)}
+                aria-label="Close member picker"
+              />
+            }
+          >
+            Select member
+          </DrawerHeaderTitle>
+        </DrawerHeader>
+
+        <DrawerBody className={pageStyles.pickerBody}>
+          <SearchBox
+            value={pickerSearch}
+            onChange={(_, d) => setPickerSearch(d.value)}
+            placeholder="Search by name or email"
+            aria-label="Search the directory"
+          />
+
+          {/* First load (no placeholder data yet) */}
+          {browseQuery.isLoading && (
+            <div className={pageStyles.pickerStatus}>
+              <Spinner size="small" label="Loading the directory…" />
+            </div>
+          )}
+
+          {/* Non-fatal mid-browse failure (e.g. 502). The Drawer stays open and
+              offers retry. */}
+          {browseQuery.isError && !browseQuery.isLoading && (
+            <div className={pageStyles.pickerError} role="alert">
+              <span>Directory temporarily unavailable — try again.</span>
+              <Button size="small" onClick={() => browseQuery.refetch()}>
+                Try again
+              </Button>
+            </div>
+          )}
+
+          {/* Clean empty state */}
+          {!browseQuery.isLoading && !browseQuery.isError && browseUsers.length === 0 && (
+            <div className={pageStyles.pickerStatus}>
+              {pickerFilter
+                ? <span>No members match “{pickerFilter}”.</span>
+                : <span>No members found in the directory.</span>}
+            </div>
+          )}
+
+          {!browseQuery.isError && browseUsers.length > 0 && (
+            <>
+              <div className={pageStyles.pickerCount}>
+                {browseUsers.length} of {browseTotal}
+              </div>
+              <div
+                className={pageStyles.pickerList}
+                role="radiogroup"
+                aria-label="Directory members"
+              >
+                {browseUsers.map((u) => {
+                  const selected = draftUser?.sub === u.sub;
+                  return (
+                    <button
+                      key={u.sub}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      className={`${pageStyles.userRow} ${selected ? pageStyles.userRowSelected : ''}`}
+                      onClick={() => setDraftUser(u)}
+                      onDoubleClick={confirmPicker}
+                    >
+                      <Avatar name={u.display_name ?? u.email} color="colorful" aria-hidden />
+                      <span className={pageStyles.userRowText}>
+                        <span className={pageStyles.userRowName}>{u.display_name ?? u.email}</span>
+                        <span className={pageStyles.userRowEmail}>{u.email}</span>
+                      </span>
+                      {selected && <Checkmark20Filled className={pageStyles.userRowCheck} />}
+                    </button>
+                  );
+                })}
+                {hasMore && (
+                  <Button
+                    className={pageStyles.pickerLoadMore}
+                    appearance="subtle"
+                    size="small"
+                    disabled={browseQuery.isFetching}
+                    onClick={() => setPickerPages((p) => p + 1)}
+                  >
+                    {browseQuery.isFetching ? 'Loading…' : 'Load more'}
+                  </Button>
+                )}
+              </div>
+            </>
+          )}
+        </DrawerBody>
+
+        <DrawerFooter className={pageStyles.pickerFooter}>
+          <Button appearance="secondary" onClick={() => setPickerOpen(false)}>
+            Cancel
+          </Button>
+          <Button appearance="primary" disabled={!draftUser} onClick={confirmPicker}>
+            Select
+          </Button>
+        </DrawerFooter>
+      </OverlayDrawer>
     </div>
   );
 }

--- a/dc-api/cmd/dc-api/main.go
+++ b/dc-api/cmd/dc-api/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/config"
 	"github.com/wso2/dc-api/internal/db"
+	"github.com/wso2/dc-api/internal/directory"
 	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/providers/common"
 	"github.com/wso2/dc-api/internal/providers/dbaas"
@@ -344,6 +345,28 @@ func main() {
 		dbaasProvisioner = dbaas.NewClient(kvClient.Dynamic())
 	}
 
+	// ── IdP SCIM2 directory (optional, read-only) ────────────────────────────
+	// Fail fast on a half-configured DCAPI_IDP_* set; build the provider only
+	// when all four variables are present. A nil provider keeps the feature
+	// dark (directory endpoints → 501, invite-by-email → 422).
+	if err := cfg.ValidateDirectory(); err != nil {
+		log.Fatal().Err(err).Msg("IdP directory config is incomplete — set all DCAPI_IDP_* variables or none")
+	}
+	var directoryProvider directory.Provider
+	if cfg.DirectoryConfigured() {
+		directoryProvider = directory.NewSCIM2Client(
+			cfg.IDPSCIMBaseURL, cfg.IDPTokenURL, cfg.IDPClientID, cfg.IDPClientSecret,
+			cfg.IDPScopes, cfg.IDPUserstoreDomain, nil)
+		log.Info().
+			Str("scim_base_url", cfg.IDPSCIMBaseURL).
+			Str("client_id", cfg.IDPClientID).
+			Str("scopes", cfg.IDPScopes).
+			Str("userstore_domain", cfg.IDPUserstoreDomain).
+			Msg("IdP directory enabled (SCIM2) — invite picker and invite-by-email active")
+	} else {
+		log.Info().Msg("IdP directory disabled (DCAPI_IDP_* unset) — invite by user_sub only")
+	}
+
 	// ── Router ────────────────────────────────────────────────────────────────
 	// All wiring happens in NewRouter. main.go does not know about individual routes.
 	router := api.NewRouter(api.RouterDeps{
@@ -365,6 +388,7 @@ func main() {
 		EndpointProvisioner: endpointProvisioner,
 		KeyVaultBackendAddr: cfg.KeyVaultBackendAddr,
 		KeyVaultBackendPort: cfg.KeyVaultBackendPort,
+		DirectoryProvider:   directoryProvider,
 		AuthMiddleware:      authMiddleware,
 		AuthService:         bffSvc,
 		TenantGroupPrefix:   cfg.TenantGroupPrefix,

--- a/dc-api/internal/api/handlers/directory.go
+++ b/dc-api/internal/api/handlers/directory.go
@@ -1,0 +1,194 @@
+// Package handlers — directory.go
+//
+// DirectoryHandler implements the optional IdP directory proxy endpoints:
+//
+//	GET /v1/tenants/{tenant_id}/directory/users   → SCIM2 user search (invite picker)
+//	GET /v1/tenants/{tenant_id}/directory/groups  → SCIM2 group listing
+//
+// The path is tenant-scoped because RBAC gating evaluates actions at a scope,
+// but the directory itself is organization-global — every tenant queries the
+// same IdP. Both routes are gated with authorization/roleAssignments/write
+// (a write action gating GETs is intentional: the directory is visible only
+// to principals who can perform invitations).
+//
+// Responses are passed through live from the IdP, minimal
+// fields only (sub/email/display_name; id/name), nothing persisted.
+//
+// Feature detection: 501 when no directory provider is configured (the
+// feature is dark until the operator reconfigures dc-api); 502 when a
+// provider is configured but the live IdP request failed (transient — retry).
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/directory"
+)
+
+const (
+	directoryDefaultLimit = 50
+	directoryMaxLimit     = 200
+	directoryMaxFilterLen = 256
+
+	// directoryUpstreamErrorMsg is the generic 502 body returned when the live
+	// IdP request fails. The detailed error (which embeds the internal SCIM URL
+	// and IdP host) is logged server-side only — it must never reach API
+	// clients. Mirrors openapi.yaml components/responses/DirectoryUpstreamError.
+	directoryUpstreamErrorMsg = "directory upstream request failed; try again or invite by user_sub"
+)
+
+// DirectoryHandler serves the /directory/* read-only proxy endpoints.
+type DirectoryHandler struct {
+	// directory may be nil — the feature is dark and every endpoint returns 501.
+	directory directory.Provider
+	log       zerolog.Logger
+}
+
+// NewDirectoryHandler creates a DirectoryHandler. dir may be nil (feature dark).
+func NewDirectoryHandler(dir directory.Provider, log zerolog.Logger) *DirectoryHandler {
+	return &DirectoryHandler{directory: dir, log: log}
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+type directoryUserResponse struct {
+	Sub         string `json:"sub"`
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+type directoryGroupResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+// ListUsers proxies a live SCIM2 user search. Gated by
+// authorization/roleAssignments/write at the route.
+func (h *DirectoryHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	if !h.tenantGuard(w, r) {
+		return
+	}
+	if h.directory == nil {
+		writeError(w, http.StatusNotImplemented,
+			"no directory provider is configured on this deployment")
+		return
+	}
+
+	filter := r.URL.Query().Get("filter")
+	if len(filter) > directoryMaxFilterLen {
+		writeError(w, http.StatusBadRequest, "filter must be at most 256 characters")
+		return
+	}
+	if strings.ContainsAny(filter, `"\`) {
+		writeError(w, http.StatusBadRequest, "filter contains invalid characters")
+		return
+	}
+	limit, offset, ok := parseDirectoryPaging(w, r)
+	if !ok {
+		return
+	}
+
+	users, total, err := h.directory.SearchUsers(r.Context(), filter, limit, offset)
+	if err != nil {
+		h.log.Error().Err(err).Str("filter", filter).Msg("directory user search failed")
+		writeError(w, http.StatusBadGateway, directoryUpstreamErrorMsg)
+		return
+	}
+
+	resp := make([]directoryUserResponse, 0, len(users))
+	for _, u := range users {
+		resp = append(resp, directoryUserResponse{
+			Sub:         u.Sub,
+			Email:       u.Email,
+			DisplayName: u.DisplayName,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"users":         resp,
+		"total_results": total,
+	})
+}
+
+// ListGroups proxies a live SCIM2 group listing. Gated by
+// authorization/roleAssignments/write at the route.
+func (h *DirectoryHandler) ListGroups(w http.ResponseWriter, r *http.Request) {
+	if !h.tenantGuard(w, r) {
+		return
+	}
+	if h.directory == nil {
+		writeError(w, http.StatusNotImplemented,
+			"no directory provider is configured on this deployment")
+		return
+	}
+
+	limit, offset, ok := parseDirectoryPaging(w, r)
+	if !ok {
+		return
+	}
+
+	groups, total, err := h.directory.ListGroups(r.Context(), limit, offset)
+	if err != nil {
+		h.log.Error().Err(err).Msg("directory group listing failed")
+		writeError(w, http.StatusBadGateway, directoryUpstreamErrorMsg)
+		return
+	}
+
+	resp := make([]directoryGroupResponse, 0, len(groups))
+	for _, g := range groups {
+		resp = append(resp, directoryGroupResponse{ID: g.ID, Name: g.Name})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"groups":        resp,
+		"total_results": total,
+	})
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// tenantGuard enforces that the URL tenant_id matches the caller's tenant
+// context (admins exempt — they operate across tenants). Mirrors
+// RoleAssignmentsHandler.tenantGuard: 404 on mismatch so other tenants'
+// identifiers are not enumerable.
+func (h *DirectoryHandler) tenantGuard(w http.ResponseWriter, r *http.Request) bool {
+	tenantID, ok := middleware.TenantFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no tenant in context")
+		return false
+	}
+	if !middleware.IsAdminFromContext(r.Context()) && chi.URLParam(r, "tenant_id") != tenantID {
+		writeError(w, http.StatusNotFound, "tenant not found")
+		return false
+	}
+	return true
+}
+
+// parseDirectoryPaging reads limit/offset with the spec's defaults and bounds
+// (limit default 50, 1..200; offset >= 0, default 0). Writes a 400 and
+// returns ok=false on invalid input.
+func parseDirectoryPaging(w http.ResponseWriter, r *http.Request) (limit, offset int, ok bool) {
+	limit = directoryDefaultLimit
+	if s := r.URL.Query().Get("limit"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 1 || n > directoryMaxLimit {
+			writeError(w, http.StatusBadRequest, "limit must be an integer between 1 and 200")
+			return 0, 0, false
+		}
+		limit = n
+	}
+	if s := r.URL.Query().Get("offset"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 0 {
+			writeError(w, http.StatusBadRequest, "offset must be a non-negative integer")
+			return 0, 0, false
+		}
+		offset = n
+	}
+	return limit, offset, true
+}

--- a/dc-api/internal/api/handlers/directory_test.go
+++ b/dc-api/internal/api/handlers/directory_test.go
@@ -1,0 +1,474 @@
+// Package handlers — directory_test.go
+//
+// Unit tests for DirectoryHandler (the optional IdP SCIM2 directory proxy).
+// These exercise the handler layer in isolation with a fake directory.Provider:
+// no DB, no httptest.Server — requests are built with httptest.NewRequest and
+// the tenant/principal context is injected exactly as the auth + tenant-context
+// middleware would. The directory package's own SCIM2 behaviour is covered in
+// internal/directory/scim2_test.go and is NOT duplicated here.
+//
+// RBAC gating (authorization/roleAssignments/write on the route) is applied in
+// router.go via Gate, not inside the handler — it is covered by the integration
+// suite (directory_invite_test.go), not here.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/directory"
+)
+
+// ── Fake directory.Provider ───────────────────────────────────────────────────
+
+// fakeDirectory implements directory.Provider with pluggable function fields
+// and records the arguments of the last call so tests can assert passthrough.
+type fakeDirectory struct {
+	lookupFn func(ctx context.Context, email string) (*directory.User, error)
+	searchFn func(ctx context.Context, filter string, limit, offset int) ([]directory.User, int, error)
+	groupsFn func(ctx context.Context, limit, offset int) ([]directory.Group, int, error)
+
+	searchCalls int
+	groupCalls  int
+	gotFilter   string
+	gotLimit    int
+	gotOffset   int
+}
+
+func (f *fakeDirectory) LookupUserByEmail(ctx context.Context, email string) (*directory.User, error) {
+	if f.lookupFn == nil {
+		return nil, errors.New("fakeDirectory: LookupUserByEmail not stubbed")
+	}
+	return f.lookupFn(ctx, email)
+}
+
+func (f *fakeDirectory) SearchUsers(ctx context.Context, filter string, limit, offset int) ([]directory.User, int, error) {
+	f.searchCalls++
+	f.gotFilter, f.gotLimit, f.gotOffset = filter, limit, offset
+	if f.searchFn == nil {
+		return nil, 0, errors.New("fakeDirectory: SearchUsers not stubbed")
+	}
+	return f.searchFn(ctx, filter, limit, offset)
+}
+
+func (f *fakeDirectory) ListGroups(ctx context.Context, limit, offset int) ([]directory.Group, int, error) {
+	f.groupCalls++
+	f.gotLimit, f.gotOffset = limit, offset
+	if f.groupsFn == nil {
+		return nil, 0, errors.New("fakeDirectory: ListGroups not stubbed")
+	}
+	return f.groupsFn(ctx, limit, offset)
+}
+
+// Compile-time interface check.
+var _ directory.Provider = (*fakeDirectory)(nil)
+
+// ── Request builder ───────────────────────────────────────────────────────────
+
+// directoryRequest builds a GET request to target with the chi tenant_id URL
+// param and the context values the auth middleware chain would inject:
+// ContextKeyTenantID (the caller's tenant) and ContextKeyIsAdmin.
+func directoryRequest(target, urlTenant, ctxTenant string, admin bool) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("tenant_id", urlTenant)
+	ctx := context.WithValue(r.Context(), chi.RouteCtxKey, rctx)
+	if ctxTenant != "" {
+		ctx = context.WithValue(ctx, middleware.ContextKeyTenantID, ctxTenant)
+	}
+	if admin {
+		ctx = context.WithValue(ctx, middleware.ContextKeyIsAdmin, true)
+	}
+	return r.WithContext(ctx)
+}
+
+// errorField decodes the standard {"error": "..."} envelope.
+func errorField(t *testing.T, body []byte) string {
+	t.Helper()
+	var e struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(body, &e), "response must be the spec's Error envelope; got: %s", body)
+	require.NotEmpty(t, e.Error, "Error envelope requires a non-empty `error` field; got: %s", body)
+	return e.Error
+}
+
+// ── Nil provider → 501 (feature-detection contract) ───────────────────────────
+
+func TestDirectoryListUsers_NilProvider_Returns501(t *testing.T) {
+	t.Parallel()
+	h := NewDirectoryHandler(nil, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, directoryRequest("/v1/tenants/acme/directory/users", "acme", "acme", false))
+
+	assert.Equal(t, http.StatusNotImplemented, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "no directory provider is configured on this deployment",
+		errorField(t, w.Body.Bytes()),
+		"501 body must match the spec's DirectoryNotConfigured example")
+}
+
+func TestDirectoryListGroups_NilProvider_Returns501(t *testing.T) {
+	t.Parallel()
+	h := NewDirectoryHandler(nil, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListGroups(w, directoryRequest("/v1/tenants/acme/directory/groups", "acme", "acme", false))
+
+	assert.Equal(t, http.StatusNotImplemented, w.Code)
+	assert.Equal(t, "no directory provider is configured on this deployment",
+		errorField(t, w.Body.Bytes()))
+}
+
+// ── Success shapes ────────────────────────────────────────────────────────────
+
+func TestDirectoryListUsers_Success_ReturnsUsersAndTotalResults(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return []directory.User{
+				{Sub: "sub-1", Email: "alice@example.com", DisplayName: "Alice A"},
+				{Sub: "sub-2", Email: "aldo@example.com"}, // no display name
+			}, 7, nil // total > page length proves total_results is the SCIM totalResults passthrough
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, directoryRequest("/v1/tenants/acme/directory/users?filter=al", "acme", "acme", false))
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp struct {
+		Users []map[string]any `json:"users"`
+		Total *int             `json:"total_results"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Total, "total_results must be present")
+	assert.Equal(t, 7, *resp.Total)
+	require.Len(t, resp.Users, 2)
+
+	assert.Equal(t, "sub-1", resp.Users[0]["sub"])
+	assert.Equal(t, "alice@example.com", resp.Users[0]["email"])
+	assert.Equal(t, "Alice A", resp.Users[0]["display_name"])
+
+	assert.Equal(t, "sub-2", resp.Users[1]["sub"])
+	_, hasDisplayName := resp.Users[1]["display_name"]
+	assert.False(t, hasDisplayName, "empty display_name must be omitted (omitempty), not rendered as \"\"")
+}
+
+func TestDirectoryListUsers_EmptyResult_ReturnsEmptyArrayNotNull(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return nil, 0, nil
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, directoryRequest("/v1/tenants/acme/directory/users", "acme", "acme", false))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := strings.TrimSpace(w.Body.String())
+	assert.Contains(t, body, `"users":[]`, "zero matches must serialize as [] (spec: array), not null")
+	assert.Contains(t, body, `"total_results":0`)
+}
+
+func TestDirectoryListGroups_Success_ReturnsGroupsAndTotalResults(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		groupsFn: func(_ context.Context, _, _ int) ([]directory.Group, int, error) {
+			return []directory.Group{
+				{ID: "g-1", Name: "platform-team"},
+				{ID: "g-2", Name: "sre"},
+			}, 12, nil
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListGroups(w, directoryRequest("/v1/tenants/acme/directory/groups", "acme", "acme", false))
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp struct {
+		Groups []map[string]any `json:"groups"`
+		Total  *int             `json:"total_results"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Total)
+	assert.Equal(t, 12, *resp.Total)
+	require.Len(t, resp.Groups, 2)
+	assert.Equal(t, "g-1", resp.Groups[0]["id"])
+	assert.Equal(t, "platform-team", resp.Groups[0]["name"])
+}
+
+// ── Filter + paging passthrough ───────────────────────────────────────────────
+
+func TestDirectoryListUsers_FilterAndPagingPassedToProvider(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return nil, 0, nil
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, directoryRequest(
+		"/v1/tenants/acme/directory/users?filter=alice&limit=5&offset=10", "acme", "acme", false))
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, 1, fake.searchCalls)
+	assert.Equal(t, "alice", fake.gotFilter, "filter must be passed through verbatim")
+	assert.Equal(t, 5, fake.gotLimit)
+	assert.Equal(t, 10, fake.gotOffset)
+}
+
+func TestDirectoryListUsers_DefaultPaging(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return nil, 0, nil
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, directoryRequest("/v1/tenants/acme/directory/users", "acme", "acme", false))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "", fake.gotFilter, "omitted filter must arrive as empty string (list-all)")
+	assert.Equal(t, 50, fake.gotLimit, "spec default limit is 50")
+	assert.Equal(t, 0, fake.gotOffset, "spec default offset is 0")
+}
+
+func TestDirectoryListGroups_PagingPassedToProvider(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		groupsFn: func(_ context.Context, _, _ int) ([]directory.Group, int, error) {
+			return nil, 0, nil
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListGroups(w, directoryRequest("/v1/tenants/acme/directory/groups?limit=200&offset=3", "acme", "acme", false))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, fake.groupCalls)
+	assert.Equal(t, 200, fake.gotLimit, "limit=200 is the inclusive maximum and must be accepted")
+	assert.Equal(t, 3, fake.gotOffset)
+}
+
+// ── Upstream failure → 502 ────────────────────────────────────────────────────
+
+func TestDirectoryListUsers_UpstreamError_Returns502(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return nil, 0, errors.New("IdP returned 503")
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, directoryRequest("/v1/tenants/acme/directory/users", "acme", "acme", false))
+
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, directoryUpstreamErrorMsg, errorField(t, w.Body.Bytes()),
+		"502 body must be the generic DirectoryUpstreamError message")
+	assert.NotContains(t, errorField(t, w.Body.Bytes()), "connection refused",
+		"upstream error detail must never leak to API clients")
+}
+
+func TestDirectoryListGroups_UpstreamError_Returns502(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		groupsFn: func(_ context.Context, _, _ int) ([]directory.Group, int, error) {
+			return nil, 0, errors.New("connection refused")
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListGroups(w, directoryRequest("/v1/tenants/acme/directory/groups", "acme", "acme", false))
+
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, directoryUpstreamErrorMsg, errorField(t, w.Body.Bytes()),
+		"502 body must be the generic DirectoryUpstreamError message")
+	assert.NotContains(t, errorField(t, w.Body.Bytes()), "connection refused",
+		"upstream error detail must never leak to API clients")
+}
+
+// ── Paging validation → 400 (provider must NOT be called) ─────────────────────
+
+func TestDirectoryListUsers_InvalidPaging_Returns400(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"limit zero", "?limit=0"},
+		{"limit above max", "?limit=201"},
+		{"limit negative", "?limit=-1"},
+		{"limit non-integer", "?limit=abc"},
+		{"offset negative", "?offset=-1"},
+		{"offset non-integer", "?offset=xyz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeDirectory{}
+			h := NewDirectoryHandler(fake, zerolog.Nop())
+			w := httptest.NewRecorder()
+
+			h.ListUsers(w, directoryRequest(
+				"/v1/tenants/acme/directory/users"+tc.query, "acme", "acme", false))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			errorField(t, w.Body.Bytes()) // must be the Error envelope
+			assert.Zero(t, fake.searchCalls, "provider must not be hit on invalid paging")
+		})
+	}
+}
+
+func TestDirectoryListGroups_InvalidPaging_Returns400(t *testing.T) {
+	t.Parallel()
+	cases := []string{"?limit=0", "?limit=201", "?limit=abc", "?offset=-1", "?offset=abc"}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeDirectory{}
+			h := NewDirectoryHandler(fake, zerolog.Nop())
+			w := httptest.NewRecorder()
+
+			h.ListGroups(w, directoryRequest("/v1/tenants/acme/directory/groups"+q, "acme", "acme", false))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			assert.Zero(t, fake.groupCalls, "provider must not be hit on invalid paging")
+		})
+	}
+}
+
+// ── Filter validation → 400 (SCIM injection defence) ──────────────────────────
+
+func TestDirectoryListUsers_InvalidFilter_Returns400(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		filter string
+	}{
+		{"double quote", `ali"ce`},
+		{"backslash", `ali\ce`},
+		{"over max length", strings.Repeat("a", 257)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeDirectory{}
+			h := NewDirectoryHandler(fake, zerolog.Nop())
+			w := httptest.NewRecorder()
+
+			req := directoryRequest("/v1/tenants/acme/directory/users", "acme", "acme", false)
+			q := req.URL.Query()
+			q.Set("filter", tc.filter)
+			req.URL.RawQuery = q.Encode()
+
+			h.ListUsers(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			assert.Zero(t, fake.searchCalls, "unsafe filter must be rejected before the provider call")
+		})
+	}
+}
+
+func TestDirectoryListUsers_FilterAtMaxLength_Accepted(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return nil, 0, nil
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	filter := strings.Repeat("a", 256) // inclusive boundary
+	req := directoryRequest("/v1/tenants/acme/directory/users", "acme", "acme", false)
+	q := req.URL.Query()
+	q.Set("filter", filter)
+	req.URL.RawQuery = q.Encode()
+
+	h.ListUsers(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, filter, fake.gotFilter)
+}
+
+// ── Tenant guard ──────────────────────────────────────────────────────────────
+
+func TestDirectoryListUsers_CrossTenantURL_Returns404(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	// Caller's tenant context is tenant-a, but the URL names tenant-b.
+	h.ListUsers(w, directoryRequest("/v1/tenants/tenant-b/directory/users", "tenant-b", "tenant-a", false))
+
+	assert.Equal(t, http.StatusNotFound, w.Code,
+		"cross-tenant access must 404 so tenant identifiers are not enumerable")
+	assert.Equal(t, "tenant not found", errorField(t, w.Body.Bytes()))
+	assert.Zero(t, fake.searchCalls)
+}
+
+func TestDirectoryListGroups_CrossTenantURL_Returns404(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListGroups(w, directoryRequest("/v1/tenants/tenant-b/directory/groups", "tenant-b", "tenant-a", false))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Zero(t, fake.groupCalls)
+}
+
+func TestDirectoryListUsers_CrossTenantURL_AdminExempt(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectory{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return nil, 0, nil
+		},
+	}
+	h := NewDirectoryHandler(fake, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	// Admin context with a mismatched URL tenant must pass the guard.
+	h.ListUsers(w, directoryRequest("/v1/tenants/tenant-b/directory/users", "tenant-b", "tenant-a", true))
+
+	assert.Equal(t, http.StatusOK, w.Code, "platform admins operate across tenants; body=%s", w.Body.String())
+	assert.Equal(t, 1, fake.searchCalls)
+}
+
+func TestDirectoryListUsers_NoTenantInContext_Returns401(t *testing.T) {
+	t.Parallel()
+	h := NewDirectoryHandler(&fakeDirectory{}, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, directoryRequest("/v1/tenants/acme/directory/users", "acme", "" /* no tenant ctx */, false))
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/dc-api/internal/api/handlers/role_assignments.go
+++ b/dc-api/internal/api/handlers/role_assignments.go
@@ -26,6 +26,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/db"
+	"github.com/wso2/dc-api/internal/directory"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/rbac"
 )
@@ -44,18 +46,27 @@ import (
 // project scope.
 type RoleAssignmentsHandler struct {
 	repo *db.Repository
-	log  zerolog.Logger
+	// directory is the optional IdP directory provider used to resolve
+	// user_email → sub on email-based invites. Nil when the deployment has no
+	// directory configured — invite-by-email then returns 422 per the spec.
+	directory directory.Provider
+	log       zerolog.Logger
 }
 
 // NewRoleAssignmentsHandler creates a RoleAssignmentsHandler with injected deps.
-func NewRoleAssignmentsHandler(repo *db.Repository, log zerolog.Logger) *RoleAssignmentsHandler {
-	return &RoleAssignmentsHandler{repo: repo, log: log}
+// dir may be nil (directory feature dark).
+func NewRoleAssignmentsHandler(repo *db.Repository, dir directory.Provider, log zerolog.Logger) *RoleAssignmentsHandler {
+	return &RoleAssignmentsHandler{repo: repo, directory: dir, log: log}
 }
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
 
 type createRoleAssignmentRequest struct {
-	UserSub string `json:"user_sub"`
+	// UserSub and UserEmail identify the principal — exactly one of the two is
+	// required. UserEmail is resolved to a sub via the directory provider at
+	// request time; only the sub is stored.
+	UserSub   string `json:"user_sub"`
+	UserEmail string `json:"user_email,omitempty"`
 	// RoleDefinition is the v2 role-definition key to grant — any catalog key
 	// (e.g. "Owner", "Contributor", "Reader", "VirtualMachineContributor"). This is
 	// the only role vocabulary the API accepts; the v1 owner/member/viewer ranks
@@ -65,8 +76,11 @@ type createRoleAssignmentRequest struct {
 }
 
 func (req *createRoleAssignmentRequest) validate() error {
-	if req.UserSub == "" {
-		return fmt.Errorf("user_sub is required")
+	if (req.UserSub == "") == (req.UserEmail == "") {
+		return fmt.Errorf("exactly one of user_sub or user_email is required")
+	}
+	if strings.ContainsAny(req.UserEmail, `"\`) {
+		return fmt.Errorf("user_email contains invalid characters")
 	}
 	if req.RoleDefinition == "" {
 		return fmt.Errorf("role_definition is required")
@@ -186,15 +200,62 @@ func (h *RoleAssignmentsHandler) Create(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Resolve user_email → sub via the directory provider (live point lookup;
+	// only the resolved sub is persisted). When no alias was
+	// supplied, the resolved IdP display name (falling back to the email) is
+	// used as the display_alias default.
+	principalID := req.UserSub
+	displayAlias := req.DisplayAlias
+	resolvedFromEmail := false
+	if req.UserEmail != "" {
+		if h.directory == nil {
+			writeError(w, http.StatusUnprocessableEntity,
+				"invite by user_email requires a directory provider, and none is configured on this deployment; invite by user_sub instead")
+			return
+		}
+		user, err := h.directory.LookupUserByEmail(r.Context(), req.UserEmail)
+		switch {
+		case errors.Is(err, directory.ErrUserNotFound):
+			writeError(w, http.StatusUnprocessableEntity,
+				fmt.Sprintf("user_email '%s' does not match any IdP user", req.UserEmail))
+			return
+		case errors.Is(err, directory.ErrAmbiguous):
+			writeError(w, http.StatusUnprocessableEntity,
+				fmt.Sprintf("user_email '%s' matches more than one IdP user; invite by user_sub instead", req.UserEmail))
+			return
+		case errors.Is(err, directory.ErrBadFilter):
+			writeError(w, http.StatusBadRequest, "user_email contains invalid characters")
+			return
+		case err != nil:
+			// Log the detailed error (which embeds the internal SCIM URL and IdP
+			// host) server-side only; return a generic body so the upstream URL
+			// never leaks to API clients. See directoryUpstreamErrorMsg.
+			h.log.Error().Err(err).Str("scope", string(scope.Type)).Str("scope_id", scope.ID).
+				Msg("directory lookup for invite-by-email failed")
+			writeError(w, http.StatusBadGateway, directoryUpstreamErrorMsg)
+			return
+		}
+		principalID = user.Sub
+		// Default the alias to the resolved IdP display name (user decision),
+		// falling back to the invited email when the IdP has no display name.
+		if displayAlias == "" {
+			displayAlias = user.DisplayName
+			if displayAlias == "" {
+				displayAlias = req.UserEmail
+			}
+		}
+		resolvedFromEmail = true
+	}
+
 	ra, err := h.repo.CreateRoleAssignment(r.Context(), models.RoleAssignment{
 		PrincipalType:  models.PrincipalTypeUser,
-		PrincipalID:    req.UserSub,
+		PrincipalID:    principalID,
 		ScopeType:      scope.Type,
 		ScopeID:        scope.ID,
 		ScopeUUID:      scope.UUID,
 		RoleDefinition: req.RoleDefinition,
 		GrantedBy:      callerID,
-		DisplayAlias:   req.DisplayAlias,
+		DisplayAlias:   displayAlias,
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key") {
@@ -203,7 +264,7 @@ func (h *RoleAssignmentsHandler) Create(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		h.log.Error().Err(err).Str("scope", string(scope.Type)).Str("scope_id", scope.ID).
-			Str("user_sub", req.UserSub).Msg("create role assignment failed")
+			Str("user_sub", principalID).Msg("create role assignment failed")
 		writeError(w, http.StatusInternalServerError, "failed to create role assignment")
 		return
 	}
@@ -218,12 +279,21 @@ func (h *RoleAssignmentsHandler) Create(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+	// Audit: record email resolution explicitly. Emails in audit_events are
+	// fine — audit is internal; the no-PII rule applies to the
+	// role_assignments row (where display_alias defaults to the resolved IdP
+	// display name, falling back to the email).
+	auditMsg := fmt.Sprintf("granted %s to %s at %s %s",
+		req.RoleDefinition, principalID, scope.Type, scope.ID)
+	if resolvedFromEmail {
+		auditMsg = fmt.Sprintf("granted %s to %s (resolved from %s) at %s %s",
+			req.RoleDefinition, principalID, req.UserEmail, scope.Type, scope.ID)
+	}
 	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
 		ResourceID: ra.ID,
 		ActorID:    callerID,
 		Action:     "ROLE_ASSIGNMENT_CREATE",
-		Message: fmt.Sprintf("granted %s to %s at %s %s",
-			req.RoleDefinition, req.UserSub, scope.Type, scope.ID),
+		Message:    auditMsg,
 	})
 
 	writeJSON(w, http.StatusCreated, toRoleAssignmentResponse(ra))

--- a/dc-api/internal/api/handlers/role_assignments_test.go
+++ b/dc-api/internal/api/handlers/role_assignments_test.go
@@ -1,0 +1,88 @@
+// Package handlers — role_assignments_test.go
+//
+// Unit tests for createRoleAssignmentRequest.validate() — the user_email XOR
+// user_sub rule introduced with the IdP directory feature, plus the
+// role_definition checks. validate() failures are what the Create handler maps
+// to HTTP 400.
+//
+// The Create handler's email-resolution branches (nil provider → 422,
+// ErrUserNotFound/ErrAmbiguous → 422, upstream failure → 502, resolved-sub
+// persistence, display_alias defaulting) are NOT unit-testable here:
+// RoleAssignmentsHandler holds the concrete *db.Repository and Create calls
+// requireAction → repo.ListRoleAssignmentsForPrincipal before any directory
+// code runs, so the paths need a real database. They are covered end-to-end in
+// test/integration/directory_invite_test.go (runs cluster-free with
+// DCAPI_TEST_NOP=1).
+package handlers
+
+import (
+	"testing"
+)
+
+func TestCreateRoleAssignmentRequest_Validate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		req     createRoleAssignmentRequest
+		wantErr bool
+	}{
+		{
+			name:    "user_sub only is valid",
+			req:     createRoleAssignmentRequest{UserSub: "sub-123", RoleDefinition: "Contributor"},
+			wantErr: false,
+		},
+		{
+			name:    "user_email only is valid",
+			req:     createRoleAssignmentRequest{UserEmail: "alice@example.com", RoleDefinition: "Contributor"},
+			wantErr: false,
+		},
+		{
+			name:    "both user_sub and user_email is rejected",
+			req:     createRoleAssignmentRequest{UserSub: "sub-123", UserEmail: "alice@example.com", RoleDefinition: "Contributor"},
+			wantErr: true,
+		},
+		{
+			name:    "neither user_sub nor user_email is rejected",
+			req:     createRoleAssignmentRequest{RoleDefinition: "Contributor"},
+			wantErr: true,
+		},
+		{
+			name:    "user_email with a double quote is rejected (SCIM filter injection)",
+			req:     createRoleAssignmentRequest{UserEmail: `ali"ce@example.com`, RoleDefinition: "Contributor"},
+			wantErr: true,
+		},
+		{
+			name:    "user_email with a backslash is rejected (SCIM filter injection)",
+			req:     createRoleAssignmentRequest{UserEmail: `ali\ce@example.com`, RoleDefinition: "Contributor"},
+			wantErr: true,
+		},
+		{
+			name:    "missing role_definition is rejected",
+			req:     createRoleAssignmentRequest{UserSub: "sub-123"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown role_definition is rejected",
+			req:     createRoleAssignmentRequest{UserSub: "sub-123", RoleDefinition: "SuperDuperAdmin"},
+			wantErr: true,
+		},
+		{
+			name:    "Owner is a known built-in role",
+			req:     createRoleAssignmentRequest{UserEmail: "alice@example.com", RoleDefinition: "Owner"},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.req.validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("expected validate() error, got nil (req=%+v)", tc.req)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected validate() error: %v (req=%+v)", err, tc.req)
+			}
+		})
+	}
+}

--- a/dc-api/internal/api/router.go
+++ b/dc-api/internal/api/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/handlers"
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/db"
+	"github.com/wso2/dc-api/internal/directory"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/providers/endpoints"
@@ -87,7 +88,12 @@ type RouterDeps struct {
 	// must be set (sourced from DCAPI_KV_BACKEND_ADDR / DCAPI_KV_BACKEND_PORT).
 	KeyVaultBackendAddr string
 	KeyVaultBackendPort int
-	AuthMiddleware      middleware.AuthValidator
+	// DirectoryProvider is the optional read-only IdP SCIM2 directory (invite
+	// picker + invite-by-email). Nil when the deployment has no DCAPI_IDP_*
+	// config: the /directory endpoints then answer 501 and role-assignment
+	// creates accept user_sub only (user_email → 422).
+	DirectoryProvider directory.Provider
+	AuthMiddleware    middleware.AuthValidator
 	// AuthService (F7 BFF) is optional. When non-nil, dc-api serves
 	// /v1/auth/{login,callback,logout,me} for cloud-ui's session-cookie
 	// auth path. When nil, those routes are not registered and the only
@@ -194,8 +200,14 @@ func NewRouter(deps RouterDeps) http.Handler {
 		bastionHandler := handlers.NewBastionHandler(deps.Repo, deps.ComputeProvider, deps.BastionImage, deps.BastionMgmtNAD, deps.DNSSearchDomain, deps.Log)
 		clusterHandler := handlers.NewClusterHandler(deps.Repo, deps.ClusterProvider, deps.Log)
 
-		// M1.5 member management handler.
-		roleAssignmentHandler := handlers.NewRoleAssignmentsHandler(deps.Repo, deps.Log)
+		// M1.5 member management handler. The directory provider (possibly nil)
+		// powers invite-by-email resolution.
+		roleAssignmentHandler := handlers.NewRoleAssignmentsHandler(deps.Repo, deps.DirectoryProvider, deps.Log)
+
+		// IdP directory proxy (optional SCIM2). The handler itself answers 501
+		// when deps.DirectoryProvider is nil, so the routes always register —
+		// 501 is the documented feature-detection signal, not a 404.
+		directoryHandler := handlers.NewDirectoryHandler(deps.DirectoryProvider, deps.Log)
 
 		// RBAC v2 capability probe — the UI asks "may I do these actions here?"
 		// and gets booleans back, so it never re-implements the matcher.
@@ -524,6 +536,16 @@ func NewRouter(deps RouterDeps) http.Handler {
 				r.Method(http.MethodPost, "/", gate(rbac.ActionRoleAssignmentWrite, roleAssignmentHandler.Create))                  // POST   /v1/tenants/{tenant_id}/role-assignments
 				r.Method(http.MethodGet, "/", gate(rbac.ActionRoleAssignmentRead, roleAssignmentHandler.List))                      // GET    /v1/tenants/{tenant_id}/role-assignments
 				r.Method(http.MethodDelete, "/{principal_id}", gate(rbac.ActionRoleAssignmentDelete, roleAssignmentHandler.Remove)) // DELETE /v1/tenants/{tenant_id}/role-assignments/{principal_id}
+			})
+
+			// IdP directory proxy — invite picker (users) + group listing.
+			// BOTH gated with roleAssignments/write even though they are GETs:
+			// intentional product guardrail — the directory is visible only to
+			// principals who can perform invitations (Owner,
+			// UserAccessAdministrator). Do NOT introduce a read action here.
+			r.Route("/directory", func(r chi.Router) {
+				r.Method(http.MethodGet, "/users", gate(rbac.ActionRoleAssignmentWrite, directoryHandler.ListUsers))   // GET /v1/tenants/{tenant_id}/directory/users
+				r.Method(http.MethodGet, "/groups", gate(rbac.ActionRoleAssignmentWrite, directoryHandler.ListGroups)) // GET /v1/tenants/{tenant_id}/directory/groups
 			})
 
 			// Images and provider networks are tenant-shared catalog (not project

--- a/dc-api/internal/config/config.go
+++ b/dc-api/internal/config/config.go
@@ -13,6 +13,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/kelseyhightower/envconfig"
@@ -238,6 +239,52 @@ type Config struct {
 	KeyVaultBackendAddr string `envconfig:"KV_BACKEND_ADDR" default:"openbao.dc-api-vault.svc.cluster.local"`
 	KeyVaultBackendPort int    `envconfig:"KV_BACKEND_PORT" default:"8200"`
 
+	// ── IdP SCIM2 directory (optional, read-only) ─────────────────────────────
+	// Optional read-only SCIM2 directory integration: powers the invite picker
+	// (GET /v1/tenants/{tid}/directory/{users,groups}) and invite-by-email
+	// (user_email on POST .../role-assignments). When ALL FOUR are unset the
+	// feature is dark — the directory endpoints answer 501 and invites work by
+	// user_sub only. Setting SOME but not all four fails startup (see
+	// ValidateDirectory) so a half-configured deployment is caught early.
+	//
+	// The OAuth2 client_credentials credential MUST hold user/group VIEW
+	// scopes only — dc-api never writes to the IdP and a leaked read-only
+	// credential cannot modify identities.
+	//
+	// Asgardeo examples:
+	//   IDP_SCIM_BASE_URL = https://api.asgardeo.io/t/{org}/scim2
+	//   IDP_TOKEN_URL     = https://api.asgardeo.io/t/{org}/oauth2/token
+	IDPSCIMBaseURL  string `envconfig:"IDP_SCIM_BASE_URL" default:""`
+	IDPTokenURL     string `envconfig:"IDP_TOKEN_URL"     default:""`
+	IDPClientID     string `envconfig:"IDP_CLIENT_ID"     default:""`
+	IDPClientSecret string `envconfig:"IDP_CLIENT_SECRET" default:""`
+
+	// IDPScopes are the OAuth2 scopes requested with the client_credentials
+	// grant when fetching the SCIM access token. Space- or comma-separated.
+	//
+	// Required by Asgardeo and WSO2 Identity Server: they only attach SCIM
+	// permissions to a client_credentials token when the scopes are explicitly
+	// requested. Without them every SCIM call returns 403 against a real org.
+	// The Asgardeo read-only set is:
+	//
+	//   IDP_SCOPES = "internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view"
+	//
+	// Optional: some IdPs grant SCIM permissions to the M2M app directly and
+	// need no scopes, so this is NOT part of the all-or-nothing
+	// ValidateDirectory check — it only matters when the other four are set.
+	// Grant LIST/VIEW scopes only; dc-api never writes to the IdP.
+	IDPScopes string `envconfig:"IDP_SCOPES" default:""`
+
+	// IDPUserstoreDomain restricts directory reads to one userstore via the
+	// WSO2 SCIM2 `domain` query parameter. Without it the IdP returns every
+	// account in the organization — including console administrators and
+	// collaborators, who are not invite candidates. The default "DEFAULT" is
+	// Asgardeo's consumer-user store; on-prem WSO2 Identity Server typically
+	// wants "PRIMARY". Set explicitly empty to list all stores (non-WSO2
+	// SCIM servers ignore the parameter either way). Not part of the
+	// all-or-nothing ValidateDirectory check.
+	IDPUserstoreDomain string `envconfig:"IDP_USERSTORE_DOMAIN" default:"DEFAULT"`
+
 	// ── Logging ───────────────────────────────────────────────────────────────
 	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
 
@@ -258,6 +305,47 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
 	return &cfg, nil
+}
+
+// DirectoryConfigured reports whether the optional IdP SCIM2 directory is
+// fully configured (all four DCAPI_IDP_* variables set).
+func (c *Config) DirectoryConfigured() bool {
+	return c.IDPSCIMBaseURL != "" && c.IDPTokenURL != "" &&
+		c.IDPClientID != "" && c.IDPClientSecret != ""
+}
+
+// ValidateDirectory fails fast on a half-configured IdP directory: either all
+// four required DCAPI_IDP_* variables (SCIM_BASE_URL, TOKEN_URL, CLIENT_ID,
+// CLIENT_SECRET) are set (feature on) or none are (feature dark). Anything in
+// between is an operator mistake — e.g. the secret didn't make it into the
+// deployment — and silently running with the feature dark would hide it until
+// the first invite-by-email fails.
+//
+// DCAPI_IDP_SCOPES is intentionally excluded from this check: it is optional
+// (some IdPs need no scopes) and only meaningful once the other four are set.
+func (c *Config) ValidateDirectory() error {
+	vars := map[string]string{
+		"DCAPI_IDP_SCIM_BASE_URL": c.IDPSCIMBaseURL,
+		"DCAPI_IDP_TOKEN_URL":     c.IDPTokenURL,
+		"DCAPI_IDP_CLIENT_ID":     c.IDPClientID,
+		"DCAPI_IDP_CLIENT_SECRET": c.IDPClientSecret,
+	}
+	var missing []string
+	set := 0
+	for name, v := range vars {
+		if v == "" {
+			missing = append(missing, name)
+		} else {
+			set++
+		}
+	}
+	if set == 0 || set == len(vars) {
+		return nil
+	}
+	sort.Strings(missing)
+	return fmt.Errorf(
+		"IdP directory config is incomplete: %s not set — set all four required DCAPI_IDP_* variables (SCIM_BASE_URL, TOKEN_URL, CLIENT_ID, CLIENT_SECRET) to enable the directory, or none to disable it (DCAPI_IDP_SCOPES is optional)",
+		strings.Join(missing, ", "))
 }
 
 // ValidateF20 performs fail-fast validation of the F20 per-VPC DNS config.

--- a/dc-api/internal/directory/interface.go
+++ b/dc-api/internal/directory/interface.go
@@ -1,0 +1,77 @@
+// Package directory provides an optional, read-only lookup facade over the
+// deployment's IdP user/group directory (SCIM2 today; the Provider interface
+// keeps the door open for others).
+//
+// Hard rules this package enforces — do not relax them when extending it:
+//
+//   - Proxy, don't store. Nothing read from the IdP is ever persisted by this
+//     package or its callers. dc-api stores only the OIDC `sub` (and, on an
+//     email-based invite, the email the inviter typed as the display_alias
+//     default) — both on the role_assignments row, never sourced from a SCIM
+//     response beyond the sub itself.
+//   - Minimal fields only. The SCIM responses are decoded into minimal structs
+//     that carry exactly the fields exposed here (sub/email/display_name for
+//     users, id/name for groups). Groups' membership, phone numbers, addresses,
+//     raw attributes — none of it is read out of the response.
+//   - Read-only credential. The configured IdP client must hold user/group
+//     VIEW scopes only. This package never issues anything but GETs.
+//
+// The feature is dark when unconfigured: main.go passes a nil Provider into
+// the router and the handlers answer 501 (directory endpoints) / 422
+// (invite-by-email) per the OpenAPI contract.
+package directory
+
+import (
+	"context"
+	"errors"
+)
+
+// User is the minimal directory user record: just enough for an invite picker.
+type User struct {
+	// Sub is the OIDC `sub` — for Asgardeo this equals the SCIM user `id`.
+	Sub string
+	// Email is the user's primary email/username.
+	Email string
+	// DisplayName is the human-readable name, when the IdP has one.
+	DisplayName string
+}
+
+// Group is the minimal directory group record.
+type Group struct {
+	ID   string
+	Name string
+}
+
+// Sentinel errors callers branch on with errors.Is.
+var (
+	// ErrNotConfigured is returned by code paths that require a directory
+	// provider when none is configured on this deployment.
+	ErrNotConfigured = errors.New("no directory provider is configured on this deployment")
+	// ErrUserNotFound means an email point-lookup matched zero IdP users.
+	ErrUserNotFound = errors.New("no IdP user matches that email")
+	// ErrAmbiguous means an email point-lookup matched more than one IdP user.
+	ErrAmbiguous = errors.New("email matches more than one IdP user")
+	// ErrBadFilter means the caller-supplied filter/email contains characters
+	// that cannot be safely embedded in a SCIM filter (defence against SCIM
+	// filter injection). Handlers map it to a 4xx, never to a 502.
+	ErrBadFilter = errors.New("filter value contains characters not allowed in a directory query")
+)
+
+// Provider is the read-only directory lookup interface the handlers depend on.
+// Implementations must respect the package-level hard rules above.
+type Provider interface {
+	// LookupUserByEmail resolves an email to exactly one directory user.
+	// Returns ErrUserNotFound (zero matches), ErrAmbiguous (>1 match), or
+	// ErrBadFilter (unsafe input). Any other error is an upstream failure
+	// (handlers map it to 502).
+	LookupUserByEmail(ctx context.Context, email string) (*User, error)
+
+	// SearchUsers returns one page of users matching filter (case-insensitive
+	// substring against username/email/display name; empty filter lists all),
+	// plus the total number of matches across all pages (SCIM2 totalResults).
+	SearchUsers(ctx context.Context, filter string, limit, offset int) ([]User, int, error)
+
+	// ListGroups returns one page of groups plus the total count across all
+	// pages (SCIM2 totalResults).
+	ListGroups(ctx context.Context, limit, offset int) ([]Group, int, error)
+}

--- a/dc-api/internal/directory/scim2.go
+++ b/dc-api/internal/directory/scim2.go
@@ -1,0 +1,425 @@
+// Package directory — scim2.go
+//
+// SCIM2Client implements Provider against any SCIM 2.0 Users/Groups API
+// (Asgardeo's /t/{org}/scim2 is the reference deployment). Authentication is
+// OAuth2 client_credentials via golang.org/x/oauth2/clientcredentials, which
+// caches the access token and refreshes it transparently.
+//
+// Caching policy:
+//   - SearchUsers / ListGroups responses are cached in-memory for a short TTL
+//     (30s, keyed by query+page, bounded size) so a type-ahead UI doesn't
+//     hammer a rate-limited SaaS IdP.
+//   - LookupUserByEmail (the invite path) is deliberately NOT cached:
+//     correctness at grant time beats rate limits there — a stale "not found"
+//     would block an invite for the cache TTL after the user is created.
+package directory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	scimTimeout   = 30 * time.Second
+	cacheTTL      = 30 * time.Second
+	cacheMaxEntry = 256
+)
+
+// SCIM2Client implements Provider against a SCIM 2.0 endpoint.
+type SCIM2Client struct {
+	baseURL string // e.g. https://api.asgardeo.io/t/{org}/scim2 — no trailing slash
+	domain  string // userstore domain filter (`domain` query param); "" = all stores
+	http    *http.Client
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	users   []User
+	groups  []Group
+	total   int
+	expires time.Time
+}
+
+// NewSCIM2Client builds a SCIM2 directory provider.
+//
+// baseURL is the SCIM2 root (e.g. "https://api.asgardeo.io/t/{org}/scim2");
+// tokenURL/clientID/clientSecret configure the OAuth2 client_credentials grant.
+//
+// scopes is the OAuth2 scope string requested with the client_credentials
+// grant, split on spaces AND commas (empties trimmed). It MUST list read-only
+// VIEW/LIST scopes only — NEVER write scopes. Asgardeo and WSO2 Identity Server
+// only attach SCIM permissions to the token when the scopes are explicitly
+// requested, so the read-only set there is
+// "internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view";
+// other IdPs grant SCIM access to the M2M app directly and need none. As a
+// guardrail, dc-api never issues SCIM writes, so even a leaked credential
+// scoped this way cannot modify identities.
+//
+// userstoreDomain restricts every user and group read to one userstore via
+// the WSO2 `domain` query parameter ("DEFAULT" is Asgardeo's consumer store;
+// on-prem WSO2 Identity Server typically uses "PRIMARY"). Without it the IdP
+// returns every account in the organization — including console
+// administrators and collaborators, who are not invite candidates. "" sends
+// no parameter (all stores); non-WSO2 SCIM servers ignore the parameter.
+//
+// httpOverride is for tests only: when non-nil it is used verbatim for SCIM
+// requests (no OAuth2 token exchange). Pass nil in production.
+func NewSCIM2Client(baseURL, tokenURL, clientID, clientSecret, scopes, userstoreDomain string, httpOverride *http.Client) *SCIM2Client {
+	c := &SCIM2Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		domain:  userstoreDomain,
+		cache:   make(map[string]cacheEntry),
+	}
+	if httpOverride != nil {
+		c.http = httpOverride
+		return c
+	}
+	cc := &clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     tokenURL,
+		Scopes:       parseScopes(scopes),
+	}
+	// Give the token exchange the same timeout as the SCIM calls.
+	tokenCtx := context.WithValue(context.Background(),
+		oauth2.HTTPClient, &http.Client{Timeout: scimTimeout})
+	c.http = cc.Client(tokenCtx)
+	c.http.Timeout = scimTimeout
+	return c
+}
+
+// parseScopes splits an OAuth2 scope string on spaces AND commas, trims each
+// token, and drops empties. "" → nil so the token request carries no scope
+// parameter at all (the correct behaviour for IdPs that need none). Both
+// separators are accepted because operators reach for either; the OAuth2 wire
+// format re-joins them with spaces.
+func parseScopes(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ' ' || r == ',' || r == '\t' || r == '\n'
+	})
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if t := strings.TrimSpace(f); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// ── Minimal SCIM response structs ────────────────────────────────────────────
+// Only the fields exposed through Provider are decoded. Do not add fields.
+
+type scimListResponse struct {
+	TotalResults int               `json:"totalResults"`
+	Resources    []json.RawMessage `json:"Resources"`
+}
+
+type scimUser struct {
+	ID          string `json:"id"`
+	UserName    string `json:"userName"`
+	DisplayName string `json:"displayName"`
+	Name        struct {
+		Formatted  string `json:"formatted"`
+		GivenName  string `json:"givenName"`
+		FamilyName string `json:"familyName"`
+	} `json:"name"`
+	Emails []scimEmail `json:"emails"`
+}
+
+// scimEmail tolerates both SCIM email encodings: a bare string
+// ("a@b.c") and the canonical object ({"value":"a@b.c","primary":true}).
+// Asgardeo emits both depending on the resource.
+type scimEmail struct {
+	Value   string
+	Primary bool
+}
+
+func (e *scimEmail) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		e.Value = s
+		return nil
+	}
+	var obj struct {
+		Value   string `json:"value"`
+		Primary bool   `json:"primary"`
+	}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return fmt.Errorf("decoding SCIM email: %w", err)
+	}
+	e.Value = obj.Value
+	e.Primary = obj.Primary
+	return nil
+}
+
+type scimGroup struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
+// stripUserstoreDomain removes the WSO2 IS / Asgardeo userstore-domain prefix
+// from a SCIM userName (e.g. "DEFAULT/alice@example.com" → "alice@example.com").
+// Users in a secondary userstore carry the prefix; primary-store users don't.
+// The segment before the first "/" is a store name, never part of an address,
+// so strip only when it contains no "@".
+func stripUserstoreDomain(userName string) string {
+	if i := strings.IndexByte(userName, '/'); i > 0 && !strings.Contains(userName[:i], "@") {
+		return userName[i+1:]
+	}
+	return userName
+}
+
+// toUser maps a SCIM user to the minimal User record.
+// Sub ← SCIM `id` (for Asgardeo the OIDC sub equals the SCIM user id).
+// Email ← userName (userstore prefix stripped) when it looks like an email,
+// else the primary/first email, else userName as-is.
+// DisplayName ← name.formatted → displayName → "given family" → userName
+// (userstore prefix stripped).
+func (u *scimUser) toUser() User {
+	email := stripUserstoreDomain(u.UserName)
+	if !strings.Contains(email, "@") {
+		if v := u.bestEmail(); v != "" {
+			email = v
+		}
+	}
+	display := u.Name.Formatted
+	if display == "" {
+		display = u.DisplayName
+	}
+	if display == "" {
+		display = strings.TrimSpace(u.Name.GivenName + " " + u.Name.FamilyName)
+	}
+	if display == "" {
+		display = stripUserstoreDomain(u.UserName)
+	}
+	return User{Sub: u.ID, Email: email, DisplayName: display}
+}
+
+func (u *scimUser) bestEmail() string {
+	for _, e := range u.Emails {
+		if e.Primary && e.Value != "" {
+			return e.Value
+		}
+	}
+	for _, e := range u.Emails {
+		if e.Value != "" {
+			return e.Value
+		}
+	}
+	return ""
+}
+
+// ── Provider implementation ──────────────────────────────────────────────────
+
+// LookupUserByEmail resolves email → exactly one user via a SCIM point lookup:
+// `userName eq "<email>"` first (most IdPs, Asgardeo included, use the email
+// as the username), falling back to `emails eq "<email>"` on zero results.
+// Never cached — see the package caching policy.
+func (c *SCIM2Client) LookupUserByEmail(ctx context.Context, email string) (*User, error) {
+	if err := checkFilterValue(email); err != nil {
+		return nil, err
+	}
+
+	for _, attr := range []string{"userName", "emails"} {
+		q := url.Values{}
+		q.Set("filter", fmt.Sprintf("%s eq %q", attr, email))
+		// count=2 is enough to distinguish "exactly one" from "ambiguous".
+		q.Set("startIndex", "1")
+		q.Set("count", "2")
+		if c.domain != "" {
+			q.Set("domain", c.domain)
+		}
+
+		var list scimListResponse
+		if err := c.get(ctx, "/Users", q, &list); err != nil {
+			return nil, err
+		}
+		if list.TotalResults == 0 {
+			continue
+		}
+		if list.TotalResults > 1 {
+			return nil, ErrAmbiguous
+		}
+		if len(list.Resources) == 0 {
+			return nil, fmt.Errorf("IdP reported 1 match for %s but returned no resource", attr)
+		}
+		var su scimUser
+		if err := json.Unmarshal(list.Resources[0], &su); err != nil {
+			return nil, fmt.Errorf("decoding SCIM user: %w", err)
+		}
+		u := su.toUser()
+		return &u, nil
+	}
+	return nil, ErrUserNotFound
+}
+
+// SearchUsers returns one page of users matching filter, plus totalResults.
+// Pages are cached for cacheTTL.
+func (c *SCIM2Client) SearchUsers(ctx context.Context, filter string, limit, offset int) ([]User, int, error) {
+	if err := checkFilterValue(filter); err != nil {
+		return nil, 0, err
+	}
+	key := fmt.Sprintf("users|%s|%d|%d", filter, limit, offset)
+	if e, ok := c.cacheGet(key); ok {
+		return e.users, e.total, nil
+	}
+
+	q := url.Values{}
+	if filter != "" {
+		q.Set("filter", fmt.Sprintf(
+			`userName co %q or name.formatted co %q or emails co %q`,
+			filter, filter, filter))
+	}
+	q.Set("startIndex", strconv.Itoa(offset+1)) // SCIM startIndex is 1-based
+	q.Set("count", strconv.Itoa(limit))
+	if c.domain != "" {
+		q.Set("domain", c.domain)
+	}
+
+	var list scimListResponse
+	if err := c.get(ctx, "/Users", q, &list); err != nil {
+		return nil, 0, err
+	}
+	users := make([]User, 0, len(list.Resources))
+	for _, raw := range list.Resources {
+		var su scimUser
+		if err := json.Unmarshal(raw, &su); err != nil {
+			return nil, 0, fmt.Errorf("decoding SCIM user: %w", err)
+		}
+		users = append(users, su.toUser())
+	}
+	c.cachePut(key, cacheEntry{users: users, total: list.TotalResults})
+	return users, list.TotalResults, nil
+}
+
+// ListGroups returns one page of groups plus totalResults. Pages are cached
+// for cacheTTL. Membership is excluded server-side (minimal-fields rule).
+func (c *SCIM2Client) ListGroups(ctx context.Context, limit, offset int) ([]Group, int, error) {
+	key := fmt.Sprintf("groups|%d|%d", limit, offset)
+	if e, ok := c.cacheGet(key); ok {
+		return e.groups, e.total, nil
+	}
+
+	q := url.Values{}
+	q.Set("startIndex", strconv.Itoa(offset+1))
+	q.Set("count", strconv.Itoa(limit))
+	q.Set("excludedAttributes", "members") // never fetch membership
+	if c.domain != "" {
+		q.Set("domain", c.domain)
+	}
+
+	var list scimListResponse
+	if err := c.get(ctx, "/Groups", q, &list); err != nil {
+		return nil, 0, err
+	}
+	groups := make([]Group, 0, len(list.Resources))
+	for _, raw := range list.Resources {
+		var sg scimGroup
+		if err := json.Unmarshal(raw, &sg); err != nil {
+			return nil, 0, fmt.Errorf("decoding SCIM group: %w", err)
+		}
+		groups = append(groups, Group{ID: sg.ID, Name: sg.DisplayName})
+	}
+	c.cachePut(key, cacheEntry{groups: groups, total: list.TotalResults})
+	return groups, list.TotalResults, nil
+}
+
+// ── Plumbing ─────────────────────────────────────────────────────────────────
+
+// checkFilterValue refuses values that cannot be safely embedded in a SCIM
+// filter expression. %q quoting above escapes double quotes, but rejecting
+// them outright is both simpler to reason about and matches reality — no
+// email or human name contains a double quote or a control character.
+func checkFilterValue(v string) error {
+	for _, r := range v {
+		if r == '"' || r == '\\' || r < 0x20 {
+			return ErrBadFilter
+		}
+	}
+	return nil
+}
+
+// get performs an authenticated GET against {baseURL}{path}?{query} and
+// decodes the JSON body into out. Non-2xx responses become wrapped errors
+// (handlers map them to 502); the response body is never included verbatim.
+func (c *SCIM2Client) get(ctx context.Context, path string, query url.Values, out interface{}) error {
+	reqURL := c.baseURL + path
+	if len(query) > 0 {
+		reqURL += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("building SCIM request: %w", err)
+	}
+	req.Header.Set("Accept", "application/scim+json, application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling IdP: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// Drain (bounded) so the connection can be reused; don't echo the body.
+		_, _ = io.CopyN(io.Discard, resp.Body, 4096)
+		return fmt.Errorf("IdP returned %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decoding IdP response: %w", err)
+	}
+	return nil
+}
+
+func (c *SCIM2Client) cacheGet(key string) (cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.cache[key]
+	if !ok || time.Now().After(e.expires) {
+		delete(c.cache, key)
+		return cacheEntry{}, false
+	}
+	return e, true
+}
+
+func (c *SCIM2Client) cachePut(key string, e cacheEntry) {
+	e.expires = time.Now().Add(cacheTTL)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.cache) >= cacheMaxEntry {
+		// Bounded size: drop expired entries first; if everything is live,
+		// evict arbitrary entries until under the cap. Simple and good
+		// enough for a 30s-TTL type-ahead cache.
+		now := time.Now()
+		for k, v := range c.cache {
+			if now.After(v.expires) {
+				delete(c.cache, k)
+			}
+		}
+		for k := range c.cache {
+			if len(c.cache) < cacheMaxEntry {
+				break
+			}
+			delete(c.cache, k)
+		}
+	}
+	c.cache[key] = e
+}

--- a/dc-api/internal/directory/scim2_test.go
+++ b/dc-api/internal/directory/scim2_test.go
@@ -1,0 +1,358 @@
+package directory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scimStub records requests and serves canned SCIM list responses keyed by path.
+type scimStub struct {
+	t        *testing.T
+	requests []*url.URL
+	// respond maps "path|filter" → response body. Empty filter key matches
+	// requests without a filter parameter.
+	respond map[string]string
+	status  int
+}
+
+func (s *scimStub) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.requests = append(s.requests, r.URL)
+		if s.status != 0 && s.status != http.StatusOK {
+			w.WriteHeader(s.status)
+			return
+		}
+		key := r.URL.Path + "|" + r.URL.Query().Get("filter")
+		body, ok := s.respond[key]
+		if !ok {
+			s.t.Fatalf("unexpected SCIM request: %s", r.URL)
+		}
+		w.Header().Set("Content-Type", "application/scim+json")
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func newTestClient(t *testing.T, stub *scimStub) (*SCIM2Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(stub.handler())
+	t.Cleanup(srv.Close)
+	return NewSCIM2Client(srv.URL, "", "", "", "", "", srv.Client()), srv
+}
+
+// listBody splices pre-marshalled JSON resource objects into a SCIM list response.
+func listBody(total int, resources ...string) string {
+	raw := "[" + strings.Join(resources, ",") + "]"
+	return fmt.Sprintf(`{"totalResults":%d,"Resources":%s}`, total, raw)
+}
+
+const aliceJSON = `{
+	"id": "sub-alice-1",
+	"userName": "alice@example.com",
+	"name": {"formatted": "Alice Perera", "givenName": "Alice", "familyName": "Perera"},
+	"emails": [{"value": "alice@example.com", "primary": true}]
+}`
+
+func TestLookupUserByEmail_FoundViaUserName(t *testing.T) {
+	stub := &scimStub{t: t, respond: map[string]string{
+		`/Users|userName eq "alice@example.com"`: listBody(1, aliceJSON),
+	}}
+	c, _ := newTestClient(t, stub)
+
+	u, err := c.LookupUserByEmail(context.Background(), "alice@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "sub-alice-1", u.Sub)
+	assert.Equal(t, "alice@example.com", u.Email)
+	assert.Equal(t, "Alice Perera", u.DisplayName)
+	require.Len(t, stub.requests, 1)
+}
+
+func TestLookupUserByEmail_FallsBackToEmailsFilter(t *testing.T) {
+	// userName lookup misses (userName is not the email); emails filter hits.
+	bob := `{"id":"sub-bob","userName":"bob.k","emails":["bob@example.com"]}`
+	stub := &scimStub{t: t, respond: map[string]string{
+		`/Users|userName eq "bob@example.com"`: listBody(0),
+		`/Users|emails eq "bob@example.com"`:   listBody(1, bob),
+	}}
+	c, _ := newTestClient(t, stub)
+
+	u, err := c.LookupUserByEmail(context.Background(), "bob@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "sub-bob", u.Sub)
+	assert.Equal(t, "bob@example.com", u.Email) // string-encoded email decoded
+	assert.Equal(t, "bob.k", u.DisplayName)     // no name → userName fallback
+	require.Len(t, stub.requests, 2)
+}
+
+func TestLookupUserByEmail_NotFound(t *testing.T) {
+	stub := &scimStub{t: t, respond: map[string]string{
+		`/Users|userName eq "ghost@example.com"`: listBody(0),
+		`/Users|emails eq "ghost@example.com"`:   listBody(0),
+	}}
+	c, _ := newTestClient(t, stub)
+
+	_, err := c.LookupUserByEmail(context.Background(), "ghost@example.com")
+	assert.ErrorIs(t, err, ErrUserNotFound)
+}
+
+func TestLookupUserByEmail_Ambiguous(t *testing.T) {
+	stub := &scimStub{t: t, respond: map[string]string{
+		`/Users|userName eq "dup@example.com"`: listBody(2, aliceJSON, aliceJSON),
+	}}
+	c, _ := newTestClient(t, stub)
+
+	_, err := c.LookupUserByEmail(context.Background(), "dup@example.com")
+	assert.ErrorIs(t, err, ErrAmbiguous)
+}
+
+func TestLookupUserByEmail_RejectsFilterInjection(t *testing.T) {
+	c := NewSCIM2Client("http://unused", "", "", "", "", "", &http.Client{})
+	for _, bad := range []string{`a" or id pr or userName eq "`, "a\\b@x.com", "a\nb@x.com"} {
+		_, err := c.LookupUserByEmail(context.Background(), bad)
+		assert.ErrorIs(t, err, ErrBadFilter, "input %q", bad)
+	}
+}
+
+func TestSearchUsers_PagingFilterAndCache(t *testing.T) {
+	filter := `userName co "ali" or name.formatted co "ali" or emails co "ali"`
+	stub := &scimStub{t: t, respond: map[string]string{
+		"/Users|" + filter: listBody(137, aliceJSON),
+	}}
+	c, _ := newTestClient(t, stub)
+
+	users, total, err := c.SearchUsers(context.Background(), "ali", 50, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 137, total)
+	require.Len(t, users, 1)
+	assert.Equal(t, "sub-alice-1", users[0].Sub)
+
+	// SCIM paging: startIndex = offset+1, count = limit.
+	require.Len(t, stub.requests, 1)
+	q := stub.requests[0].Query()
+	assert.Equal(t, "101", q.Get("startIndex"))
+	assert.Equal(t, "50", q.Get("count"))
+
+	// Second identical call is served from cache — no new request.
+	_, total2, err := c.SearchUsers(context.Background(), "ali", 50, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 137, total2)
+	assert.Len(t, stub.requests, 1, "second call must hit the cache")
+}
+
+func TestSearchUsers_EmptyFilterListsAll(t *testing.T) {
+	stub := &scimStub{t: t, respond: map[string]string{
+		"/Users|": listBody(1, aliceJSON),
+	}}
+	c, _ := newTestClient(t, stub)
+
+	_, _, err := c.SearchUsers(context.Background(), "", 50, 0)
+	require.NoError(t, err)
+	require.Len(t, stub.requests, 1)
+	_, hasFilter := stub.requests[0].Query()["filter"]
+	assert.False(t, hasFilter, "empty filter must omit the filter parameter")
+}
+
+func TestListGroups_MapsAndExcludesMembers(t *testing.T) {
+	stub := &scimStub{t: t, respond: map[string]string{
+		"/Groups|": `{"totalResults":12,"Resources":[{"id":"grp-1","displayName":"platform-engineering","members":[{"value":"should-not-be-read"}]}]}`,
+	}}
+	c, _ := newTestClient(t, stub)
+
+	groups, total, err := c.ListGroups(context.Background(), 50, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 12, total)
+	require.Len(t, groups, 1)
+	assert.Equal(t, Group{ID: "grp-1", Name: "platform-engineering"}, groups[0])
+
+	q := stub.requests[0].Query()
+	assert.Equal(t, "members", q.Get("excludedAttributes"))
+	assert.Equal(t, "1", q.Get("startIndex"))
+	assert.Equal(t, "50", q.Get("count"))
+}
+
+func TestUpstreamErrorIsWrappedNotSentinel(t *testing.T) {
+	stub := &scimStub{t: t, status: http.StatusServiceUnavailable, respond: map[string]string{}}
+	c, _ := newTestClient(t, stub)
+
+	_, _, err := c.SearchUsers(context.Background(), "x", 10, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IdP returned 503")
+	assert.False(t, errors.Is(err, ErrUserNotFound))
+	assert.False(t, errors.Is(err, ErrBadFilter))
+}
+
+func TestParseScopes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   \t ", nil},
+		{"commas only", " , , ", nil},
+		{"single", "internal_user_mgt_view", []string{"internal_user_mgt_view"}},
+		{
+			"space separated",
+			"internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view",
+			[]string{"internal_user_mgt_list", "internal_user_mgt_view", "internal_group_mgt_view"},
+		},
+		{
+			"comma separated",
+			"internal_user_mgt_list,internal_user_mgt_view,internal_group_mgt_view",
+			[]string{"internal_user_mgt_list", "internal_user_mgt_view", "internal_group_mgt_view"},
+		},
+		{
+			"mixed separators and padding",
+			" internal_user_mgt_list, internal_user_mgt_view  internal_group_mgt_view , ",
+			[]string{"internal_user_mgt_list", "internal_user_mgt_view", "internal_group_mgt_view"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseScopes(tc.in))
+		})
+	}
+}
+
+// tokenEndpoint is an httptest server that captures the OAuth2 token request's
+// form values and answers with a canned client_credentials token. It lets the
+// test assert exactly what scopes (if any) the SCIM client requested.
+func tokenEndpoint(t *testing.T, captured *url.Values) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		*captured = r.Form
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestTokenRequestCarriesConfiguredScopes(t *testing.T) {
+	var form url.Values
+	tokenSrv := tokenEndpoint(t, &form)
+
+	// SCIM endpoint returns an empty list; we only care that a token was fetched.
+	scimStub := &scimStub{t: t, respond: map[string]string{"/Users|": listBody(0)}}
+	scimSrv := httptest.NewServer(scimStub.handler())
+	t.Cleanup(scimSrv.Close)
+
+	scopes := "internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view"
+	// httpOverride nil → real OAuth2 client_credentials exchange against tokenSrv.
+	c := NewSCIM2Client(scimSrv.URL, tokenSrv.URL, "cid", "secret", scopes, "", nil)
+
+	_, _, err := c.SearchUsers(context.Background(), "", 10, 0)
+	require.NoError(t, err)
+
+	// The OAuth2 wire format space-joins scopes into a single "scope" field.
+	assert.Equal(t,
+		"internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view",
+		form.Get("scope"))
+	assert.Equal(t, "client_credentials", form.Get("grant_type"))
+}
+
+func TestTokenRequestOmitsScopesWhenUnconfigured(t *testing.T) {
+	var form url.Values
+	tokenSrv := tokenEndpoint(t, &form)
+
+	scimStub := &scimStub{t: t, respond: map[string]string{"/Users|": listBody(0)}}
+	scimSrv := httptest.NewServer(scimStub.handler())
+	t.Cleanup(scimSrv.Close)
+
+	c := NewSCIM2Client(scimSrv.URL, tokenSrv.URL, "cid", "secret", "", "", nil)
+
+	_, _, err := c.SearchUsers(context.Background(), "", 10, 0)
+	require.NoError(t, err)
+
+	// No scopes configured → no scope parameter on the token request.
+	_, present := form["scope"]
+	assert.False(t, present, "token request must omit scope when none configured")
+}
+
+func TestToUser_StripsUserstoreDomain(t *testing.T) {
+	cases := []struct {
+		name        string
+		user        scimUser
+		wantEmail   string
+		wantDisplay string
+	}{
+		{
+			name:        "DEFAULT-store user with no name attributes",
+			user:        scimUser{ID: "u1", UserName: "DEFAULT/alice@example.com"},
+			wantEmail:   "alice@example.com",
+			wantDisplay: "alice@example.com",
+		},
+		{
+			name:        "primary-store user passes through unchanged",
+			user:        scimUser{ID: "u2", UserName: "bob@example.com"},
+			wantEmail:   "bob@example.com",
+			wantDisplay: "bob@example.com",
+		},
+		{
+			name: "name attributes still win over the stripped userName",
+			user: func() scimUser {
+				u := scimUser{ID: "u3", UserName: "DEFAULT/carol@example.com"}
+				u.Name.GivenName = "Carol"
+				u.Name.FamilyName = "Day"
+				return u
+			}(),
+			wantEmail:   "carol@example.com",
+			wantDisplay: "Carol Day",
+		},
+		{
+			name:        "slash inside an address segment is not a store prefix",
+			user:        scimUser{ID: "u4", UserName: "weird@example.com/extra"},
+			wantEmail:   "weird@example.com/extra",
+			wantDisplay: "weird@example.com/extra",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.user.toUser()
+			assert.Equal(t, tc.wantEmail, got.Email)
+			assert.Equal(t, tc.wantDisplay, got.DisplayName)
+		})
+	}
+}
+
+func TestUserstoreDomainParameter(t *testing.T) {
+	stub := &scimStub{t: t, respond: map[string]string{
+		"/Users|":                                listBody(1, aliceJSON),
+		`/Users|userName eq "alice@example.com"`: listBody(1, aliceJSON),
+		"/Groups|":                               `{"totalResults":0,"Resources":[]}`,
+	}}
+	srv := httptest.NewServer(stub.handler())
+	t.Cleanup(srv.Close)
+	c := NewSCIM2Client(srv.URL, "", "", "", "", "DEFAULT", srv.Client())
+
+	_, _, err := c.SearchUsers(context.Background(), "", 10, 0)
+	require.NoError(t, err)
+	_, err = c.LookupUserByEmail(context.Background(), "alice@example.com")
+	require.NoError(t, err)
+	_, _, err = c.ListGroups(context.Background(), 10, 0)
+	require.NoError(t, err)
+
+	require.Len(t, stub.requests, 3)
+	for _, r := range stub.requests {
+		assert.Equal(t, "DEFAULT", r.Query().Get("domain"),
+			"request %s must carry the userstore domain", r)
+	}
+
+	// Empty domain → the parameter is omitted entirely.
+	stub2 := &scimStub{t: t, respond: map[string]string{"/Users|": listBody(0)}}
+	c2, _ := newTestClient(t, stub2)
+	_, _, err = c2.SearchUsers(context.Background(), "", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, stub2.requests, 1)
+	_, has := stub2.requests[0].Query()["domain"]
+	assert.False(t, has, "empty domain must omit the parameter")
+}

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -66,6 +66,18 @@ tags:
     description: RKE2 Kubernetes clusters (async provisioning via Rancher)
   - name: roleAssignments
     description: Role assignments — granting catalog roles to principals at tenant or project scope
+  - name: directory
+    description: |
+      Read-only lookups against the deployment's IdP directory via an optional
+      SCIM2 provider. The directory is organization-global (scoped server-side
+      to the deployment's configured userstore, so console administrator
+      accounts are not listed); the endpoints are
+      tenant-scoped only so RBAC
+      gating can evaluate the caller's actions at a scope. dc-api proxies every
+      read live to the IdP and persists nothing — at most the OIDC `sub` is
+      stored, on the role assignment an invite subsequently creates. When no
+      directory provider is configured the feature is dark and these endpoints
+      return `501`.
   - name: service-accounts
     description: Service account lifecycle and token management
   - name: networking-vnets
@@ -745,8 +757,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/InviteEmailUnprocessable"
         "500":
           $ref: "#/components/responses/InternalError"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
 
     get:
       operationId: listVMRoleAssignments
@@ -1218,8 +1234,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/InviteEmailUnprocessable"
         "500":
           $ref: "#/components/responses/InternalError"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
 
     get:
       operationId: listClusterRoleAssignments
@@ -1660,10 +1680,12 @@ paths:
       summary: Grant a role to a principal at tenant scope
       description: |
         Creates a `role_assignments` row binding the user (identified by
-        their OIDC `sub`) to the tenant scope. Returns 409 if the user
-        already holds that role. Also UPSERTs a `tenants` registry row
-        for the tenant as a side effect, so the tenant is discoverable
-        by admins via `GET /v1/tenants` without a separate registration.
+        their OIDC `sub`, or by a `user_email` resolved to a `sub` through
+        the optional directory provider) to the tenant scope. Returns 409
+        if the user already holds that role. Also UPSERTs a `tenants`
+        registry row for the tenant as a side effect, so the tenant is
+        discoverable by admins via `GET /v1/tenants` without a separate
+        registration.
 
         The URL `{tenant_id}` must match the caller's own tenant context
         (Option D: derived from a `role_assignments` row, not from any
@@ -1676,10 +1698,18 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CreateRoleAssignmentRequest"
-            example:
-              user_sub: 01abc123-0000-0000-0000-user000000001
-              role_definition: Contributor
-              display_alias: alice-laptop
+            examples:
+              invite_by_sub:
+                summary: Grant by OIDC sub (works on every deployment)
+                value:
+                  user_sub: 01abc123-0000-0000-0000-user000000001
+                  role_definition: Contributor
+                  display_alias: alice-laptop
+              invite_by_email:
+                summary: Grant by email (requires the directory provider; alias defaults to the IdP display name, then the email)
+                value:
+                  user_email: alice@example.com
+                  role_definition: Contributor
       responses:
         "201":
           description: Role assignment created
@@ -1697,8 +1727,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/InviteEmailUnprocessable"
         "500":
           $ref: "#/components/responses/InternalError"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
 
     get:
       operationId: listTenantRoleAssignments
@@ -1773,6 +1807,168 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  # ── Directory (optional SCIM2 read-only proxy) ─────────────────────────────
+
+  /v1/tenants/{tenant_id}/directory/users:
+    parameters:
+      - $ref: "#/components/parameters/TenantID"
+
+    get:
+      operationId: listDirectoryUsers
+      tags: [directory]
+      summary: Search the IdP directory for users
+      description: |
+        Proxies a live, read-only SCIM2 search against the deployment's
+        identity provider and returns minimal user records — `sub`, `email`,
+        and `display_name`, just enough for an invite picker. Nothing else
+        from the SCIM response is exposed and nothing is persisted:
+        dc-api stores only the `sub`, and only on the
+        role assignment an invite subsequently creates.
+
+        The path is tenant-scoped because RBAC gating evaluates actions at a
+        scope, but the directory itself is organization-global: every tenant
+        queries the same directory.
+
+        The URL `{tenant_id}` must match the caller's own tenant context
+        (derived from a `role_assignments` row, not from any IdP
+        group); a mismatch returns 404 so other tenants' identifiers are not
+        enumerable. Platform admins may operate on any tenant.
+
+        Clients may probe this endpoint for feature detection: `501` means
+        no directory provider is configured on this deployment (hide email
+        type-ahead and invite-by-email affordances); `502` means a provider
+        is configured but the live IdP request failed (show an error and
+        offer retry).
+
+        **Required action**: `authorization/roleAssignments/write` — the
+        directory is visible only to principals who can perform invitations
+        (e.g. `Owner`, `UserAccessAdministrator`). `Reader` and `Contributor`
+        get 403.
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          description: |
+            Optional case-insensitive substring matched against the user's
+            email/username and display name (mapped to SCIM2 `co` filters
+            underneath). Empty or omitted lists all users (paginated).
+          schema:
+            type: string
+            maxLength: 256
+            example: alice
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of users to return per page (SCIM2 `count` underneath).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+            example: 50
+        - name: offset
+          in: query
+          required: false
+          description: Number of users to skip (SCIM2 `startIndex = offset + 1` underneath).
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+            example: 0
+      responses:
+        "200":
+          description: One page of matching directory users.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DirectoryUserList"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/DirectoryNotConfigured"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
+
+  /v1/tenants/{tenant_id}/directory/groups:
+    parameters:
+      - $ref: "#/components/parameters/TenantID"
+
+    get:
+      operationId: listDirectoryGroups
+      tags: [directory]
+      summary: List the IdP directory's groups
+      description: |
+        Proxies a live, read-only SCIM2 listing of the identity provider's
+        groups and returns minimal records — `id` and `name` only. Nothing
+        else from the SCIM response is exposed and nothing is persisted.
+
+        The path is tenant-scoped because RBAC gating evaluates actions at a
+        scope, but the directory itself is organization-global: every tenant
+        queries the same directory.
+
+        The URL `{tenant_id}` must match the caller's own tenant context
+        (derived from a `role_assignments` row, not from any IdP
+        group); a mismatch returns 404 so other tenants' identifiers are not
+        enumerable. Platform admins may operate on any tenant.
+
+        `501` means no directory provider is configured on this deployment
+        (the feature is dark); `502` means a provider is configured but the
+        live IdP request failed.
+
+        **Required action**: `authorization/roleAssignments/write` — the
+        directory is visible only to principals who can perform invitations
+        (e.g. `Owner`, `UserAccessAdministrator`). `Reader` and `Contributor`
+        get 403.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of groups to return per page (SCIM2 `count` underneath).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+            example: 50
+        - name: offset
+          in: query
+          required: false
+          description: Number of groups to skip (SCIM2 `startIndex = offset + 1` underneath).
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+            example: 0
+      responses:
+        "200":
+          description: One page of directory groups.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DirectoryGroupList"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/DirectoryNotConfigured"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
+
   /v1/tenants/{tenant_id}/projects/{project_id}/permissions:check:
     parameters:
       - $ref: "#/components/parameters/TenantID"
@@ -1827,8 +2023,9 @@ paths:
       summary: Grant a role to a principal at project scope
       description: |
         Creates a `role_assignments` row binding the user (identified by
-        their OIDC `sub`) to the project scope. Returns 409 if the user
-        already holds that role at the project.
+        their OIDC `sub`, or by a `user_email` resolved to a `sub` through
+        the optional directory provider) to the project scope. Returns 409
+        if the user already holds that role at the project.
 
         The URL `{tenant_id}` must match the caller's own tenant context
         (Option D: derived from a `role_assignments` row, not from any
@@ -1842,10 +2039,18 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CreateRoleAssignmentRequest"
-            example:
-              user_sub: 01abc123-0000-0000-0000-user000000001
-              role_definition: VirtualMachineContributor
-              display_alias: alice-laptop
+            examples:
+              invite_by_sub:
+                summary: Grant by OIDC sub (works on every deployment)
+                value:
+                  user_sub: 01abc123-0000-0000-0000-user000000001
+                  role_definition: VirtualMachineContributor
+                  display_alias: alice-laptop
+              invite_by_email:
+                summary: Grant by email (requires the directory provider; alias defaults to the IdP display name, then the email)
+                value:
+                  user_email: alice@example.com
+                  role_definition: VirtualMachineContributor
       responses:
         "201":
           description: Role assignment created
@@ -1863,8 +2068,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/InviteEmailUnprocessable"
         "500":
           $ref: "#/components/responses/InternalError"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
 
     get:
       operationId: listProjectRoleAssignments
@@ -3839,8 +4048,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/InviteEmailUnprocessable"
         "500":
           $ref: "#/components/responses/InternalError"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
 
     get:
       operationId: listKeyVaultRoleAssignments
@@ -5084,8 +5297,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/InviteEmailUnprocessable"
         "500":
           $ref: "#/components/responses/InternalError"
+        "502":
+          $ref: "#/components/responses/DirectoryUpstreamError"
 
     get:
       operationId: listDatabaseRoleAssignments
@@ -5361,6 +5578,55 @@ components:
             $ref: "#/components/schemas/Error"
           example:
             error: "OpenBao backend is sealed; retry in a few seconds"
+
+    DirectoryNotConfigured:
+      description: |
+        No directory provider is configured on this deployment — the optional
+        SCIM2 directory feature is dark. This status is the feature-detection
+        signal: clients that receive it should hide email type-ahead and
+        invite-by-email affordances entirely (it will not change until the
+        operator reconfigures dc-api).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "no directory provider is configured on this deployment"
+
+    DirectoryUpstreamError:
+      description: |
+        A directory provider is configured, but the live SCIM2 request to the
+        IdP failed (connection error, timeout, or a non-2xx upstream
+        response). Unlike `501`, this is transient — the caller may retry.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "directory upstream request failed; try again or invite by user_sub"
+
+    InviteEmailUnprocessable:
+      description: |
+        The `user_email` invite could not be resolved to an OIDC `sub`.
+        Returned when the email matches no IdP user, matches more than one,
+        or when `user_email` was supplied on a deployment with no directory
+        provider configured (probe `GET .../directory/users` — `501` there
+        means invite-by-email is unavailable here). Resubmitting the same
+        grant with `user_sub` always works.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            email_not_found:
+              value:
+                error: "user_email 'alice@example.com' does not match any IdP user"
+            email_ambiguous:
+              value:
+                error: "user_email 'alice@example.com' matches more than one IdP user; invite by user_sub instead"
+            no_directory_provider:
+              value:
+                error: "invite by user_email requires a directory provider, and none is configured on this deployment; invite by user_sub instead"
 
   schemas:
 
@@ -6220,8 +6486,14 @@ components:
           type: string
           description: |
             Admin-set mnemonic shown by cloud-ui instead of the opaque
-            `principal_id`. Optional. No PII is sourced from the IdP —
-            purely what the inviter typed when they added the principal.
+            `principal_id`. Optional. No PII is **stored** from the IdP:
+            email-based invites consult the directory provider live to
+            resolve `user_email` → `sub`, but the only IdP-derived values
+            persisted are the `sub` itself and — when the inviter supplies
+            no alias — the resolved IdP display name (falling back to the
+            invite email when the directory has no display name) copied once
+            into this field as its default. Otherwise it is purely what the
+            inviter typed when they added the principal.
           example: alice-laptop
 
     PermissionsCheckRequest:
@@ -6303,12 +6575,39 @@ components:
 
     CreateRoleAssignmentRequest:
       type: object
-      required: [user_sub, role_definition]
+      required: [role_definition]
+      description: |
+        Grant request shared by every role-assignment scope (tenant, project,
+        and per-resource). The principal is identified by **exactly one** of
+        `user_sub` or `user_email`; supplying both, or neither, returns 400.
       properties:
         user_sub:
           type: string
-          description: OIDC `sub` of the user to grant the role to
+          description: |
+            OIDC `sub` of the user to grant the role to. Mutually exclusive
+            with `user_email` — exactly one of the two is required. Granting
+            by `user_sub` works on every deployment and never contacts the
+            IdP.
           example: 01abc123-0000-0000-0000-user000000001
+        user_email:
+          type: string
+          format: email
+          description: |
+            Email address of the user to grant the role to. Mutually
+            exclusive with `user_sub` — exactly one of the two is required.
+            dc-api resolves the email to an OIDC `sub` via a live SCIM2
+            point lookup against the deployment's directory provider at
+            request time, stores only the resolved `sub`, and uses the
+            resolved IdP display name (falling back to the email when the
+            directory has no display name) as the default `display_alias`
+            when none is supplied. Nothing else from the lookup is persisted.
+
+            Returns 422 when the email does not resolve to exactly one IdP
+            user (no match or ambiguous), and 422 when no directory provider
+            is configured on this deployment (probe
+            `GET /v1/tenants/{tenant_id}/directory/users` — `501` there
+            means invite-by-email is unavailable).
+          example: alice@example.com
         role_definition:
           type: string
           description: |
@@ -6321,10 +6620,84 @@ components:
           description: |
             Optional mnemonic the granter sets so cloud-ui can show a
             readable name in the role-assignment list instead of the opaque
-            `user_sub`. Not propagated to the IdP and never matched
-            against any IdP attribute — purely admin bookkeeping.
-            Stored verbatim, max 256 chars by convention.
+            `user_sub`. Defaults to the resolved IdP display name (falling
+            back to the invite email when the directory has no display name)
+            when the grant uses `user_email` and no alias is supplied;
+            otherwise purely what the inviter typed. Never propagated to the
+            IdP, and nothing beyond that one-time invite-time default is ever
+            stored. Stored verbatim, max 256 chars by convention.
           example: alice-laptop
+
+    # ── Directory (optional SCIM2 read-only proxy) ─────────────────────────────
+
+    DirectoryUser:
+      type: object
+      required: [sub, email]
+      description: |
+        Minimal user record proxied live from the IdP's SCIM2 Users resource.
+        These three fields are the entire exposure — nothing else from the
+        SCIM response (groups, phone numbers, addresses, raw attributes) is
+        ever surfaced, and dc-api persists none of it.
+      properties:
+        sub:
+          type: string
+          description: OIDC `sub` — the value to use as `user_sub` when granting a role.
+          example: 01abc123-0000-0000-0000-user000000001
+        email:
+          type: string
+          format: email
+          example: alice@example.com
+        display_name:
+          type: string
+          description: Human-readable name from the IdP, when one is set.
+          example: Alice Perera
+
+    DirectoryGroup:
+      type: object
+      required: [id, name]
+      description: |
+        Minimal group record proxied live from the IdP's SCIM2 Groups
+        resource. These two fields are the entire exposure; membership and
+        all other SCIM attributes stay in the IdP, and dc-api persists
+        nothing.
+      properties:
+        id:
+          type: string
+          description: SCIM2 group identifier in the IdP.
+          example: 7f3a1c2e-0000-0000-0000-grp000000001
+        name:
+          type: string
+          example: platform-engineering
+
+    DirectoryUserList:
+      type: object
+      required: [users, total_results]
+      properties:
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectoryUser"
+        total_results:
+          type: integer
+          description: |
+            Total number of users matching the filter across all pages
+            (SCIM2 `totalResults`), not the size of this page.
+          example: 137
+
+    DirectoryGroupList:
+      type: object
+      required: [groups, total_results]
+      properties:
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectoryGroup"
+        total_results:
+          type: integer
+          description: |
+            Total number of groups across all pages (SCIM2 `totalResults`),
+            not the size of this page.
+          example: 12
 
     # ── Service Accounts ───────────────────────────────────────────────────────
 

--- a/dc-api/test/contract/contract_test.go
+++ b/dc-api/test/contract/contract_test.go
@@ -97,7 +97,11 @@ func TestSpec_Conformance(t *testing.T) {
 	composite := middleware.NewCompositeAuth(saAuth, testAuth)
 
 	// 3. Router with all providers nopped out — schemathesis only validates
-	// response *shapes*, not real provisioning.
+	// response *shapes*, not real provisioning. DirectoryProvider is
+	// intentionally nil (feature dark): the /directory endpoints then answer
+	// the documented 501 and invite-by-email the documented 422, both
+	// deterministic — exactly what the spec's DirectoryNotConfigured /
+	// InviteEmailUnprocessable responses describe.
 	router := api.NewRouter(api.RouterDeps{
 		Repo:            repo,
 		ComputeProvider: nopCompute{},
@@ -130,11 +134,18 @@ func TestSpec_Conformance(t *testing.T) {
 	// 6. Run schemathesis. We keep the operation set tight on purpose:
 	//   - health: anonymous /healthz
 	//   - keyvaults, projects: pure DB CRUD
-	//   - members, service-accounts, tenants: pure DB + RBAC
+	//   - roleAssignments, service-accounts, tenants: pure DB + RBAC
+	//     (roleAssignments is the RBAC-v2 name of the old `members` tag —
+	//     the regex previously said `members`, which no longer matches any
+	//     operation, so these endpoints had silently dropped out of coverage)
+	//   - directory: works backend-free BY DESIGN — with a nil
+	//     DirectoryProvider the endpoints return the documented 501
+	//     feature-detection response, and the RBAC gate / tenant guard cover
+	//     the 403/404 shapes
 	// Networking, VMs, clusters, bastions, images need real backends and
 	// are out of scope. --include-tag matches a single tag value, so we use
 	// the regex variant to express the allowlist.
-	tagRegex := `^(health|keyvaults|members|projects|service-accounts|tenants)$`
+	tagRegex := `^(health|directory|keyvaults|roleAssignments|projects|service-accounts|tenants)$`
 	checks := strings.Join([]string{
 		"not_a_server_error",
 		"status_code_conformance",

--- a/dc-api/test/integration/directory_invite_test.go
+++ b/dc-api/test/integration/directory_invite_test.go
@@ -1,0 +1,474 @@
+//go:build integration
+
+// directory_invite_test.go — IdP directory feature integration tests.
+//
+// Covers the two surfaces the directory feature added:
+//
+//  1. POST /v1/tenants/{tenant_id}/role-assignments with `user_email` —
+//     resolution through the directory provider (nil provider → 422,
+//     not-found/ambiguous → 422, upstream failure → 502, success → 201 with
+//     PrincipalID = resolved sub and display_alias defaulting to the email).
+//  2. GET /v1/tenants/{tenant_id}/directory/{users,groups} through the FULL
+//     middleware stack — TenantContext + the roleAssignments/write gate (a
+//     write action on GETs is intentional: only inviters may browse the
+//     directory). The handler-internal branches (paging/filter validation,
+//     response shapes) are unit-tested in internal/api/handlers/directory_test.go.
+//
+// These paths are unit-untestable at the handler layer because
+// RoleAssignmentsHandler holds the concrete *db.Repository and the RBAC gate
+// queries it before any directory code runs. None of them touch
+// Harvester/KubeOVN, so the suite is fully exercisable in cluster-free mode:
+//
+//	DCAPI_TEST_NOP=1 go test -tags integration -run 'EmailInvite|DirectoryEndpoints' ./test/integration/...
+//
+// The directory provider is a per-test fake wired into a dedicated sub-env
+// router (directorySubEnv) — no live IdP is involved.
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"github.com/wso2/dc-api/internal/api"
+	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/directory"
+	"github.com/wso2/dc-api/internal/models"
+)
+
+// ── Fake directory provider ───────────────────────────────────────────────────
+
+// fakeDirectoryProvider is a deterministic directory.Provider double. Function
+// fields stub behaviour; counters record invocations (mutex-guarded — the
+// httptest server handles requests on its own goroutines).
+type fakeDirectoryProvider struct {
+	mu          sync.Mutex
+	lookupFn    func(ctx context.Context, email string) (*directory.User, error)
+	searchFn    func(ctx context.Context, filter string, limit, offset int) ([]directory.User, int, error)
+	groupsFn    func(ctx context.Context, limit, offset int) ([]directory.Group, int, error)
+	lookupCalls int
+	lastEmail   string
+}
+
+func (f *fakeDirectoryProvider) LookupUserByEmail(ctx context.Context, email string) (*directory.User, error) {
+	f.mu.Lock()
+	f.lookupCalls++
+	f.lastEmail = email
+	fn := f.lookupFn
+	f.mu.Unlock()
+	if fn == nil {
+		return nil, fmt.Errorf("fakeDirectoryProvider: LookupUserByEmail not stubbed")
+	}
+	return fn(ctx, email)
+}
+
+func (f *fakeDirectoryProvider) SearchUsers(ctx context.Context, filter string, limit, offset int) ([]directory.User, int, error) {
+	f.mu.Lock()
+	fn := f.searchFn
+	f.mu.Unlock()
+	if fn == nil {
+		return nil, 0, fmt.Errorf("fakeDirectoryProvider: SearchUsers not stubbed")
+	}
+	return fn(ctx, filter, limit, offset)
+}
+
+func (f *fakeDirectoryProvider) ListGroups(ctx context.Context, limit, offset int) ([]directory.Group, int, error) {
+	f.mu.Lock()
+	fn := f.groupsFn
+	f.mu.Unlock()
+	if fn == nil {
+		return nil, 0, fmt.Errorf("fakeDirectoryProvider: ListGroups not stubbed")
+	}
+	return fn(ctx, limit, offset)
+}
+
+func (f *fakeDirectoryProvider) stats() (calls int, lastEmail string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lookupCalls, f.lastEmail
+}
+
+var _ directory.Provider = (*fakeDirectoryProvider)(nil)
+
+// ── Sub-env with a directory provider ─────────────────────────────────────────
+
+// directorySubEnv builds a fresh httptest.Server over the shared env's repo +
+// JWT minter with all-nop compute/cluster/network backends and the given
+// directory provider (nil = feature dark). AutoProvisionMembers=false so tests
+// control role rows exactly (mirrors rbacSubEnv). Works identically in live
+// and DCAPI_TEST_NOP=1 modes — nothing here touches the cluster.
+func directorySubEnv(t *testing.T, dir directory.Provider) *TestEnv {
+	t.Helper()
+	testAuth, err := middleware.NewTestModeAuth(env.JWT.PublicKeyJWKS(), middleware.AuthConfig{
+		TenantGroupPrefix:    "dc-tenant-",
+		AdminGroup:           "dc-admin",
+		AutoProvisionMembers: false,
+	}, env.DB)
+	require.NoError(t, err, "directorySubEnv: create test auth")
+
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}).With().Timestamp().Logger()
+	saAuth := middleware.NewServiceAccountAuth(env.DB, logger)
+	composite := middleware.NewCompositeAuth(saAuth, testAuth)
+
+	router := api.NewRouter(api.RouterDeps{
+		Repo:              env.DB,
+		ComputeProvider:   &nopComputeProvider{},
+		ClusterProvider:   &nopClusterProvider{},
+		NetworkProvider:   nopNetwork{},
+		DirectoryProvider: dir,
+		AuthMiddleware:    composite,
+		Log:               logger,
+	})
+	srv := httptest.NewServer(router)
+	t.Cleanup(func() { srv.Close() })
+	return &TestEnv{
+		Server:  srv,
+		BaseURL: srv.URL,
+		DB:      env.DB,
+		JWT:     env.JWT,
+	}
+}
+
+// inviteByEmail POSTs a role-assignment grant body with arbitrary fields set,
+// so tests can exercise the user_email / user_sub / display_alias combinations
+// the typed InviteMember helper doesn't cover.
+func inviteByEmail(t *testing.T, c *APIClient, tenantID string, body map[string]string) (MemberResponse, []byte, int) {
+	t.Helper()
+	raw, status, err := c.do(context.Background(), http.MethodPost,
+		fmt.Sprintf("/v1/tenants/%s/role-assignments", tenantID), body)
+	require.NoError(t, err)
+	var resp MemberResponse
+	_ = json.Unmarshal(raw, &resp)
+	return resp, raw, status
+}
+
+// ownerClientForDirectoryEnv seeds an Owner role for a fresh tenant on the
+// given sub-env and returns the tenant ID plus an authenticated client.
+func ownerClientForDirectoryEnv(t *testing.T, subEnv *TestEnv, label string) (tenantID string, c *APIClient) {
+	t.Helper()
+	tenantID = randomTenantID(label)
+	ownerSub := "sub-owner-" + randomName("dir")
+	insertRole(t, subEnv, ownerSub, tenantID, models.RoleOwner)
+	token := mintTokenForSubEnv(t, subEnv, ownerSub, tenantID)
+	return tenantID, NewAPIClient(subEnv.BaseURL, token)
+}
+
+// ── Email invite: POST /role-assignments with user_email ─────────────────────
+
+func TestEmailInvite_NilProvider_Returns422(t *testing.T) {
+	t.Parallel()
+	subEnv := directorySubEnv(t, nil) // feature dark
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-nilprov")
+
+	_, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_email":      "alice@example.com",
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, status,
+		"user_email with no directory provider must 422 per InviteEmailUnprocessable; body=%s", raw)
+	require.Contains(t, ErrorBody(raw), "directory provider",
+		"422 body must explain that no directory provider is configured")
+}
+
+func TestEmailInvite_ResolvedHappyPath_StoresSubAndDefaultsAlias(t *testing.T) {
+	t.Parallel()
+	const resolvedSub = "01abc123-resolved-sub-0001"
+	const email = "alice@example.com"
+	const displayName = "Alice A"
+	fake := &fakeDirectoryProvider{
+		lookupFn: func(_ context.Context, _ string) (*directory.User, error) {
+			return &directory.User{Sub: resolvedSub, Email: email, DisplayName: displayName}, nil
+		},
+	}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-happy")
+
+	created, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_email":      email,
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusCreated, status, "resolved email invite must 201; body=%s", raw)
+	require.Equal(t, resolvedSub, created.PrincipalID,
+		"principal_id must be the directory-resolved sub, never the email")
+	require.Equal(t, displayName, created.DisplayAlias,
+		"display_alias must default to the resolved IdP display name when none is supplied")
+	require.Equal(t, "Contributor", created.RoleDefinition)
+
+	calls, lastEmail := fake.stats()
+	require.Equal(t, 1, calls, "exactly one directory lookup per invite")
+	require.Equal(t, email, lastEmail, "the request's user_email must be passed to the provider verbatim")
+
+	// The persisted row (via LIST) must carry the sub + alias, proving that
+	// only the resolved sub plus the display-name
+	// default survives.
+	listResp, listStatus, err := client.ListMembers(context.Background(), tenantID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, listStatus)
+	var found *MemberResponse
+	for i := range listResp.Members {
+		if listResp.Members[i].PrincipalID == resolvedSub {
+			found = &listResp.Members[i]
+		}
+	}
+	require.NotNil(t, found, "invited principal must appear in the role-assignment list")
+	require.Equal(t, displayName, found.DisplayAlias)
+}
+
+// TestEmailInvite_NoDisplayName_DefaultsAliasToEmail pins the fallback half of
+// the display-name-with-email-fallback default: when the resolved IdP user has
+// no display name, the alias falls back to the invited email.
+func TestEmailInvite_NoDisplayName_DefaultsAliasToEmail(t *testing.T) {
+	t.Parallel()
+	const resolvedSub = "01abc123-resolved-sub-0003"
+	const email = "carol@example.com"
+	fake := &fakeDirectoryProvider{
+		lookupFn: func(_ context.Context, _ string) (*directory.User, error) {
+			// No DisplayName set — the IdP has none for this user.
+			return &directory.User{Sub: resolvedSub, Email: email}, nil
+		},
+	}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-nodisplay")
+
+	created, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_email":      email,
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusCreated, status, "resolved email invite must 201; body=%s", raw)
+	require.Equal(t, resolvedSub, created.PrincipalID,
+		"principal_id must be the directory-resolved sub, never the email")
+	require.Equal(t, email, created.DisplayAlias,
+		"display_alias must fall back to the invited email when the IdP has no display name")
+}
+
+func TestEmailInvite_ExplicitAliasNotOverwritten(t *testing.T) {
+	t.Parallel()
+	const resolvedSub = "01abc123-resolved-sub-0002"
+	fake := &fakeDirectoryProvider{
+		lookupFn: func(_ context.Context, email string) (*directory.User, error) {
+			return &directory.User{Sub: resolvedSub, Email: email}, nil
+		},
+	}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-alias")
+
+	created, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_email":      "bob@example.com",
+		"role_definition": "Reader",
+		"display_alias":   "bob-from-finance",
+	})
+	require.Equal(t, http.StatusCreated, status, "body=%s", raw)
+	require.Equal(t, resolvedSub, created.PrincipalID)
+	require.Equal(t, "bob-from-finance", created.DisplayAlias,
+		"a caller-supplied display_alias must win over the email default")
+}
+
+func TestEmailInvite_UserNotFound_Returns422(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectoryProvider{
+		lookupFn: func(_ context.Context, _ string) (*directory.User, error) {
+			return nil, directory.ErrUserNotFound
+		},
+	}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-nouser")
+
+	_, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_email":      "ghost@example.com",
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, status, "body=%s", raw)
+	require.Contains(t, ErrorBody(raw), "does not match any IdP user")
+}
+
+func TestEmailInvite_AmbiguousEmail_Returns422(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectoryProvider{
+		lookupFn: func(_ context.Context, _ string) (*directory.User, error) {
+			return nil, directory.ErrAmbiguous
+		},
+	}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-ambig")
+
+	_, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_email":      "twins@example.com",
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, status, "body=%s", raw)
+	require.Contains(t, ErrorBody(raw), "more than one IdP user")
+}
+
+func TestEmailInvite_UpstreamFailure_Returns502(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectoryProvider{
+		lookupFn: func(_ context.Context, _ string) (*directory.User, error) {
+			return nil, fmt.Errorf("IdP returned 503")
+		},
+	}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-upstream")
+
+	_, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_email":      "alice@example.com",
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusBadGateway, status,
+		"a non-sentinel directory error is an upstream failure → 502; body=%s", raw)
+	require.Contains(t, ErrorBody(raw), "directory lookup failed")
+}
+
+func TestEmailInvite_BothSubAndEmail_Returns400(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectoryProvider{}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-both")
+
+	_, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"user_sub":        "sub-explicit",
+		"user_email":      "alice@example.com",
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusBadRequest, status,
+		"user_sub and user_email are mutually exclusive; body=%s", raw)
+	calls, _ := fake.stats()
+	require.Zero(t, calls, "validation must reject before any directory lookup")
+}
+
+func TestEmailInvite_NeitherSubNorEmail_Returns400(t *testing.T) {
+	t.Parallel()
+	subEnv := directorySubEnv(t, &fakeDirectoryProvider{})
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-neither")
+
+	_, raw, status := inviteByEmail(t, client, tenantID, map[string]string{
+		"role_definition": "Contributor",
+	})
+	require.Equal(t, http.StatusBadRequest, status,
+		"one of user_sub / user_email is required; body=%s", raw)
+}
+
+// TestEmailInvite_UserSubPathUnchanged is the regression guard: a classic
+// user_sub grant must behave exactly as before the directory feature landed —
+// 201, principal_id = the literal sub, no alias default, and zero directory
+// provider involvement.
+func TestEmailInvite_UserSubPathUnchanged(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectoryProvider{}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "inv-subonly")
+
+	inviteeSub := "sub-invitee-" + randomName("u")
+	created, raw, status, err := client.InviteMember(context.Background(), tenantID, inviteeSub, "Contributor")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status, "body=%s", raw)
+	require.Equal(t, inviteeSub, created.PrincipalID)
+	require.Empty(t, created.DisplayAlias,
+		"user_sub invites must not invent a display_alias")
+
+	calls, _ := fake.stats()
+	require.Zero(t, calls, "user_sub invites must never consult the directory")
+}
+
+// ── Directory endpoints through the full middleware stack ────────────────────
+
+func TestDirectoryEndpoints_OwnerGets200(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDirectoryProvider{
+		searchFn: func(_ context.Context, _ string, _, _ int) ([]directory.User, int, error) {
+			return []directory.User{{Sub: "s1", Email: "alice@example.com", DisplayName: "Alice"}}, 1, nil
+		},
+		groupsFn: func(_ context.Context, _, _ int) ([]directory.Group, int, error) {
+			return []directory.Group{{ID: "g1", Name: "platform"}}, 1, nil
+		},
+	}
+	subEnv := directorySubEnv(t, fake)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "dir-owner")
+	ctx := context.Background()
+
+	rawUsers, status, err := client.do(ctx, http.MethodGet,
+		fmt.Sprintf("/v1/tenants/%s/directory/users?filter=ali", tenantID), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status,
+		"Owner holds roleAssignments/write → directory must be visible; body=%s", rawUsers)
+	var users struct {
+		Users        []map[string]any `json:"users"`
+		TotalResults *int             `json:"total_results"`
+	}
+	require.NoError(t, json.Unmarshal(rawUsers, &users))
+	require.Len(t, users.Users, 1)
+	require.NotNil(t, users.TotalResults)
+	require.Equal(t, 1, *users.TotalResults)
+
+	rawGroups, status, err := client.do(ctx, http.MethodGet,
+		fmt.Sprintf("/v1/tenants/%s/directory/groups", tenantID), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status, "body=%s", rawGroups)
+	var groups struct {
+		Groups []map[string]any `json:"groups"`
+	}
+	require.NoError(t, json.Unmarshal(rawGroups, &groups))
+	require.Len(t, groups.Groups, 1)
+}
+
+// TestDirectoryEndpoints_ContributorGets403 pins the intentional product
+// guardrail: the route is gated with authorization/roleAssignments/write even
+// though it's a GET, so Contributor (no write) must NOT see the directory.
+func TestDirectoryEndpoints_ContributorGets403(t *testing.T) {
+	t.Parallel()
+	subEnv := directorySubEnv(t, &fakeDirectoryProvider{})
+
+	tenantID := randomTenantID("dir-contrib")
+	memberSub := "sub-member-" + randomName("dir")
+	insertRole(t, subEnv, memberSub, tenantID, models.RoleMember) // → Contributor
+	client := NewAPIClient(subEnv.BaseURL, mintTokenForSubEnv(t, subEnv, memberSub, tenantID))
+	ctx := context.Background()
+
+	for _, path := range []string{"users", "groups"} {
+		raw, status, err := client.do(ctx, http.MethodGet,
+			fmt.Sprintf("/v1/tenants/%s/directory/%s", tenantID, path), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, status,
+			"Contributor lacks roleAssignments/write → directory/%s must 403; body=%s", path, raw)
+	}
+}
+
+func TestDirectoryEndpoints_NilProvider_Returns501ThroughStack(t *testing.T) {
+	t.Parallel()
+	subEnv := directorySubEnv(t, nil)
+	tenantID, client := ownerClientForDirectoryEnv(t, subEnv, "dir-nilprov")
+	ctx := context.Background()
+
+	for _, path := range []string{"users", "groups"} {
+		raw, status, err := client.do(ctx, http.MethodGet,
+			fmt.Sprintf("/v1/tenants/%s/directory/%s", tenantID, path), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotImplemented, status,
+			"nil provider → 501 feature-detection on directory/%s; body=%s", path, raw)
+		require.Contains(t, ErrorBody(raw), "no directory provider is configured")
+	}
+}
+
+func TestDirectoryEndpoints_CrossTenant_Returns404(t *testing.T) {
+	t.Parallel()
+	subEnv := directorySubEnv(t, &fakeDirectoryProvider{})
+
+	tenantA := randomTenantID("dir-xt-a")
+	tenantB := randomTenantID("dir-xt-b")
+	ownerSub := "sub-owner-" + randomName("dirx")
+	insertRole(t, subEnv, ownerSub, tenantA, models.RoleOwner)
+	insertRole(t, subEnv, "sub-other-"+randomName("dirx"), tenantB, models.RoleOwner) // tenantB exists
+	client := NewAPIClient(subEnv.BaseURL, mintTokenForSubEnv(t, subEnv, ownerSub, tenantA))
+
+	raw, status, err := client.do(context.Background(), http.MethodGet,
+		fmt.Sprintf("/v1/tenants/%s/directory/users", tenantB), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, status,
+		"tenant A's owner must get 404 on tenant B's directory URL (non-enumerable); body=%s", raw)
+}

--- a/dcctl/cmd/bastion/create.go
+++ b/dcctl/cmd/bastion/create.go
@@ -177,12 +177,12 @@ func pollBastionUntilDone(ctx context.Context, tenantID, projectID string, apiCl
 		}
 		b := resp.JSON200
 		switch b.Status {
-		case dcapi.ACTIVE:
+		case dcapi.ResourceStatusACTIVE:
 			if b.MgmtIp != nil && *b.MgmtIp != "" {
 				fmt.Println(" done!")
 				return b, nil
 			}
-		case dcapi.FAILED:
+		case dcapi.ResourceStatusFAILED:
 			fmt.Println()
 			return nil, fmt.Errorf("bastion provisioning failed: %s", cliutil.DerefOrDash(b.Message))
 		}

--- a/dcctl/cmd/peering/create.go
+++ b/dcctl/cmd/peering/create.go
@@ -179,10 +179,10 @@ func pollPeeringUntilDone(ctx context.Context, tenantID, projectID string, apiCl
 		}
 		p := resp.JSON200
 		switch p.Status {
-		case dcapi.ACTIVE:
+		case dcapi.ResourceStatusACTIVE:
 			fmt.Println(" done!")
 			return p, nil
-		case dcapi.FAILED:
+		case dcapi.ResourceStatusFAILED:
 			fmt.Println()
 			return nil, fmt.Errorf("Peering provisioning failed: %s", cliutil.DerefOrDash(p.Message))
 		}

--- a/dcctl/cmd/subnet/create.go
+++ b/dcctl/cmd/subnet/create.go
@@ -153,10 +153,10 @@ func pollSubnetUntilDone(ctx context.Context, tenantID, projectID string, apiCli
 		}
 		s := resp.JSON200
 		switch s.Status {
-		case dcapi.ACTIVE:
+		case dcapi.ResourceStatusACTIVE:
 			fmt.Println(" done!")
 			return s, nil
-		case dcapi.FAILED:
+		case dcapi.ResourceStatusFAILED:
 			fmt.Println()
 			return nil, fmt.Errorf("Subnet provisioning failed: %s", cliutil.DerefOrDash(s.Message))
 		}

--- a/dcctl/cmd/tenant/member_create.go
+++ b/dcctl/cmd/tenant/member_create.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 	"github.com/wso2/dcctl/cmd/internal/cliutil"
 	"github.com/wso2/dcctl/internal/client"
@@ -12,18 +14,37 @@ import (
 	dcconfig "github.com/wso2/dcctl/internal/config"
 )
 
+// legacyRoles are the retired v1 rank names. They are rejected with a hint
+// instead of being silently mapped to a v2 role-definition key.
+var legacyRoles = map[string]bool{"owner": true, "member": true, "viewer": true}
+
 func newMemberCreateCmd() *cobra.Command {
 	var role string
+	var alias string
 
 	cmd := &cobra.Command{
-		Use:   "create <user_sub>",
-		Short: "Invite a user to the tenant",
-		Long: `Invite a user to the active (or specified) tenant and grant them a role.
+		Use:   "create <email-or-sub>",
+		Short: "Grant a user a role on the tenant",
+		Long: `Grant a user a role on the active (or specified) tenant.
+
+The user is identified by email address (resolved to an identity by the
+platform's directory) or, alternatively, by their raw OIDC subject ("sub").
+An argument containing "@" is treated as an email; anything else is sent
+as a sub.
+
+If the email does not match exactly one user — or the deployment has no
+directory provider configured — the API returns 422; in that case grant by
+the raw sub instead.
+
+--role takes a role-definition key (e.g. Owner, Contributor, Reader).
+List the full catalog with: GET /v1/role-definitions. The v1 ranks
+(owner/member/viewer) are no longer accepted.
 
 Examples:
-  dcctl tenant member create alice@example.com --role member
-  dcctl tenant member create alice@example.com --role owner
-  dcctl tenant member create alice@example.com --role viewer --tenant other-tenant`,
+  dcctl tenant member create alice@example.com --role Contributor
+  dcctl tenant member create alice@example.com --role Owner --alias "Alice P"
+  dcctl tenant member create 01abc123-0000-0000-0000-user000000001 --role Reader
+  dcctl tenant member create alice@example.com --role Reader --tenant other-tenant`,
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,32 +53,47 @@ Examples:
 			if err != nil {
 				return err
 			}
-			return runMemberCreate(cmd.Context(), args[0], role, tenantID)
+			return runMemberCreate(cmd.Context(), args[0], role, alias, tenantID)
 		},
 	}
-	cmd.Flags().StringVar(&role, "role", "member", "Role to grant: owner, member, or viewer")
+	cmd.Flags().StringVar(&role, "role", "", "Role-definition key to grant (e.g. Owner, Contributor, Reader); no default")
+	cmd.Flags().StringVar(&alias, "alias", "", "Optional display alias shown instead of the opaque sub; defaults to the email on email grants")
 	_ = cmd.MarkFlagRequired("role")
 	return cmd
 }
 
-func runMemberCreate(ctx context.Context, userSub, role, tenantID string) error {
+func runMemberCreate(ctx context.Context, principal, role, alias, tenantID string) error {
+	if legacyRoles[role] {
+		return fmt.Errorf("%q is a retired v1 role rank — pass a role-definition key instead (e.g. Owner, Contributor, Reader; full catalog: GET /v1/role-definitions)", role)
+	}
+
 	creds, err := dcconfig.LoadCredentials()
 	if err != nil {
 		return err
 	}
 
+	req := dcapi.CreateRoleAssignmentRequest{RoleDefinition: role}
+	if strings.Contains(principal, "@") {
+		email := openapi_types.Email(principal)
+		req.UserEmail = &email
+	} else {
+		req.UserSub = &principal
+	}
+	if alias != "" {
+		req.DisplayAlias = &alias
+	}
+
 	apiClient := client.New(creds.AccessToken)
-	resp, err := apiClient.Typed.InviteMemberWithResponse(ctx, tenantID, dcapi.InviteMemberRequest{
-		UserSub: userSub,
-		Role:    dcapi.InviteMemberRequestRole(role),
-	})
+	resp, err := apiClient.Typed.CreateTenantRoleAssignmentWithResponse(ctx, tenantID, req)
 	if err != nil {
-		return fmt.Errorf("POST /v1/tenants/%s/members: %w", tenantID, err)
+		return fmt.Errorf("POST /v1/tenants/%s/role-assignments: %w", tenantID, err)
 	}
 	if resp.StatusCode() != http.StatusCreated || resp.JSON201 == nil {
 		return cliutil.APIErrorf(resp.StatusCode(), resp.Body)
 	}
 
-	fmt.Printf("Added %s to tenant %s with role %s.\n", userSub, tenantID, role)
+	ra := resp.JSON201
+	fmt.Printf("Granted %s to %s on tenant %s (principal %s).\n",
+		ra.RoleDefinition, principal, tenantID, ra.PrincipalId)
 	return nil
 }

--- a/dcctl/cmd/tenant/member_delete.go
+++ b/dcctl/cmd/tenant/member_delete.go
@@ -19,13 +19,17 @@ func newMemberDeleteCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete <user_sub>",
-		Short: "Remove a user from the tenant",
-		Long: `Remove a user from the active (or specified) tenant.
+		Short: "Revoke a user's role assignments on the tenant",
+		Long: `Revoke all of a user's role assignments on the active (or specified) tenant.
+
+The argument is the user's OIDC subject ("sub") — the PRINCIPAL_ID column
+of "dcctl tenant member list". Unlike create, delete does not accept an
+email address. Removing the last Owner of a tenant is refused.
 
 Examples:
-  dcctl tenant member delete alice@example.com
-  dcctl tenant member delete alice@example.com --yes
-  dcctl tenant member delete alice@example.com --tenant other-tenant`,
+  dcctl tenant member delete 01abc123-0000-0000-0000-user000000001
+  dcctl tenant member delete 01abc123-0000-0000-0000-user000000001 --yes
+  dcctl tenant member delete 01abc123-0000-0000-0000-user000000001 --tenant other-tenant`,
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -53,9 +57,9 @@ func runMemberDelete(ctx context.Context, userSub, tenantID string, force bool) 
 	}
 
 	apiClient := client.New(creds.AccessToken)
-	resp, err := apiClient.Typed.RemoveMemberWithResponse(ctx, tenantID, userSub)
+	resp, err := apiClient.Typed.DeleteTenantRoleAssignmentWithResponse(ctx, tenantID, userSub)
 	if err != nil {
-		return fmt.Errorf("DELETE /v1/tenants/%s/members/%s: %w", tenantID, userSub, err)
+		return fmt.Errorf("DELETE /v1/tenants/%s/role-assignments/%s: %w", tenantID, userSub, err)
 	}
 	if resp.StatusCode() >= http.StatusMultipleChoices {
 		return cliutil.APIErrorf(resp.StatusCode(), resp.Body)

--- a/dcctl/cmd/tenant/member_list.go
+++ b/dcctl/cmd/tenant/member_list.go
@@ -19,8 +19,10 @@ func newMemberListCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all human members of the tenant",
-		Long: `List all human members of the active (or specified) tenant.
+		Short: "List user role assignments on the tenant",
+		Long: `List all user role assignments on the active (or specified) tenant.
+
+Service accounts are excluded; use "dcctl tenant service-account list".
 
 Examples:
   dcctl tenant member list
@@ -47,32 +49,38 @@ func runMemberList(ctx context.Context, tenantID string, outputJSON bool) error 
 	}
 
 	apiClient := client.New(creds.AccessToken)
-	resp, err := apiClient.Typed.ListMembersWithResponse(ctx, tenantID)
+	resp, err := apiClient.Typed.ListTenantRoleAssignmentsWithResponse(ctx, tenantID)
 	if err != nil {
-		return fmt.Errorf("GET /v1/tenants/%s/members: %w", tenantID, err)
+		return fmt.Errorf("GET /v1/tenants/%s/role-assignments: %w", tenantID, err)
 	}
-	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil || resp.JSON200.Members == nil {
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil || resp.JSON200.RoleAssignments == nil {
 		return cliutil.APIErrorf(resp.StatusCode(), resp.Body)
 	}
-	members := *resp.JSON200.Members
+	assignments := *resp.JSON200.RoleAssignments
 
 	if outputJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(members)
+		return enc.Encode(assignments)
 	}
 
-	if len(members) == 0 {
+	if len(assignments) == 0 {
 		fmt.Println("No members found.")
 		return nil
 	}
 
-	fmt.Printf("%-40s  %-8s  %-20s  %s\n", "PRINCIPAL_ID", "ROLE", "GRANTED_AT", "GRANTED_BY")
-	fmt.Printf("%-40s  %-8s  %-20s  %s\n",
-		strings.Repeat("-", 40), "--------", "--------------------", "--------------------")
-	for _, m := range members {
-		fmt.Printf("%-40s  %-8s  %-20s  %s\n",
-			m.PrincipalId, m.Role, m.GrantedAt.Format("2006-01-02 15:04:05"), m.GrantedBy)
+	fmt.Printf("%-40s  %-24s  %-28s  %-20s  %s\n",
+		"PRINCIPAL_ID", "ALIAS", "ROLE", "GRANTED_AT", "GRANTED_BY")
+	fmt.Printf("%-40s  %-24s  %-28s  %-20s  %s\n",
+		strings.Repeat("-", 40), strings.Repeat("-", 24), strings.Repeat("-", 28),
+		"--------------------", "--------------------")
+	for _, ra := range assignments {
+		fmt.Printf("%-40s  %-24s  %-28s  %-20s  %s\n",
+			ra.PrincipalId,
+			cliutil.Truncate(cliutil.DerefOrDash(ra.DisplayAlias), 24),
+			ra.RoleDefinition,
+			ra.GrantedAt.Format("2006-01-02 15:04:05"),
+			ra.GrantedBy)
 	}
 	return nil
 }

--- a/dcctl/cmd/tenant/members.go
+++ b/dcctl/cmd/tenant/members.go
@@ -6,9 +6,9 @@
 //	dcctl tenant current           — print the currently active tenant
 //	dcctl tenant list              — list all accessible tenants
 //
-// Member management:
+// Member management (tenant-scope role assignments):
 //
-//	dcctl tenant member create <user_sub> --role <r>
+//	dcctl tenant member create <email-or-sub> --role <role-definition-key>
 //	dcctl tenant member list
 //	dcctl tenant member delete <user_sub>
 //

--- a/dcctl/cmd/vm/create.go
+++ b/dcctl/cmd/vm/create.go
@@ -224,12 +224,12 @@ func pollUntilDone(ctx context.Context, tenantID, projectID string, apiClient *c
 		}
 		vm := resp.JSON200
 		switch vm.Status {
-		case dcapi.PENDING:
+		case dcapi.ResourceStatusPENDING:
 			continue
-		case dcapi.ACTIVE:
+		case dcapi.ResourceStatusACTIVE:
 			fmt.Println(" done!")
 			return vm, nil
-		case dcapi.FAILED:
+		case dcapi.ResourceStatusFAILED:
 			fmt.Println()
 			return nil, fmt.Errorf("VM provisioning failed: %s", cliutil.DerefOrDash(vm.Message))
 		}

--- a/dcctl/cmd/vnet/create.go
+++ b/dcctl/cmd/vnet/create.go
@@ -149,10 +149,10 @@ func pollVNetUntilDone(ctx context.Context, tenantID, projectID string, apiClien
 		}
 		v := resp.JSON200
 		switch v.Status {
-		case dcapi.ACTIVE:
+		case dcapi.ResourceStatusACTIVE:
 			fmt.Println(" done!")
 			return v, nil
-		case dcapi.FAILED:
+		case dcapi.ResourceStatusFAILED:
 			fmt.Println()
 			return nil, fmt.Errorf("VNet provisioning failed: %s", cliutil.DerefOrDash(v.Message))
 		}

--- a/dcctl/internal/client/generated/dcapi.gen.go
+++ b/dcctl/internal/client/generated/dcapi.gen.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,54 +38,6 @@ func (e AttachNSGRequestTargetType) Valid() bool {
 	}
 }
 
-// Defines values for ClusterNodeSize.
-const (
-	ClusterNodeSizeLarge  ClusterNodeSize = "large"
-	ClusterNodeSizeMedium ClusterNodeSize = "medium"
-	ClusterNodeSizeSmall  ClusterNodeSize = "small"
-	ClusterNodeSizeXlarge ClusterNodeSize = "xlarge"
-)
-
-// Valid indicates whether the value is a known member of the ClusterNodeSize enum.
-func (e ClusterNodeSize) Valid() bool {
-	switch e {
-	case ClusterNodeSizeLarge:
-		return true
-	case ClusterNodeSizeMedium:
-		return true
-	case ClusterNodeSizeSmall:
-		return true
-	case ClusterNodeSizeXlarge:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for CreateClusterRequestNodeSize.
-const (
-	CreateClusterRequestNodeSizeLarge  CreateClusterRequestNodeSize = "large"
-	CreateClusterRequestNodeSizeMedium CreateClusterRequestNodeSize = "medium"
-	CreateClusterRequestNodeSizeSmall  CreateClusterRequestNodeSize = "small"
-	CreateClusterRequestNodeSizeXlarge CreateClusterRequestNodeSize = "xlarge"
-)
-
-// Valid indicates whether the value is a known member of the CreateClusterRequestNodeSize enum.
-func (e CreateClusterRequestNodeSize) Valid() bool {
-	switch e {
-	case CreateClusterRequestNodeSizeLarge:
-		return true
-	case CreateClusterRequestNodeSizeMedium:
-		return true
-	case CreateClusterRequestNodeSizeSmall:
-		return true
-	case CreateClusterRequestNodeSizeXlarge:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for CreateDNSRecordRequestType.
 const (
 	CreateDNSRecordRequestTypeA     CreateDNSRecordRequestType = "A"
@@ -109,6 +62,93 @@ func (e CreateDNSRecordRequestType) Valid() bool {
 	case CreateDNSRecordRequestTypeSRV:
 		return true
 	case CreateDNSRecordRequestTypeTXT:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateDatabaseRequestEngine.
+const (
+	CreateDatabaseRequestEnginePostgres CreateDatabaseRequestEngine = "postgres"
+)
+
+// Valid indicates whether the value is a known member of the CreateDatabaseRequestEngine enum.
+func (e CreateDatabaseRequestEngine) Valid() bool {
+	switch e {
+	case CreateDatabaseRequestEnginePostgres:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateDatabaseRequestInstanceClass.
+const (
+	DbM52xlarge CreateDatabaseRequestInstanceClass = "db.m5.2xlarge"
+	DbM5Large   CreateDatabaseRequestInstanceClass = "db.m5.large"
+	DbM5Xlarge  CreateDatabaseRequestInstanceClass = "db.m5.xlarge"
+	DbR52xlarge CreateDatabaseRequestInstanceClass = "db.r5.2xlarge"
+	DbR5Large   CreateDatabaseRequestInstanceClass = "db.r5.large"
+	DbR5Xlarge  CreateDatabaseRequestInstanceClass = "db.r5.xlarge"
+	DbT32xlarge CreateDatabaseRequestInstanceClass = "db.t3.2xlarge"
+	DbT3Large   CreateDatabaseRequestInstanceClass = "db.t3.large"
+	DbT3Medium  CreateDatabaseRequestInstanceClass = "db.t3.medium"
+	DbT3Micro   CreateDatabaseRequestInstanceClass = "db.t3.micro"
+	DbT3Small   CreateDatabaseRequestInstanceClass = "db.t3.small"
+	DbT3Xlarge  CreateDatabaseRequestInstanceClass = "db.t3.xlarge"
+)
+
+// Valid indicates whether the value is a known member of the CreateDatabaseRequestInstanceClass enum.
+func (e CreateDatabaseRequestInstanceClass) Valid() bool {
+	switch e {
+	case DbM52xlarge:
+		return true
+	case DbM5Large:
+		return true
+	case DbM5Xlarge:
+		return true
+	case DbR52xlarge:
+		return true
+	case DbR5Large:
+		return true
+	case DbR5Xlarge:
+		return true
+	case DbT32xlarge:
+		return true
+	case DbT3Large:
+		return true
+	case DbT3Medium:
+		return true
+	case DbT3Micro:
+		return true
+	case DbT3Small:
+		return true
+	case DbT3Xlarge:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateNodePoolRequestSize.
+const (
+	CreateNodePoolRequestSizeLarge  CreateNodePoolRequestSize = "large"
+	CreateNodePoolRequestSizeMedium CreateNodePoolRequestSize = "medium"
+	CreateNodePoolRequestSizeSmall  CreateNodePoolRequestSize = "small"
+	CreateNodePoolRequestSizeXlarge CreateNodePoolRequestSize = "xlarge"
+)
+
+// Valid indicates whether the value is a known member of the CreateNodePoolRequestSize enum.
+func (e CreateNodePoolRequestSize) Valid() bool {
+	switch e {
+	case CreateNodePoolRequestSizeLarge:
+		return true
+	case CreateNodePoolRequestSizeMedium:
+		return true
+	case CreateNodePoolRequestSizeSmall:
+		return true
+	case CreateNodePoolRequestSizeXlarge:
 		return true
 	default:
 		return false
@@ -211,21 +251,87 @@ func (e DNSRecordType) Valid() bool {
 	}
 }
 
-// Defines values for InviteMemberRequestRole.
+// Defines values for DatabaseEngine.
 const (
-	InviteMemberRequestRoleMember InviteMemberRequestRole = "member"
-	InviteMemberRequestRoleOwner  InviteMemberRequestRole = "owner"
-	InviteMemberRequestRoleViewer InviteMemberRequestRole = "viewer"
+	DatabaseEnginePostgres DatabaseEngine = "postgres"
 )
 
-// Valid indicates whether the value is a known member of the InviteMemberRequestRole enum.
-func (e InviteMemberRequestRole) Valid() bool {
+// Valid indicates whether the value is a known member of the DatabaseEngine enum.
+func (e DatabaseEngine) Valid() bool {
 	switch e {
-	case InviteMemberRequestRoleMember:
+	case DatabaseEnginePostgres:
 		return true
-	case InviteMemberRequestRoleOwner:
+	default:
+		return false
+	}
+}
+
+// Defines values for DatabaseNetworkMode.
+const (
+	DatabaseNetworkModeLegacy DatabaseNetworkMode = "legacy"
+	DatabaseNetworkModeVpc    DatabaseNetworkMode = "vpc"
+)
+
+// Valid indicates whether the value is a known member of the DatabaseNetworkMode enum.
+func (e DatabaseNetworkMode) Valid() bool {
+	switch e {
+	case DatabaseNetworkModeLegacy:
 		return true
-	case InviteMemberRequestRoleViewer:
+	case DatabaseNetworkModeVpc:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for DatabaseStatus.
+const (
+	DatabaseStatusACTIVE   DatabaseStatus = "ACTIVE"
+	DatabaseStatusDELETING DatabaseStatus = "DELETING"
+	DatabaseStatusFAILED   DatabaseStatus = "FAILED"
+	DatabaseStatusPENDING  DatabaseStatus = "PENDING"
+)
+
+// Valid indicates whether the value is a known member of the DatabaseStatus enum.
+func (e DatabaseStatus) Valid() bool {
+	switch e {
+	case DatabaseStatusACTIVE:
+		return true
+	case DatabaseStatusDELETING:
+		return true
+	case DatabaseStatusFAILED:
+		return true
+	case DatabaseStatusPENDING:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for DatabaseNetworkLegacyMode.
+const (
+	DatabaseNetworkLegacyModeLegacy DatabaseNetworkLegacyMode = "legacy"
+)
+
+// Valid indicates whether the value is a known member of the DatabaseNetworkLegacyMode enum.
+func (e DatabaseNetworkLegacyMode) Valid() bool {
+	switch e {
+	case DatabaseNetworkLegacyModeLegacy:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for DatabaseNetworkVPCMode.
+const (
+	Vpc DatabaseNetworkVPCMode = "vpc"
+)
+
+// Valid indicates whether the value is a known member of the DatabaseNetworkVPCMode enum.
+func (e DatabaseNetworkVPCMode) Valid() bool {
+	switch e {
+	case Vpc:
 		return true
 	default:
 		return false
@@ -310,6 +416,96 @@ func (e NSGRuleProtocol) Valid() bool {
 	}
 }
 
+// Defines values for NodePoolRole.
+const (
+	System NodePoolRole = "system"
+	Worker NodePoolRole = "worker"
+)
+
+// Valid indicates whether the value is a known member of the NodePoolRole enum.
+func (e NodePoolRole) Valid() bool {
+	switch e {
+	case System:
+		return true
+	case Worker:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for NodePoolSize.
+const (
+	NodePoolSizeLarge  NodePoolSize = "large"
+	NodePoolSizeMedium NodePoolSize = "medium"
+	NodePoolSizeSmall  NodePoolSize = "small"
+	NodePoolSizeXlarge NodePoolSize = "xlarge"
+)
+
+// Valid indicates whether the value is a known member of the NodePoolSize enum.
+func (e NodePoolSize) Valid() bool {
+	switch e {
+	case NodePoolSizeLarge:
+		return true
+	case NodePoolSizeMedium:
+		return true
+	case NodePoolSizeSmall:
+		return true
+	case NodePoolSizeXlarge:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for NodePoolStatus.
+const (
+	Deleting     NodePoolStatus = "deleting"
+	Failed       NodePoolStatus = "failed"
+	Provisioning NodePoolStatus = "provisioning"
+	Ready        NodePoolStatus = "ready"
+	Scaling      NodePoolStatus = "scaling"
+)
+
+// Valid indicates whether the value is a known member of the NodePoolStatus enum.
+func (e NodePoolStatus) Valid() bool {
+	switch e {
+	case Deleting:
+		return true
+	case Failed:
+		return true
+	case Provisioning:
+		return true
+	case Ready:
+		return true
+	case Scaling:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for NodePoolTaintEffect.
+const (
+	NoExecute        NodePoolTaintEffect = "NoExecute"
+	NoSchedule       NodePoolTaintEffect = "NoSchedule"
+	PreferNoSchedule NodePoolTaintEffect = "PreferNoSchedule"
+)
+
+// Valid indicates whether the value is a known member of the NodePoolTaintEffect enum.
+func (e NodePoolTaintEffect) Valid() bool {
+	switch e {
+	case NoExecute:
+		return true
+	case NoSchedule:
+		return true
+	case PreferNoSchedule:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for QuotaExceededErrorError.
 const (
 	QuotaExceededErrorErrorQuotaExceeded QuotaExceededErrorError = "quota_exceeded"
@@ -327,22 +523,22 @@ func (e QuotaExceededErrorError) Valid() bool {
 
 // Defines values for ResourceStatus.
 const (
-	ACTIVE   ResourceStatus = "ACTIVE"
-	DELETING ResourceStatus = "DELETING"
-	FAILED   ResourceStatus = "FAILED"
-	PENDING  ResourceStatus = "PENDING"
+	ResourceStatusACTIVE   ResourceStatus = "ACTIVE"
+	ResourceStatusDELETING ResourceStatus = "DELETING"
+	ResourceStatusFAILED   ResourceStatus = "FAILED"
+	ResourceStatusPENDING  ResourceStatus = "PENDING"
 )
 
 // Valid indicates whether the value is a known member of the ResourceStatus enum.
 func (e ResourceStatus) Valid() bool {
 	switch e {
-	case ACTIVE:
+	case ResourceStatusACTIVE:
 		return true
-	case DELETING:
+	case ResourceStatusDELETING:
 		return true
-	case FAILED:
+	case ResourceStatusFAILED:
 		return true
-	case PENDING:
+	case ResourceStatusPENDING:
 		return true
 	default:
 		return false
@@ -367,35 +563,17 @@ func (e RoleAssignmentPrincipalType) Valid() bool {
 	}
 }
 
-// Defines values for RoleAssignmentRole.
-const (
-	RoleAssignmentRoleMember RoleAssignmentRole = "member"
-	RoleAssignmentRoleOwner  RoleAssignmentRole = "owner"
-	RoleAssignmentRoleViewer RoleAssignmentRole = "viewer"
-)
-
-// Valid indicates whether the value is a known member of the RoleAssignmentRole enum.
-func (e RoleAssignmentRole) Valid() bool {
-	switch e {
-	case RoleAssignmentRoleMember:
-		return true
-	case RoleAssignmentRoleOwner:
-		return true
-	case RoleAssignmentRoleViewer:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for RoleAssignmentScopeType.
 const (
-	RoleAssignmentScopeTypeTenant RoleAssignmentScopeType = "tenant"
+	RoleAssignmentScopeTypeProject RoleAssignmentScopeType = "project"
+	RoleAssignmentScopeTypeTenant  RoleAssignmentScopeType = "tenant"
 )
 
 // Valid indicates whether the value is a known member of the RoleAssignmentScopeType enum.
 func (e RoleAssignmentScopeType) Valid() bool {
 	switch e {
+	case RoleAssignmentScopeTypeProject:
+		return true
 	case RoleAssignmentScopeTypeTenant:
 		return true
 	default:
@@ -448,6 +626,75 @@ func (e ServiceAccountRole) Valid() bool {
 	}
 }
 
+// Defines values for SharedResourceKind.
+const (
+	Clusters        SharedResourceKind = "clusters"
+	Databases       SharedResourceKind = "databases"
+	Keyvaults       SharedResourceKind = "keyvaults"
+	VirtualMachines SharedResourceKind = "virtual-machines"
+)
+
+// Valid indicates whether the value is a known member of the SharedResourceKind enum.
+func (e SharedResourceKind) Valid() bool {
+	switch e {
+	case Clusters:
+		return true
+	case Databases:
+		return true
+	case Keyvaults:
+		return true
+	case VirtualMachines:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SystemPoolSpecCount.
+const (
+	N1 SystemPoolSpecCount = 1
+	N3 SystemPoolSpecCount = 3
+	N5 SystemPoolSpecCount = 5
+)
+
+// Valid indicates whether the value is a known member of the SystemPoolSpecCount enum.
+func (e SystemPoolSpecCount) Valid() bool {
+	switch e {
+	case N1:
+		return true
+	case N3:
+		return true
+	case N5:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SystemPoolSpecSize.
+const (
+	SystemPoolSpecSizeLarge  SystemPoolSpecSize = "large"
+	SystemPoolSpecSizeMedium SystemPoolSpecSize = "medium"
+	SystemPoolSpecSizeSmall  SystemPoolSpecSize = "small"
+	SystemPoolSpecSizeXlarge SystemPoolSpecSize = "xlarge"
+)
+
+// Valid indicates whether the value is a known member of the SystemPoolSpecSize enum.
+func (e SystemPoolSpecSize) Valid() bool {
+	switch e {
+	case SystemPoolSpecSizeLarge:
+		return true
+	case SystemPoolSpecSizeMedium:
+		return true
+	case SystemPoolSpecSizeSmall:
+		return true
+	case SystemPoolSpecSizeXlarge:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for TenantSummaryRoles.
 const (
 	TenantSummaryRolesMember TenantSummaryRoles = "member"
@@ -471,35 +718,35 @@ func (e TenantSummaryRoles) Valid() bool {
 
 // Defines values for VirtualMachineSize.
 const (
-	VirtualMachineSizeLarge  VirtualMachineSize = "large"
-	VirtualMachineSizeMedium VirtualMachineSize = "medium"
-	VirtualMachineSizeSmall  VirtualMachineSize = "small"
-	VirtualMachineSizeXlarge VirtualMachineSize = "xlarge"
+	Large  VirtualMachineSize = "large"
+	Medium VirtualMachineSize = "medium"
+	Small  VirtualMachineSize = "small"
+	Xlarge VirtualMachineSize = "xlarge"
 )
 
 // Valid indicates whether the value is a known member of the VirtualMachineSize enum.
 func (e VirtualMachineSize) Valid() bool {
 	switch e {
-	case VirtualMachineSizeLarge:
+	case Large:
 		return true
-	case VirtualMachineSizeMedium:
+	case Medium:
 		return true
-	case VirtualMachineSizeSmall:
+	case Small:
 		return true
-	case VirtualMachineSizeXlarge:
+	case Xlarge:
 		return true
 	default:
 		return false
 	}
 }
 
-// Defines values for UpdateProjectQuota400JSONResponseBody1Error.
+// Defines values for UpdateProjectQuota400JSONResponseBody2Error.
 const (
-	QuotaBelowUsage UpdateProjectQuota400JSONResponseBody1Error = "quota_below_usage"
+	QuotaBelowUsage UpdateProjectQuota400JSONResponseBody2Error = "quota_below_usage"
 )
 
-// Valid indicates whether the value is a known member of the UpdateProjectQuota400JSONResponseBody1Error enum.
-func (e UpdateProjectQuota400JSONResponseBody1Error) Valid() bool {
+// Valid indicates whether the value is a known member of the UpdateProjectQuota400JSONResponseBody2Error enum.
+func (e UpdateProjectQuota400JSONResponseBody2Error) Valid() bool {
 	switch e {
 	case QuotaBelowUsage:
 		return true
@@ -621,27 +868,36 @@ type Cluster struct {
 	//   (`provisioning.cattle.io/cluster`). Examples:
 	//   `"waiting for viable init node"`, `"configuring control plane"`.
 	//   The reconciler refreshes this every poll cycle without flipping
-	//   status, so callers polling GET see progress without a state
-	//   change.
+	//   status, so callers polling GET see progress without a state change.
 	// - **FAILED**: terminal failure reason from the upstream Stalled
 	//   condition (e.g. `"control plane never became healthy"`).
 	// - **ACTIVE**: typically empty.
-	Message      *string          `json:"message,omitempty"`
-	Name         string           `json:"name"`
-	NodeSize     *ClusterNodeSize `json:"node_size,omitempty"`
-	ProviderType string           `json:"provider_type"`
+	Message      *string `json:"message,omitempty"`
+	Name         string  `json:"name"`
+	ProviderType string  `json:"provider_type"`
 
 	// Status Lifecycle status of any DC-API resource.
 	// - `PENDING` — accepted, provisioning in progress
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
-	Status   ResourceStatus `json:"status"`
-	TenantId string         `json:"tenant_id"`
-}
+	Status ResourceStatus `json:"status"`
 
-// ClusterNodeSize defines model for Cluster.NodeSize.
-type ClusterNodeSize string
+	// SystemPool Embedded system node pool. Always present. For the list endpoint
+	// this provides a quick at-a-glance view; for full node-pool detail
+	// call `GET .../clusters/{id}/node-pools`.
+	SystemPool NodePool `json:"system_pool"`
+	TenantId   string   `json:"tenant_id"`
+
+	// TotalNodeCount Sum of node counts across all pools (system + all worker pools).
+	// Useful for at-a-glance capacity display.
+	TotalNodeCount int `json:"total_node_count"`
+
+	// WorkerPoolCount Number of worker pools currently attached to this cluster. Does
+	// not include the system pool. Fetch the full list via
+	// `GET .../clusters/{id}/node-pools`.
+	WorkerPoolCount int `json:"worker_pool_count"`
+}
 
 // CreateBastionRequest defines model for CreateBastionRequest.
 type CreateBastionRequest struct {
@@ -683,6 +939,13 @@ type CreateBastionResponse struct {
 // - **VPC path (F32)**:    set `vnet_id` + `subnet_id` only.
 //
 // Providing both or neither returns `400`.
+//
+// Worker node pools are **optional** at create time: supply `worker_pools`
+// to provision one or more worker pools alongside the cluster in a single
+// request. Each entry follows the `CreateNodePoolRequest` shape (the role
+// is always `worker` and must not be included). Pool names must be unique
+// within the cluster and must not be `system` (reserved). Worker pools can
+// also be added after cluster creation via `POST .../clusters/{id}/node-pools`.
 type CreateClusterRequest struct {
 	// ImageName Image ID from `GET /v1/images`
 	ImageName string `json:"image_name"`
@@ -690,33 +953,41 @@ type CreateClusterRequest struct {
 	// K8sVersion RKE2 Kubernetes version string
 	K8sVersion string `json:"k8s_version"`
 
-	// Name Unique cluster name within the tenant
+	// Name Unique cluster name within the project. DNS-label-safe, max 32
+	// chars (leaves room for `<cluster>-<pool>-<suffix>` Rancher CRD
+	// naming).
 	Name string `json:"name"`
 
 	// NetworkName Network ID from `GET /v1/networks`. Legacy bridge path.
 	// Mutually exclusive with `vnet_id` + `subnet_id`.
 	NetworkName *string `json:"network_name,omitempty"`
 
-	// NodeCount Number of worker nodes (1–10)
-	NodeCount int `json:"node_count"`
-
-	// NodeDiskGb Optional root disk override per node. Defaults to size default.
-	NodeDiskGb *int `json:"node_disk_gb,omitempty"`
-
-	// NodeSize Named instance size for each node
-	NodeSize CreateClusterRequestNodeSize `json:"node_size"`
-
 	// SubnetId UUID of an ACTIVE Subnet inside the specified `vnet_id`.
 	// Required when `vnet_id` is set. Mutually exclusive with `network_name`.
 	SubnetId *openapi_types.UUID `json:"subnet_id,omitempty"`
 
-	// VnetId UUID of a ACTIVE VNet in this tenant. F32 VPC path.
+	// SystemPool Specification for the system node pool, supplied at cluster create time.
+	// The system pool hosts the Kubernetes control-plane and etcd quorum.
+	// User workloads do not schedule here by default (RKE2 applies
+	// `node-role.kubernetes.io/control-plane:NoSchedule` and
+	// `node-role.kubernetes.io/etcd:NoExecute` taints automatically).
+	//
+	// The pool name is always `system` — it is set by the server and must
+	// not be provided in the request.
+	SystemPool SystemPoolSpec `json:"system_pool"`
+
+	// VnetId UUID of an ACTIVE VNet in this tenant. VPC path (F32).
 	// Mutually exclusive with `network_name`. Requires `subnet_id`.
 	VnetId *openapi_types.UUID `json:"vnet_id,omitempty"`
-}
 
-// CreateClusterRequestNodeSize Named instance size for each node
-type CreateClusterRequestNodeSize string
+	// WorkerPools Optional list of worker pools to provision alongside the cluster.
+	// Each entry follows the `CreateNodePoolRequest` shape (the role is
+	// always `worker` and must not be included). Pool names must be unique
+	// within the cluster and must not be `system` (reserved). Worker pools
+	// can also be added after cluster creation via
+	// `POST .../clusters/{id}/node-pools`.
+	WorkerPools *[]CreateNodePoolRequest `json:"worker_pools,omitempty"`
+}
 
 // CreateClusterResponse defines model for CreateClusterResponse.
 type CreateClusterResponse struct {
@@ -748,6 +1019,37 @@ type CreateDNSZoneRequest struct {
 	// (e.g. `internal.lk.wso2.com`). Uniqueness enforced per (vnet_id, name).
 	Name string `json:"name"`
 }
+
+// CreateDatabaseRequest Body for `POST .../databases`. Network selection is optional —
+// omit to use the project's default (first ACTIVE subnet).
+type CreateDatabaseRequest struct {
+	// AllocatedStorageGb Data-volume size in GiB.
+	AllocatedStorageGb int `json:"allocated_storage_gb"`
+
+	// Engine Database engine. v1 supports postgres only.
+	Engine *CreateDatabaseRequestEngine `json:"engine,omitempty"`
+
+	// EngineVersion Engine version (e.g. "16"). Informational in v1 — accepted and
+	// stored but not acted on by the controller until Task 2 lands
+	// multi-version support.
+	EngineVersion *string `json:"engine_version,omitempty"`
+
+	// InstanceClass RDS-style instance size class.
+	InstanceClass CreateDatabaseRequestInstanceClass `json:"instance_class"`
+
+	// Name Project-unique name (DNS-label rules; ≤32 chars).
+	Name string `json:"name"`
+
+	// Network Discriminated network selection. Omit to auto-pick the project's
+	// default subnet (VPC mode).
+	Network *DatabaseNetworkSpec `json:"network,omitempty"`
+}
+
+// CreateDatabaseRequestEngine Database engine. v1 supports postgres only.
+type CreateDatabaseRequestEngine string
+
+// CreateDatabaseRequestInstanceClass RDS-style instance size class.
+type CreateDatabaseRequestInstanceClass string
 
 // CreateImageRequest defines model for CreateImageRequest.
 type CreateImageRequest struct {
@@ -782,6 +1084,43 @@ type CreateNSGRequest struct {
 	// Rules Initial rule set. May be empty.
 	Rules *[]NSGRule `json:"rules,omitempty"`
 }
+
+// CreateNodePoolRequest Request body for `POST .../clusters/{id}/node-pools`.
+// Always creates a **worker** pool — the role is set by the server and
+// must not be included in the request.
+//
+// Pool name must be unique within the cluster. The name `system` is
+// reserved and will be rejected with `400`.
+type CreateNodePoolRequest struct {
+	// Count Number of nodes in the pool (1–50)
+	Count int `json:"count"`
+
+	// DiskGb Optional root disk override in GiB. Defaults to the size default.
+	// Minimum 40 GiB.
+	DiskGb *int `json:"disk_gb,omitempty"`
+
+	// ImageName Optional Harvester VM image for nodes in this pool. Format:
+	// `namespace/image-name` (same as `CreateClusterRequest.image_name`).
+	// Omit to reuse the image already set in the cluster's system pool
+	// (the provider falls back to its configured default).
+	ImageName *string `json:"image_name,omitempty"`
+
+	// Labels Optional node labels (max 50 entries)
+	Labels *map[string]string `json:"labels,omitempty"`
+
+	// Name Pool name. DNS-label-safe, max 40 chars. Must be unique within
+	// the cluster. The value `system` is reserved and will be rejected.
+	Name string `json:"name"`
+
+	// Size Instance size for each node in the pool
+	Size CreateNodePoolRequestSize `json:"size"`
+
+	// Taints Optional node taints (max 10)
+	Taints *[]NodePoolTaint `json:"taints,omitempty"`
+}
+
+// CreateNodePoolRequestSize Instance size for each node in the pool
+type CreateNodePoolRequestSize string
 
 // CreatePeeringRequest defines model for CreatePeeringRequest.
 type CreatePeeringRequest struct {
@@ -842,6 +1181,46 @@ type CreateProjectRequest struct {
 
 	// StorageGb Storage quota GiB (default 500 when omitted)
 	StorageGb *int `json:"storage_gb,omitempty"`
+}
+
+// CreateRoleAssignmentRequest Grant request shared by every role-assignment scope (tenant, project,
+// and per-resource). The principal is identified by **exactly one** of
+// `user_sub` or `user_email`; supplying both, or neither, returns 400.
+type CreateRoleAssignmentRequest struct {
+	// DisplayAlias Optional mnemonic the granter sets so cloud-ui can show a
+	// readable name in the role-assignment list instead of the opaque
+	// `user_sub`. Defaults to the invite email when the grant uses
+	// `user_email` and no alias is supplied; otherwise purely what the
+	// inviter typed. Never propagated to the IdP, and no IdP attribute
+	// beyond that invite-time email default is ever stored.
+	// Stored verbatim, max 256 chars by convention.
+	DisplayAlias *string `json:"display_alias,omitempty"`
+
+	// RoleDefinition Role-definition key to grant — any catalog key from
+	// `GET /v1/role-definitions` (e.g. `Owner`, `Contributor`, `Reader`,
+	// `VirtualMachineContributor`). The v1 owner/member/viewer ranks are gone.
+	RoleDefinition string `json:"role_definition"`
+
+	// UserEmail Email address of the user to grant the role to. Mutually
+	// exclusive with `user_sub` — exactly one of the two is required.
+	// dc-api resolves the email to an OIDC `sub` via a live SCIM2
+	// point lookup against the deployment's directory provider at
+	// request time, stores only the resolved `sub`, and uses the email
+	// as the default `display_alias` when none is supplied. The email
+	// itself is not persisted beyond that inviter-visible alias.
+	//
+	// Returns 422 when the email does not resolve to exactly one IdP
+	// user (no match or ambiguous), and 422 when no directory provider
+	// is configured on this deployment (probe
+	// `GET /v1/tenants/{tenant_id}/directory/users` — `501` there
+	// means invite-by-email is unavailable).
+	UserEmail *openapi_types.Email `json:"user_email,omitempty"`
+
+	// UserSub OIDC `sub` of the user to grant the role to. Mutually exclusive
+	// with `user_email` — exactly one of the two is required. Granting
+	// by `user_sub` works on every deployment and never contacts the
+	// IdP.
+	UserSub *string `json:"user_sub,omitempty"`
 }
 
 // CreateRouteTableRequest defines model for CreateRouteTableRequest.
@@ -1037,6 +1416,131 @@ type DNSZone struct {
 	VnetId    openapi_types.UUID `json:"vnet_id"`
 }
 
+// Database A managed Database resource. Spec fields come from create-time
+// input; status fields (`status`, `message`, `endpoint_address`,
+// `endpoint_port`) are populated from the live DBInstance CR status
+// on every GET.
+type Database struct {
+	AllocatedStorageGb int       `json:"allocated_storage_gb"`
+	CreatedAt          time.Time `json:"created_at"`
+
+	// EndpointAddress IP or hostname clients connect to. Empty until ACTIVE.
+	EndpointAddress *string `json:"endpoint_address,omitempty"`
+
+	// EndpointPort TCP port. Empty until ACTIVE.
+	EndpointPort  *int               `json:"endpoint_port,omitempty"`
+	Engine        DatabaseEngine     `json:"engine"`
+	EngineVersion *string            `json:"engine_version,omitempty"`
+	Id            openapi_types.UUID `json:"id"`
+	InstanceClass string             `json:"instance_class"`
+
+	// Message Human-readable status message from the controller.
+	Message *string `json:"message,omitempty"`
+
+	// NadRef Set only when network_mode=legacy.
+	NadRef      *string             `json:"nad_ref,omitempty"`
+	Name        string              `json:"name"`
+	NetworkMode DatabaseNetworkMode `json:"network_mode"`
+	ProjectId   string              `json:"project_id"`
+	Status      DatabaseStatus      `json:"status"`
+
+	// SubnetId Set only when network_mode=vpc.
+	SubnetId  *openapi_types.UUID `json:"subnet_id,omitempty"`
+	TenantId  string              `json:"tenant_id"`
+	UpdatedAt time.Time           `json:"updated_at"`
+
+	// VnetId Set only when network_mode=vpc.
+	VnetId *openapi_types.UUID `json:"vnet_id,omitempty"`
+}
+
+// DatabaseEngine defines model for Database.Engine.
+type DatabaseEngine string
+
+// DatabaseNetworkMode defines model for Database.NetworkMode.
+type DatabaseNetworkMode string
+
+// DatabaseStatus defines model for Database.Status.
+type DatabaseStatus string
+
+// DatabaseCredentials Master user credentials for a Database. Returned exactly once on
+// the first call to `GET .../{id}/credentials`. Save them immediately;
+// dc-api will never return them again.
+type DatabaseCredentials struct {
+	// CaCert PEM-encoded CA certificate for SSL verification. Use with
+	// `sslmode=verify-ca` in psql/JDBC connection strings.
+	CaCert   *string `json:"ca_cert,omitempty"`
+	Password string  `json:"password"`
+	Username string  `json:"username"`
+}
+
+// DatabaseNetworkLegacy Pre-existing Multus NAD on a VLAN bridge. Used for environments
+// not yet migrated to KubeOVN (e.g. lk prod).
+type DatabaseNetworkLegacy struct {
+	Mode DatabaseNetworkLegacyMode `json:"mode"`
+
+	// NadRef Multus NAD as 'namespace/name'.
+	NadRef string `json:"nad_ref"`
+}
+
+// DatabaseNetworkLegacyMode defines model for DatabaseNetworkLegacy.Mode.
+type DatabaseNetworkLegacyMode string
+
+// DatabaseNetworkSpec Discriminated network selection. Omit to auto-pick the project's
+// default subnet (VPC mode).
+type DatabaseNetworkSpec struct {
+	union json.RawMessage
+}
+
+// DatabaseNetworkVPC KubeOVN-managed VPC + subnet (the modern path).
+type DatabaseNetworkVPC struct {
+	Mode     DatabaseNetworkVPCMode `json:"mode"`
+	SubnetId openapi_types.UUID     `json:"subnet_id"`
+	VnetId   openapi_types.UUID     `json:"vnet_id"`
+}
+
+// DatabaseNetworkVPCMode defines model for DatabaseNetworkVPC.Mode.
+type DatabaseNetworkVPCMode string
+
+// DirectoryGroup Minimal group record proxied live from the IdP's SCIM2 Groups
+// resource. These two fields are the entire exposure; membership and
+// all other SCIM attributes stay in the IdP, and dc-api persists
+// nothing.
+type DirectoryGroup struct {
+	// Id SCIM2 group identifier in the IdP.
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// DirectoryGroupList defines model for DirectoryGroupList.
+type DirectoryGroupList struct {
+	Groups []DirectoryGroup `json:"groups"`
+
+	// TotalResults Total number of groups across all pages (SCIM2 `totalResults`),
+	// not the size of this page.
+	TotalResults int `json:"total_results"`
+}
+
+// DirectoryUser Minimal user record proxied live from the IdP's SCIM2 Users resource.
+// These three fields are the entire exposure — nothing else from the
+// SCIM response (groups, phone numbers, addresses, raw attributes) is
+// ever surfaced, and dc-api persists none of it.
+type DirectoryUser struct {
+	// DisplayName Human-readable name from the IdP, when one is set.
+	DisplayName *string             `json:"display_name,omitempty"`
+	Email       openapi_types.Email `json:"email"`
+
+	// Sub OIDC `sub` — the value to use as `user_sub` when granting a role.
+	Sub string `json:"sub"`
+}
+
+// DirectoryUserList defines model for DirectoryUserList.
+type DirectoryUserList struct {
+	// TotalResults Total number of users matching the filter across all pages
+	// (SCIM2 `totalResults`), not the size of this page.
+	TotalResults int             `json:"total_results"`
+	Users        []DirectoryUser `json:"users"`
+}
+
 // Error defines model for Error.
 type Error struct {
 	// Error Human-readable description of what went wrong
@@ -1055,23 +1559,6 @@ type Image struct {
 	// Namespace Harvester namespace the image lives in
 	Namespace string `json:"namespace"`
 }
-
-// InviteMemberRequest defines model for InviteMemberRequest.
-type InviteMemberRequest struct {
-	// DisplayAlias Optional mnemonic the inviter sets so cloud-ui can show a
-	// readable name in the members list instead of the opaque
-	// `user_sub`. Not propagated to the IdP and never matched
-	// against any IdP attribute — purely admin bookkeeping.
-	// Stored verbatim, max 256 chars by convention.
-	DisplayAlias *string                 `json:"display_alias,omitempty"`
-	Role         InviteMemberRequestRole `json:"role"`
-
-	// UserSub OIDC `sub` of the user to invite
-	UserSub string `json:"user_sub"`
-}
-
-// InviteMemberRequestRole defines model for InviteMemberRequest.Role.
-type InviteMemberRequestRole string
 
 // KeyVault defines model for KeyVault.
 type KeyVault struct {
@@ -1286,6 +1773,111 @@ type Network struct {
 	Namespace string `json:"namespace"`
 }
 
+// NodePool Represents a node pool within a cluster. Node pools are either
+// `system` (exactly one per cluster, controlplane + etcd) or `worker`
+// (0..N, user workloads).
+//
+// The `role` field is server-set and readOnly — callers cannot change it.
+type NodePool struct {
+	// Count Current desired node count. For the `system` pool this is
+	// constrained to `{1, 3, 5}`; for worker pools the range is 1–50.
+	Count     int        `json:"count"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+
+	// DiskGb Root disk size in GiB (set at creation, immutable)
+	DiskGb *int `json:"disk_gb,omitempty"`
+
+	// Labels Arbitrary key/value labels applied to all nodes in the pool as
+	// Kubernetes node labels. Keys and values must follow Kubernetes
+	// label syntax. Maximum 50 entries.
+	// Only user-mutable on `worker` pools; absent on the `system` pool.
+	Labels *map[string]string `json:"labels,omitempty"`
+
+	// Name Pool name. DNS-label-safe, max 40 chars. The system pool is
+	// always named `system`. Worker pool names are user-supplied at
+	// creation and immutable thereafter.
+	Name *string `json:"name,omitempty"`
+
+	// Role Pool category. `system` = controlplane + etcd (exactly one per
+	// cluster). `worker` = user workloads (0..N per cluster). This
+	// field is set by the server and never accepted from the caller.
+	Role *NodePoolRole `json:"role,omitempty"`
+
+	// Size Instance size. Immutable after pool creation. To change size,
+	// add a new pool of the desired size and delete the old one.
+	Size *NodePoolSize `json:"size,omitempty"`
+
+	// Status Lifecycle status of the pool, derived from the Rancher machinePool
+	// condition. `scaling` indicates a PATCH count change is in progress.
+	Status *NodePoolStatus `json:"status,omitempty"`
+
+	// Taints Node taints applied to all nodes in the pool. Maximum 10.
+	// Only present on `worker` pools; always absent on the `system`
+	// pool (controlled exclusively by RKE2 — not user-mutable).
+	Taints *[]NodePoolTaint `json:"taints,omitempty"`
+}
+
+// NodePoolRole Pool category. `system` = controlplane + etcd (exactly one per
+// cluster). `worker` = user workloads (0..N per cluster). This
+// field is set by the server and never accepted from the caller.
+type NodePoolRole string
+
+// NodePoolSize Instance size. Immutable after pool creation. To change size,
+// add a new pool of the desired size and delete the old one.
+type NodePoolSize string
+
+// NodePoolStatus Lifecycle status of the pool, derived from the Rancher machinePool
+// condition. `scaling` indicates a PATCH count change is in progress.
+type NodePoolStatus string
+
+// NodePoolTaint A Kubernetes node taint applied to all nodes in a worker pool.
+// Key must be a DNS subdomain (e.g. `nvidia.com/gpu`).
+// Value is optional. Effect is required.
+type NodePoolTaint struct {
+	// Effect Taint effect
+	Effect NodePoolTaintEffect `json:"effect"`
+
+	// Key Taint key (DNS subdomain, max 253 chars)
+	Key string `json:"key"`
+
+	// Value Optional taint value (max 63 chars)
+	Value *string `json:"value,omitempty"`
+}
+
+// NodePoolTaintEffect Taint effect
+type NodePoolTaintEffect string
+
+// PatchNodePoolRequest Request body for `PATCH .../clusters/{id}/node-pools/{pool_name}`.
+// All fields are optional; omit a field to leave it unchanged.
+//
+// **Mutable fields**:
+//   - `count` — scale the pool. For the `system` pool, only growth in
+//     steps `{1→3, 3→5}` is permitted; shrinks return `400`. Worker
+//     pools accept any value 1–50.
+//   - `taints` — replaces the entire taint array. Send `[]` to clear.
+//     Refused on the `system` pool.
+//   - `labels` — replaces the entire label map. Send `{}` to clear.
+//     Refused on the `system` pool.
+//
+// The fields `name`, `role`, and `size` are immutable and must not be
+// sent. The handler returns `400` with a descriptive error if they are
+// present (even though they are not in this schema, a strict decoder
+// or explicit handler check catches them).
+type PatchNodePoolRequest struct {
+	// Count New desired node count. System pool: must be `3` when current
+	// is `1`, or `5` when current is `3`; no other values accepted.
+	// Worker pools: any value 1–50.
+	Count *int `json:"count,omitempty"`
+
+	// Labels Replacement label map. Replaces the existing map in full.
+	// Send `{}` to remove all labels. Refused on the `system` pool.
+	Labels *map[string]string `json:"labels,omitempty"`
+
+	// Taints Replacement taint list. Replaces the existing list in full.
+	// Send `[]` to remove all taints. Refused on the `system` pool.
+	Taints *[]NodePoolTaint `json:"taints,omitempty"`
+}
+
 // Peering defines model for Peering.
 type Peering struct {
 	AllowForwardedTraffic bool               `json:"allow_forwarded_traffic"`
@@ -1308,6 +1900,20 @@ type Peering struct {
 
 	// Warning Present when `allow_forwarded_traffic` is true (no-op in M2).
 	Warning *string `json:"warning,omitempty"`
+}
+
+// PermissionsCheckRequest defines model for PermissionsCheckRequest.
+type PermissionsCheckRequest struct {
+	// Actions Action keys to evaluate at the scope, e.g. `compute/virtualMachines/write`.
+	Actions []string `json:"actions"`
+}
+
+// PermissionsCheckResponse defines model for PermissionsCheckResponse.
+type PermissionsCheckResponse struct {
+	Results []struct {
+		Action  string `json:"action"`
+		Allowed bool   `json:"allowed"`
+	} `json:"results"`
 }
 
 // PrivateEndpoint defines model for PrivateEndpoint.
@@ -1424,8 +2030,13 @@ type ResourceStatus string
 // RoleAssignment defines model for RoleAssignment.
 type RoleAssignment struct {
 	// DisplayAlias Admin-set mnemonic shown by cloud-ui instead of the opaque
-	// `principal_id`. Optional. No PII is sourced from the IdP —
-	// purely what the inviter typed when they added the principal.
+	// `principal_id`. Optional. No PII is **stored** from the IdP:
+	// email-based invites consult the directory provider live to
+	// resolve `user_email` → `sub`, but the only IdP-derived values
+	// persisted are the `sub` itself and — when the inviter supplies
+	// no alias — the invite email used as this field's default.
+	// Otherwise it is purely what the inviter typed when they added
+	// the principal.
 	DisplayAlias *string   `json:"display_alias,omitempty"`
 	GrantedAt    time.Time `json:"granted_at"`
 
@@ -1434,7 +2045,7 @@ type RoleAssignment struct {
 	// (legacy autoprovision path, default off in Option D),
 	// `member-invite:<inviter-sub>` (when the row was created
 	// implicitly by an admin invite), or a bare sub when
-	// granted explicitly via the members API.
+	// granted explicitly via the role-assignments API.
 	GrantedBy string `json:"granted_by"`
 
 	// Id UUID of the role_assignments row
@@ -1443,23 +2054,51 @@ type RoleAssignment struct {
 	// PrincipalId OIDC `sub` for users; service account UUID for SAs
 	PrincipalId   string                      `json:"principal_id"`
 	PrincipalType RoleAssignmentPrincipalType `json:"principal_type"`
-	Role          RoleAssignmentRole          `json:"role"`
 
-	// ScopeId Identifier of the scope (e.g. tenant slug)
+	// RoleDefinition RBAC v2 role-definition key (e.g. `Contributor`,
+	// `VirtualMachineContributor`). Resolve it to a display name via
+	// `GET /v1/role-definitions`.
+	RoleDefinition string `json:"role_definition"`
+
+	// ScopeId Identifier of the scope (tenant or project slug)
 	ScopeId string `json:"scope_id"`
 
-	// ScopeType Scope hierarchy level. Only `tenant` is active in M1.5.
+	// ScopeType Scope hierarchy level the role is granted at.
 	ScopeType RoleAssignmentScopeType `json:"scope_type"`
 }
 
 // RoleAssignmentPrincipalType defines model for RoleAssignment.PrincipalType.
 type RoleAssignmentPrincipalType string
 
-// RoleAssignmentRole defines model for RoleAssignment.Role.
-type RoleAssignmentRole string
-
-// RoleAssignmentScopeType Scope hierarchy level. Only `tenant` is active in M1.5.
+// RoleAssignmentScopeType Scope hierarchy level the role is granted at.
 type RoleAssignmentScopeType string
+
+// RoleDefinition A role definition: a named set of allow/deny action patterns, split
+// across the control plane (`actions` / `not_actions`) and the data plane
+// (`data_actions` / `not_data_actions`). Patterns may use the `*` wildcard.
+// `key` is the stable identifier a role assignment stores.
+type RoleDefinition struct {
+	// Actions Control-plane action patterns this role grants.
+	Actions []string `json:"actions"`
+
+	// Builtin True for the system catalog; false for tenant-owned custom roles.
+	Builtin bool `json:"builtin"`
+
+	// DataActions Data-plane action patterns (touching resource contents) this role grants.
+	DataActions *[]string `json:"data_actions,omitempty"`
+	Description string    `json:"description"`
+	DisplayName string    `json:"display_name"`
+
+	// Key Stable identifier — a reserved PascalCase name for built-ins
+	// (e.g. `VirtualMachineContributor`), or a UUID for custom roles.
+	Key string `json:"key"`
+
+	// NotActions Control-plane patterns subtracted from `actions` within this role.
+	NotActions *[]string `json:"not_actions,omitempty"`
+
+	// NotDataActions Data-plane patterns subtracted from `data_actions` within this role.
+	NotDataActions *[]string `json:"not_data_actions,omitempty"`
+}
 
 // RouteRule defines model for RouteRule.
 type RouteRule struct {
@@ -1526,6 +2165,26 @@ type ServiceAccount struct {
 // ServiceAccountRole defines model for ServiceAccount.Role.
 type ServiceAccountRole string
 
+// SharedResource A resource the caller can reach through a resource-scope grant, with
+// just enough for the UI to list it and deep-link to its detail page.
+type SharedResource struct {
+	Id openapi_types.UUID `json:"id"`
+
+	// Kind URL path segment for the resource's detail route.
+	Kind SharedResourceKind `json:"kind"`
+	Name string             `json:"name"`
+
+	// ProjectId Slug of the project the resource lives in.
+	ProjectId string `json:"project_id"`
+
+	// Roles Role-definition keys the caller holds on this resource.
+	Roles  []string `json:"roles"`
+	Status string   `json:"status"`
+}
+
+// SharedResourceKind URL path segment for the resource's detail route.
+type SharedResourceKind string
+
 // Subnet defines model for Subnet.
 type Subnet struct {
 	Cidr         string             `json:"cidr"`
@@ -1547,6 +2206,35 @@ type Subnet struct {
 	UpdatedAt time.Time          `json:"updated_at"`
 	VnetId    openapi_types.UUID `json:"vnet_id"`
 }
+
+// SystemPoolSpec Specification for the system node pool, supplied at cluster create time.
+// The system pool hosts the Kubernetes control-plane and etcd quorum.
+// User workloads do not schedule here by default (RKE2 applies
+// `node-role.kubernetes.io/control-plane:NoSchedule` and
+// `node-role.kubernetes.io/etcd:NoExecute` taints automatically).
+//
+// The pool name is always `system` — it is set by the server and must
+// not be provided in the request.
+type SystemPoolSpec struct {
+	// Count Number of system nodes. Must be `1`, `3`, or `5` (etcd quorum
+	// constraints). Use `1` for dev/test clusters; `3` or `5` for HA.
+	Count SystemPoolSpecCount `json:"count"`
+
+	// DiskGb Optional root disk override in GiB. Defaults to the size default
+	// (40 GiB for `small`/`medium`, 80 GiB for `large`, 160 GiB for
+	// `xlarge`). Minimum 40 GiB.
+	DiskGb *int `json:"disk_gb,omitempty"`
+
+	// Size Instance size for each system node
+	Size SystemPoolSpecSize `json:"size"`
+}
+
+// SystemPoolSpecCount Number of system nodes. Must be `1`, `3`, or `5` (etcd quorum
+// constraints). Use `1` for dev/test clusters; `3` or `5` for HA.
+type SystemPoolSpecCount int
+
+// SystemPoolSpecSize Instance size for each system node
+type SystemPoolSpecSize string
 
 // Tenant Full tenant record from the `tenants` registry. Returned by the
 // admin endpoints (`POST /v1/admin/tenants`, `GET /v1/tenants` admin
@@ -1716,11 +2404,20 @@ type BadRequest = Error
 // Conflict defines model for Conflict.
 type Conflict = Error
 
+// DirectoryNotConfigured defines model for DirectoryNotConfigured.
+type DirectoryNotConfigured = Error
+
+// DirectoryUpstreamError defines model for DirectoryUpstreamError.
+type DirectoryUpstreamError = Error
+
 // Forbidden defines model for Forbidden.
 type Forbidden = Error
 
 // InternalError defines model for InternalError.
 type InternalError = Error
+
+// InviteEmailUnprocessable defines model for InviteEmailUnprocessable.
+type InviteEmailUnprocessable = Error
 
 // NotFound defines model for NotFound.
 type NotFound = Error
@@ -1760,9 +2457,32 @@ type AuthLoginParams struct {
 	ReturnTo *string `form:"return_to,omitempty" json:"return_to,omitempty"`
 }
 
-// UpdateProjectQuota400JSONResponseBody1 defines parameters for UpdateProjectQuota.
-type UpdateProjectQuota400JSONResponseBody1 struct {
-	Error UpdateProjectQuota400JSONResponseBody1Error `json:"error"`
+// ListDirectoryGroupsParams defines parameters for ListDirectoryGroups.
+type ListDirectoryGroupsParams struct {
+	// Limit Maximum number of groups to return per page (SCIM2 `count` underneath).
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of groups to skip (SCIM2 `startIndex = offset + 1` underneath).
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// ListDirectoryUsersParams defines parameters for ListDirectoryUsers.
+type ListDirectoryUsersParams struct {
+	// Filter Optional case-insensitive substring matched against the user's
+	// email/username and display name (mapped to SCIM2 `co` filters
+	// underneath). Empty or omitted lists all users (paginated).
+	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
+
+	// Limit Maximum number of users to return per page (SCIM2 `count` underneath).
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of users to skip (SCIM2 `startIndex = offset + 1` underneath).
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// UpdateProjectQuota400JSONResponseBody2 defines parameters for UpdateProjectQuota.
+type UpdateProjectQuota400JSONResponseBody2 struct {
+	Error UpdateProjectQuota400JSONResponseBody2Error `json:"error"`
 
 	// InUse A capacity triplet — used in `QuotaExceededError` bodies for
 	// the `tenant_cap`, `allocated`, `available`, and `requested` fields.
@@ -1774,8 +2494,8 @@ type UpdateProjectQuota400JSONResponseBody1 struct {
 	Requested TenantCap `json:"requested"`
 }
 
-// UpdateProjectQuota400JSONResponseBody1Error defines parameters for UpdateProjectQuota.
-type UpdateProjectQuota400JSONResponseBody1Error string
+// UpdateProjectQuota400JSONResponseBody2Error defines parameters for UpdateProjectQuota.
+type UpdateProjectQuota400JSONResponseBody2Error string
 
 // UpdateProjectQuota400JSONResponseBody defines parameters for UpdateProjectQuota.
 type UpdateProjectQuota400JSONResponseBody struct {
@@ -1834,8 +2554,8 @@ type AdminUpdateTenantCapJSONRequestBody = UpdateTenantCapRequest
 // CreateImageJSONRequestBody defines body for CreateImage for application/json ContentType.
 type CreateImageJSONRequestBody = CreateImageRequest
 
-// InviteMemberJSONRequestBody defines body for InviteMember for application/json ContentType.
-type InviteMemberJSONRequestBody = InviteMemberRequest
+// CheckPermissionsJSONRequestBody defines body for CheckPermissions for application/json ContentType.
+type CheckPermissionsJSONRequestBody = PermissionsCheckRequest
 
 // CreateProjectJSONRequestBody defines body for CreateProject for application/json ContentType.
 type CreateProjectJSONRequestBody = CreateProjectRequest
@@ -1849,14 +2569,47 @@ type CreateBastionJSONRequestBody = CreateBastionRequest
 // CreateClusterJSONRequestBody defines body for CreateCluster for application/json ContentType.
 type CreateClusterJSONRequestBody = CreateClusterRequest
 
+// CreateNodePoolJSONRequestBody defines body for CreateNodePool for application/json ContentType.
+type CreateNodePoolJSONRequestBody = CreateNodePoolRequest
+
+// UpdateNodePoolJSONRequestBody defines body for UpdateNodePool for application/json ContentType.
+type UpdateNodePoolJSONRequestBody = PatchNodePoolRequest
+
+// CheckClusterPermissionsJSONRequestBody defines body for CheckClusterPermissions for application/json ContentType.
+type CheckClusterPermissionsJSONRequestBody = PermissionsCheckRequest
+
+// CreateClusterRoleAssignmentJSONRequestBody defines body for CreateClusterRoleAssignment for application/json ContentType.
+type CreateClusterRoleAssignmentJSONRequestBody = CreateRoleAssignmentRequest
+
+// CreateDatabaseJSONRequestBody defines body for CreateDatabase for application/json ContentType.
+type CreateDatabaseJSONRequestBody = CreateDatabaseRequest
+
+// CheckDatabasePermissionsJSONRequestBody defines body for CheckDatabasePermissions for application/json ContentType.
+type CheckDatabasePermissionsJSONRequestBody = PermissionsCheckRequest
+
+// CreateDatabaseRoleAssignmentJSONRequestBody defines body for CreateDatabaseRoleAssignment for application/json ContentType.
+type CreateDatabaseRoleAssignmentJSONRequestBody = CreateRoleAssignmentRequest
+
 // CreateKeyVaultJSONRequestBody defines body for CreateKeyVault for application/json ContentType.
 type CreateKeyVaultJSONRequestBody = CreateKeyVaultRequest
+
+// CheckKeyVaultPermissionsJSONRequestBody defines body for CheckKeyVaultPermissions for application/json ContentType.
+type CheckKeyVaultPermissionsJSONRequestBody = PermissionsCheckRequest
 
 // CreateKeyVaultPrivateEndpointJSONRequestBody defines body for CreateKeyVaultPrivateEndpoint for application/json ContentType.
 type CreateKeyVaultPrivateEndpointJSONRequestBody = CreatePrivateEndpointRequest
 
+// CreateKeyVaultRoleAssignmentJSONRequestBody defines body for CreateKeyVaultRoleAssignment for application/json ContentType.
+type CreateKeyVaultRoleAssignmentJSONRequestBody = CreateRoleAssignmentRequest
+
 // PutKeyVaultSecretJSONRequestBody defines body for PutKeyVaultSecret for application/json ContentType.
 type PutKeyVaultSecretJSONRequestBody = KeyVaultSecretCreateRequest
+
+// CheckProjectPermissionsJSONRequestBody defines body for CheckProjectPermissions for application/json ContentType.
+type CheckProjectPermissionsJSONRequestBody = PermissionsCheckRequest
+
+// CreateProjectRoleAssignmentJSONRequestBody defines body for CreateProjectRoleAssignment for application/json ContentType.
+type CreateProjectRoleAssignmentJSONRequestBody = CreateRoleAssignmentRequest
 
 // CreateSecurityGroupJSONRequestBody defines body for CreateSecurityGroup for application/json ContentType.
 type CreateSecurityGroupJSONRequestBody = CreateNSGRequest
@@ -1872,6 +2625,12 @@ type CreateServiceAccountJSONRequestBody = CreateServiceAccountRequest
 
 // CreateVirtualMachineJSONRequestBody defines body for CreateVirtualMachine for application/json ContentType.
 type CreateVirtualMachineJSONRequestBody = CreateVirtualMachineRequest
+
+// CheckVMPermissionsJSONRequestBody defines body for CheckVMPermissions for application/json ContentType.
+type CheckVMPermissionsJSONRequestBody = PermissionsCheckRequest
+
+// CreateVMRoleAssignmentJSONRequestBody defines body for CreateVMRoleAssignment for application/json ContentType.
+type CreateVMRoleAssignmentJSONRequestBody = CreateRoleAssignmentRequest
 
 // CreateVNetJSONRequestBody defines body for CreateVNet for application/json ContentType.
 type CreateVNetJSONRequestBody = CreateVNetRequest
@@ -1899,6 +2658,98 @@ type AssociateRouteTableJSONRequestBody AssociateRouteTableJSONBody
 
 // CreateSubnetJSONRequestBody defines body for CreateSubnet for application/json ContentType.
 type CreateSubnetJSONRequestBody = CreateSubnetRequest
+
+// CreateTenantRoleAssignmentJSONRequestBody defines body for CreateTenantRoleAssignment for application/json ContentType.
+type CreateTenantRoleAssignmentJSONRequestBody = CreateRoleAssignmentRequest
+
+// AsDatabaseNetworkVPC returns the union data inside the DatabaseNetworkSpec as a DatabaseNetworkVPC
+func (t DatabaseNetworkSpec) AsDatabaseNetworkVPC() (DatabaseNetworkVPC, error) {
+	var body DatabaseNetworkVPC
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDatabaseNetworkVPC overwrites any union data inside the DatabaseNetworkSpec as the provided DatabaseNetworkVPC
+func (t *DatabaseNetworkSpec) FromDatabaseNetworkVPC(v DatabaseNetworkVPC) error {
+	v.Mode = "vpc"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDatabaseNetworkVPC performs a merge with any union data inside the DatabaseNetworkSpec, using the provided DatabaseNetworkVPC
+func (t *DatabaseNetworkSpec) MergeDatabaseNetworkVPC(v DatabaseNetworkVPC) error {
+	v.Mode = "vpc"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDatabaseNetworkLegacy returns the union data inside the DatabaseNetworkSpec as a DatabaseNetworkLegacy
+func (t DatabaseNetworkSpec) AsDatabaseNetworkLegacy() (DatabaseNetworkLegacy, error) {
+	var body DatabaseNetworkLegacy
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDatabaseNetworkLegacy overwrites any union data inside the DatabaseNetworkSpec as the provided DatabaseNetworkLegacy
+func (t *DatabaseNetworkSpec) FromDatabaseNetworkLegacy(v DatabaseNetworkLegacy) error {
+	v.Mode = "legacy"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDatabaseNetworkLegacy performs a merge with any union data inside the DatabaseNetworkSpec, using the provided DatabaseNetworkLegacy
+func (t *DatabaseNetworkSpec) MergeDatabaseNetworkLegacy(v DatabaseNetworkLegacy) error {
+	v.Mode = "legacy"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t DatabaseNetworkSpec) Discriminator() (string, error) {
+	var discriminator struct {
+		Discriminator string `json:"mode"`
+	}
+	err := json.Unmarshal(t.union, &discriminator)
+	return discriminator.Discriminator, err
+}
+
+func (t DatabaseNetworkSpec) ValueByDiscriminator() (interface{}, error) {
+	discriminator, err := t.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+	switch discriminator {
+	case "legacy":
+		return t.AsDatabaseNetworkLegacy()
+	case "vpc":
+		return t.AsDatabaseNetworkVPC()
+	default:
+		return nil, errors.New("unknown discriminator value: " + discriminator)
+	}
+}
+
+func (t DatabaseNetworkSpec) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *DatabaseNetworkSpec) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
 
 // AsQuotaExceededError returns the union data inside the AdminUpdateTenantCap400JSONResponseBody as a QuotaExceededError
 func (t AdminUpdateTenantCap400JSONResponseBody) AsQuotaExceededError() (QuotaExceededError, error) {
@@ -1962,6 +2813,32 @@ func (t *AdminUpdateTenantCap400JSONResponseBody) UnmarshalJSON(b []byte) error 
 	return err
 }
 
+// AsError returns the union data inside the UpdateProjectQuota400JSONResponseBody as a Error
+func (t UpdateProjectQuota400JSONResponseBody) AsError() (Error, error) {
+	var body Error
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromError overwrites any union data inside the UpdateProjectQuota400JSONResponseBody as the provided Error
+func (t *UpdateProjectQuota400JSONResponseBody) FromError(v Error) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeError performs a merge with any union data inside the UpdateProjectQuota400JSONResponseBody, using the provided Error
+func (t *UpdateProjectQuota400JSONResponseBody) MergeError(v Error) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsQuotaExceededError returns the union data inside the UpdateProjectQuota400JSONResponseBody as a QuotaExceededError
 func (t UpdateProjectQuota400JSONResponseBody) AsQuotaExceededError() (QuotaExceededError, error) {
 	var body QuotaExceededError
@@ -1988,22 +2865,22 @@ func (t *UpdateProjectQuota400JSONResponseBody) MergeQuotaExceededError(v QuotaE
 	return err
 }
 
-// AsUpdateProjectQuota400JSONResponseBody1 returns the union data inside the UpdateProjectQuota400JSONResponseBody as a UpdateProjectQuota400JSONResponseBody1
-func (t UpdateProjectQuota400JSONResponseBody) AsUpdateProjectQuota400JSONResponseBody1() (UpdateProjectQuota400JSONResponseBody1, error) {
-	var body UpdateProjectQuota400JSONResponseBody1
+// AsUpdateProjectQuota400JSONResponseBody2 returns the union data inside the UpdateProjectQuota400JSONResponseBody as a UpdateProjectQuota400JSONResponseBody2
+func (t UpdateProjectQuota400JSONResponseBody) AsUpdateProjectQuota400JSONResponseBody2() (UpdateProjectQuota400JSONResponseBody2, error) {
+	var body UpdateProjectQuota400JSONResponseBody2
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromUpdateProjectQuota400JSONResponseBody1 overwrites any union data inside the UpdateProjectQuota400JSONResponseBody as the provided UpdateProjectQuota400JSONResponseBody1
-func (t *UpdateProjectQuota400JSONResponseBody) FromUpdateProjectQuota400JSONResponseBody1(v UpdateProjectQuota400JSONResponseBody1) error {
+// FromUpdateProjectQuota400JSONResponseBody2 overwrites any union data inside the UpdateProjectQuota400JSONResponseBody as the provided UpdateProjectQuota400JSONResponseBody2
+func (t *UpdateProjectQuota400JSONResponseBody) FromUpdateProjectQuota400JSONResponseBody2(v UpdateProjectQuota400JSONResponseBody2) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergeUpdateProjectQuota400JSONResponseBody1 performs a merge with any union data inside the UpdateProjectQuota400JSONResponseBody, using the provided UpdateProjectQuota400JSONResponseBody1
-func (t *UpdateProjectQuota400JSONResponseBody) MergeUpdateProjectQuota400JSONResponseBody1(v UpdateProjectQuota400JSONResponseBody1) error {
+// MergeUpdateProjectQuota400JSONResponseBody2 performs a merge with any union data inside the UpdateProjectQuota400JSONResponseBody, using the provided UpdateProjectQuota400JSONResponseBody2
+func (t *UpdateProjectQuota400JSONResponseBody) MergeUpdateProjectQuota400JSONResponseBody2(v UpdateProjectQuota400JSONResponseBody2) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -2122,11 +2999,23 @@ type ClientInterface interface {
 	// AuthMe request
 	AuthMe(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListRoleDefinitions request
+	ListRoleDefinitions(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRoleDefinition request
+	GetRoleDefinition(ctx context.Context, key string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListTenants request
 	ListTenants(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTenantCapUsage request
 	GetTenantCapUsage(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListDirectoryGroups request
+	ListDirectoryGroups(ctx context.Context, tenantId TenantID, params *ListDirectoryGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListDirectoryUsers request
+	ListDirectoryUsers(ctx context.Context, tenantId TenantID, params *ListDirectoryUsersParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListImages request
 	ListImages(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2136,19 +3025,13 @@ type ClientInterface interface {
 
 	CreateImage(ctx context.Context, tenantId TenantID, body CreateImageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListMembers request
-	ListMembers(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// InviteMemberWithBody request with any body
-	InviteMemberWithBody(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	InviteMember(ctx context.Context, tenantId TenantID, body InviteMemberJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// RemoveMember request
-	RemoveMember(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// ListNetworks request
 	ListNetworks(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CheckPermissionsWithBody request with any body
+	CheckPermissionsWithBody(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CheckPermissions(ctx context.Context, tenantId TenantID, body CheckPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListProjects request
 	ListProjects(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2200,6 +3083,74 @@ type ClientInterface interface {
 	// GetClusterKubeconfig request
 	GetClusterKubeconfig(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListNodePools request
+	ListNodePools(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateNodePoolWithBody request with any body
+	CreateNodePoolWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, body CreateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteNodePool request
+	DeleteNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetNodePool request
+	GetNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateNodePoolWithBody request with any body
+	UpdateNodePoolWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, body UpdateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CheckClusterPermissionsWithBody request with any body
+	CheckClusterPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CheckClusterPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckClusterPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListClusterRoleAssignments request
+	ListClusterRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateClusterRoleAssignmentWithBody request with any body
+	CreateClusterRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateClusterRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateClusterRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteClusterRoleAssignment request
+	DeleteClusterRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListDatabases request
+	ListDatabases(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateDatabaseWithBody request with any body
+	CreateDatabaseWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDatabase(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateDatabaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteDatabase request
+	DeleteDatabase(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDatabase request
+	GetDatabase(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDatabaseCredentials request
+	GetDatabaseCredentials(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CheckDatabasePermissionsWithBody request with any body
+	CheckDatabasePermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CheckDatabasePermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckDatabasePermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListDatabaseRoleAssignments request
+	ListDatabaseRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateDatabaseRoleAssignmentWithBody request with any body
+	CreateDatabaseRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDatabaseRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateDatabaseRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteDatabaseRoleAssignment request
+	DeleteDatabaseRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListKeyVaults request
 	ListKeyVaults(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2220,6 +3171,11 @@ type ClientInterface interface {
 	// RotateKeyVaultCredentials request
 	RotateKeyVaultCredentials(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// CheckKeyVaultPermissionsWithBody request with any body
+	CheckKeyVaultPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CheckKeyVaultPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckKeyVaultPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListKeyVaultPrivateEndpoints request
 	ListKeyVaultPrivateEndpoints(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2233,6 +3189,17 @@ type ClientInterface interface {
 
 	// GetKeyVaultPrivateEndpoint request
 	GetKeyVaultPrivateEndpoint(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, epId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListKeyVaultRoleAssignments request
+	ListKeyVaultRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateKeyVaultRoleAssignmentWithBody request with any body
+	CreateKeyVaultRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateKeyVaultRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateKeyVaultRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteKeyVaultRoleAssignment request
+	DeleteKeyVaultRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListKeyVaultSecrets request
 	ListKeyVaultSecrets(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, params *ListKeyVaultSecretsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2250,6 +3217,22 @@ type ClientInterface interface {
 
 	// RestoreKeyVaultSecret request
 	RestoreKeyVaultSecret(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, key string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CheckProjectPermissionsWithBody request with any body
+	CheckProjectPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CheckProjectPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, body CheckProjectPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProjectRoleAssignments request
+	ListProjectRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateProjectRoleAssignmentWithBody request with any body
+	CreateProjectRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateProjectRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateProjectRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectRoleAssignment request
+	DeleteProjectRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListSecurityGroups request
 	ListSecurityGroups(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2305,6 +3288,22 @@ type ClientInterface interface {
 
 	// GetVirtualMachine request
 	GetVirtualMachine(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CheckVMPermissionsWithBody request with any body
+	CheckVMPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CheckVMPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckVMPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListVMRoleAssignments request
+	ListVMRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateVMRoleAssignmentWithBody request with any body
+	CreateVMRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateVMRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateVMRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteVMRoleAssignment request
+	DeleteVMRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListVNets request
 	ListVNets(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2407,6 +3406,20 @@ type ClientInterface interface {
 
 	// GetSubnet request
 	GetSubnet(ctx context.Context, tenantId TenantID, projectId ProjectID, vnetId VNetID, subnetId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListTenantRoleAssignments request
+	ListTenantRoleAssignments(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateTenantRoleAssignmentWithBody request with any body
+	CreateTenantRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateTenantRoleAssignment(ctx context.Context, tenantId TenantID, body CreateTenantRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteTenantRoleAssignment request
+	DeleteTenantRoleAssignment(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListSharedResources request
+	ListSharedResources(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) GetHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -2517,6 +3530,30 @@ func (c *Client) AuthMe(ctx context.Context, reqEditors ...RequestEditorFn) (*ht
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListRoleDefinitions(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRoleDefinitionsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRoleDefinition(ctx context.Context, key string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRoleDefinitionRequest(c.Server, key)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListTenants(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListTenantsRequest(c.Server)
 	if err != nil {
@@ -2531,6 +3568,30 @@ func (c *Client) ListTenants(ctx context.Context, reqEditors ...RequestEditorFn)
 
 func (c *Client) GetTenantCapUsage(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetTenantCapUsageRequest(c.Server, tenantId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListDirectoryGroups(ctx context.Context, tenantId TenantID, params *ListDirectoryGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDirectoryGroupsRequest(c.Server, tenantId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListDirectoryUsers(ctx context.Context, tenantId TenantID, params *ListDirectoryUsersParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDirectoryUsersRequest(c.Server, tenantId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2577,56 +3638,32 @@ func (c *Client) CreateImage(ctx context.Context, tenantId TenantID, body Create
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListMembers(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListMembersRequest(c.Server, tenantId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) InviteMemberWithBody(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewInviteMemberRequestWithBody(c.Server, tenantId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) InviteMember(ctx context.Context, tenantId TenantID, body InviteMemberJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewInviteMemberRequest(c.Server, tenantId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) RemoveMember(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRemoveMemberRequest(c.Server, tenantId, principalId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) ListNetworks(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListNetworksRequest(c.Server, tenantId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckPermissionsWithBody(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckPermissionsRequestWithBody(c.Server, tenantId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckPermissions(ctx context.Context, tenantId TenantID, body CheckPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckPermissionsRequest(c.Server, tenantId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2853,6 +3890,306 @@ func (c *Client) GetClusterKubeconfig(ctx context.Context, tenantId TenantID, pr
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListNodePools(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListNodePoolsRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateNodePoolWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateNodePoolRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, body CreateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateNodePoolRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteNodePoolRequest(c.Server, tenantId, projectId, id, poolName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetNodePoolRequest(c.Server, tenantId, projectId, id, poolName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateNodePoolWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateNodePoolRequestWithBody(c.Server, tenantId, projectId, id, poolName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateNodePool(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, body UpdateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateNodePoolRequest(c.Server, tenantId, projectId, id, poolName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckClusterPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckClusterPermissionsRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckClusterPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckClusterPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckClusterPermissionsRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListClusterRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListClusterRoleAssignmentsRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateClusterRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateClusterRoleAssignmentRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateClusterRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateClusterRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateClusterRoleAssignmentRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteClusterRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteClusterRoleAssignmentRequest(c.Server, tenantId, projectId, id, principalId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListDatabases(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDatabasesRequest(c.Server, tenantId, projectId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDatabaseWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDatabaseRequestWithBody(c.Server, tenantId, projectId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDatabase(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateDatabaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDatabaseRequest(c.Server, tenantId, projectId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteDatabase(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteDatabaseRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDatabase(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDatabaseRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDatabaseCredentials(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDatabaseCredentialsRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckDatabasePermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckDatabasePermissionsRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckDatabasePermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckDatabasePermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckDatabasePermissionsRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListDatabaseRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDatabaseRoleAssignmentsRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDatabaseRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDatabaseRoleAssignmentRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDatabaseRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateDatabaseRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDatabaseRoleAssignmentRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteDatabaseRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteDatabaseRoleAssignmentRequest(c.Server, tenantId, projectId, id, principalId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListKeyVaults(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListKeyVaultsRequest(c.Server, tenantId, projectId)
 	if err != nil {
@@ -2937,6 +4274,30 @@ func (c *Client) RotateKeyVaultCredentials(ctx context.Context, tenantId TenantI
 	return c.Client.Do(req)
 }
 
+func (c *Client) CheckKeyVaultPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckKeyVaultPermissionsRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckKeyVaultPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckKeyVaultPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckKeyVaultPermissionsRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListKeyVaultPrivateEndpoints(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListKeyVaultPrivateEndpointsRequest(c.Server, tenantId, projectId, id)
 	if err != nil {
@@ -2987,6 +4348,54 @@ func (c *Client) DeleteKeyVaultPrivateEndpoint(ctx context.Context, tenantId Ten
 
 func (c *Client) GetKeyVaultPrivateEndpoint(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, epId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetKeyVaultPrivateEndpointRequest(c.Server, tenantId, projectId, id, epId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListKeyVaultRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListKeyVaultRoleAssignmentsRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateKeyVaultRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateKeyVaultRoleAssignmentRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateKeyVaultRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateKeyVaultRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateKeyVaultRoleAssignmentRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteKeyVaultRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteKeyVaultRoleAssignmentRequest(c.Server, tenantId, projectId, id, principalId)
 	if err != nil {
 		return nil, err
 	}
@@ -3059,6 +4468,78 @@ func (c *Client) PutKeyVaultSecret(ctx context.Context, tenantId TenantID, proje
 
 func (c *Client) RestoreKeyVaultSecret(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, key string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRestoreKeyVaultSecretRequest(c.Server, tenantId, projectId, id, key)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckProjectPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckProjectPermissionsRequestWithBody(c.Server, tenantId, projectId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckProjectPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, body CheckProjectPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckProjectPermissionsRequest(c.Server, tenantId, projectId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProjectRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProjectRoleAssignmentsRequest(c.Server, tenantId, projectId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectRoleAssignmentRequestWithBody(c.Server, tenantId, projectId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateProjectRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectRoleAssignmentRequest(c.Server, tenantId, projectId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectRoleAssignmentRequest(c.Server, tenantId, projectId, principalId)
 	if err != nil {
 		return nil, err
 	}
@@ -3299,6 +4780,78 @@ func (c *Client) DeleteVirtualMachine(ctx context.Context, tenantId TenantID, pr
 
 func (c *Client) GetVirtualMachine(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetVirtualMachineRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckVMPermissionsWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckVMPermissionsRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CheckVMPermissions(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckVMPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckVMPermissionsRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListVMRoleAssignments(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListVMRoleAssignmentsRequest(c.Server, tenantId, projectId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateVMRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateVMRoleAssignmentRequestWithBody(c.Server, tenantId, projectId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateVMRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateVMRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateVMRoleAssignmentRequest(c.Server, tenantId, projectId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteVMRoleAssignment(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteVMRoleAssignmentRequest(c.Server, tenantId, projectId, id, principalId)
 	if err != nil {
 		return nil, err
 	}
@@ -3753,6 +5306,66 @@ func (c *Client) GetSubnet(ctx context.Context, tenantId TenantID, projectId Pro
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListTenantRoleAssignments(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListTenantRoleAssignmentsRequest(c.Server, tenantId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateTenantRoleAssignmentWithBody(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateTenantRoleAssignmentRequestWithBody(c.Server, tenantId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateTenantRoleAssignment(ctx context.Context, tenantId TenantID, body CreateTenantRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateTenantRoleAssignmentRequest(c.Server, tenantId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteTenantRoleAssignment(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteTenantRoleAssignmentRequest(c.Server, tenantId, principalId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListSharedResources(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSharedResourcesRequest(c.Server, tenantId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // NewGetHealthRequest generates requests for GetHealth
 func NewGetHealthRequest(server string) (*http.Request, error) {
 	var err error
@@ -4033,6 +5646,67 @@ func NewAuthMeRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewListRoleDefinitionsRequest generates requests for ListRoleDefinitions
+func NewListRoleDefinitionsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/role-definitions")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRoleDefinitionRequest generates requests for GetRoleDefinition
+func NewGetRoleDefinitionRequest(server string, key string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "key", key, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/role-definitions/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListTenantsRequest generates requests for ListTenants
 func NewListTenantsRequest(server string) (*http.Request, error) {
 	var err error
@@ -4084,6 +5758,164 @@ func NewGetTenantCapUsageRequest(server string, tenantId TenantID) (*http.Reques
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListDirectoryGroupsRequest generates requests for ListDirectoryGroups
+func NewListDirectoryGroupsRequest(server string, tenantId TenantID, params *ListDirectoryGroupsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/directory/groups", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListDirectoryUsersRequest generates requests for ListDirectoryUsers
+func NewListDirectoryUsersRequest(server string, tenantId TenantID, params *ListDirectoryUsersParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/directory/users", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Filter != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "filter", *params.Filter, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
 	}
 
 	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
@@ -4175,128 +6007,6 @@ func NewCreateImageRequestWithBody(server string, tenantId TenantID, contentType
 	return req, nil
 }
 
-// NewListMembersRequest generates requests for ListMembers
-func NewListMembersRequest(server string, tenantId TenantID) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/tenants/%s/members", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewInviteMemberRequest calls the generic InviteMember builder with application/json body
-func NewInviteMemberRequest(server string, tenantId TenantID, body InviteMemberJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewInviteMemberRequestWithBody(server, tenantId, "application/json", bodyReader)
-}
-
-// NewInviteMemberRequestWithBody generates requests for InviteMember with any type of body
-func NewInviteMemberRequestWithBody(server string, tenantId TenantID, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/tenants/%s/members", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewRemoveMemberRequest generates requests for RemoveMember
-func NewRemoveMemberRequest(server string, tenantId TenantID, principalId string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "principal_id", principalId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/tenants/%s/members/%s", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
 // NewListNetworksRequest generates requests for ListNetworks
 func NewListNetworksRequest(server string, tenantId TenantID) (*http.Request, error) {
 	var err error
@@ -4327,6 +6037,53 @@ func NewListNetworksRequest(server string, tenantId TenantID) (*http.Request, er
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewCheckPermissionsRequest calls the generic CheckPermissions builder with application/json body
+func NewCheckPermissionsRequest(server string, tenantId TenantID, body CheckPermissionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCheckPermissionsRequestWithBody(server, tenantId, "application/json", bodyReader)
+}
+
+// NewCheckPermissionsRequestWithBody generates requests for CheckPermissions with any type of body
+func NewCheckPermissionsRequestWithBody(server string, tenantId TenantID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/permissions:check", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -4978,6 +6735,982 @@ func NewGetClusterKubeconfigRequest(server string, tenantId TenantID, projectId 
 	return req, nil
 }
 
+// NewListNodePoolsRequest generates requests for ListNodePools
+func NewListNodePoolsRequest(server string, tenantId TenantID, projectId ProjectID, id ResourceID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/node-pools", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateNodePoolRequest calls the generic CreateNodePool builder with application/json body
+func NewCreateNodePoolRequest(server string, tenantId TenantID, projectId ProjectID, id ResourceID, body CreateNodePoolJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateNodePoolRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCreateNodePoolRequestWithBody generates requests for CreateNodePool with any type of body
+func NewCreateNodePoolRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id ResourceID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/node-pools", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteNodePoolRequest generates requests for DeleteNodePool
+func NewDeleteNodePoolRequest(server string, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "pool_name", poolName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/node-pools/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetNodePoolRequest generates requests for GetNodePool
+func NewGetNodePoolRequest(server string, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "pool_name", poolName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/node-pools/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateNodePoolRequest calls the generic UpdateNodePool builder with application/json body
+func NewUpdateNodePoolRequest(server string, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, body UpdateNodePoolJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateNodePoolRequestWithBody(server, tenantId, projectId, id, poolName, "application/json", bodyReader)
+}
+
+// NewUpdateNodePoolRequestWithBody generates requests for UpdateNodePool with any type of body
+func NewUpdateNodePoolRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "pool_name", poolName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/node-pools/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCheckClusterPermissionsRequest calls the generic CheckClusterPermissions builder with application/json body
+func NewCheckClusterPermissionsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckClusterPermissionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCheckClusterPermissionsRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCheckClusterPermissionsRequestWithBody generates requests for CheckClusterPermissions with any type of body
+func NewCheckClusterPermissionsRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/permissions:check", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListClusterRoleAssignmentsRequest generates requests for ListClusterRoleAssignments
+func NewListClusterRoleAssignmentsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateClusterRoleAssignmentRequest calls the generic CreateClusterRoleAssignment builder with application/json body
+func NewCreateClusterRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateClusterRoleAssignmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateClusterRoleAssignmentRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCreateClusterRoleAssignmentRequestWithBody generates requests for CreateClusterRoleAssignment with any type of body
+func NewCreateClusterRoleAssignmentRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteClusterRoleAssignmentRequest generates requests for DeleteClusterRoleAssignment
+func NewDeleteClusterRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "principal_id", principalId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/clusters/%s/role-assignments/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListDatabasesRequest generates requests for ListDatabases
+func NewListDatabasesRequest(server string, tenantId TenantID, projectId ProjectID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateDatabaseRequest calls the generic CreateDatabase builder with application/json body
+func NewCreateDatabaseRequest(server string, tenantId TenantID, projectId ProjectID, body CreateDatabaseJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDatabaseRequestWithBody(server, tenantId, projectId, "application/json", bodyReader)
+}
+
+// NewCreateDatabaseRequestWithBody generates requests for CreateDatabase with any type of body
+func NewCreateDatabaseRequestWithBody(server string, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteDatabaseRequest generates requests for DeleteDatabase
+func NewDeleteDatabaseRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases/%s", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetDatabaseRequest generates requests for GetDatabase
+func NewGetDatabaseRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases/%s", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetDatabaseCredentialsRequest generates requests for GetDatabaseCredentials
+func NewGetDatabaseCredentialsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases/%s/credentials", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCheckDatabasePermissionsRequest calls the generic CheckDatabasePermissions builder with application/json body
+func NewCheckDatabasePermissionsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckDatabasePermissionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCheckDatabasePermissionsRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCheckDatabasePermissionsRequestWithBody generates requests for CheckDatabasePermissions with any type of body
+func NewCheckDatabasePermissionsRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases/%s/permissions:check", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListDatabaseRoleAssignmentsRequest generates requests for ListDatabaseRoleAssignments
+func NewListDatabaseRoleAssignmentsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateDatabaseRoleAssignmentRequest calls the generic CreateDatabaseRoleAssignment builder with application/json body
+func NewCreateDatabaseRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateDatabaseRoleAssignmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDatabaseRoleAssignmentRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCreateDatabaseRoleAssignmentRequestWithBody generates requests for CreateDatabaseRoleAssignment with any type of body
+func NewCreateDatabaseRoleAssignmentRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteDatabaseRoleAssignmentRequest generates requests for DeleteDatabaseRoleAssignment
+func NewDeleteDatabaseRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "principal_id", principalId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/databases/%s/role-assignments/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListKeyVaultsRequest generates requests for ListKeyVaults
 func NewListKeyVaultsRequest(server string, tenantId TenantID, projectId ProjectID) (*http.Request, error) {
 	var err error
@@ -5265,6 +7998,67 @@ func NewRotateKeyVaultCredentialsRequest(server string, tenantId TenantID, proje
 	return req, nil
 }
 
+// NewCheckKeyVaultPermissionsRequest calls the generic CheckKeyVaultPermissions builder with application/json body
+func NewCheckKeyVaultPermissionsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckKeyVaultPermissionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCheckKeyVaultPermissionsRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCheckKeyVaultPermissionsRequestWithBody generates requests for CheckKeyVaultPermissions with any type of body
+func NewCheckKeyVaultPermissionsRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/keyvaults/%s/permissions:check", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListKeyVaultPrivateEndpointsRequest generates requests for ListKeyVaultPrivateEndpoints
 func NewListKeyVaultPrivateEndpointsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
 	var err error
@@ -5477,6 +8271,170 @@ func NewGetKeyVaultPrivateEndpointRequest(server string, tenantId TenantID, proj
 	}
 
 	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListKeyVaultRoleAssignmentsRequest generates requests for ListKeyVaultRoleAssignments
+func NewListKeyVaultRoleAssignmentsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/keyvaults/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateKeyVaultRoleAssignmentRequest calls the generic CreateKeyVaultRoleAssignment builder with application/json body
+func NewCreateKeyVaultRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateKeyVaultRoleAssignmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateKeyVaultRoleAssignmentRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCreateKeyVaultRoleAssignmentRequestWithBody generates requests for CreateKeyVaultRoleAssignment with any type of body
+func NewCreateKeyVaultRoleAssignmentRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/keyvaults/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteKeyVaultRoleAssignmentRequest generates requests for DeleteKeyVaultRoleAssignment
+func NewDeleteKeyVaultRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "principal_id", principalId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/keyvaults/%s/role-assignments/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -5824,6 +8782,203 @@ func NewRestoreKeyVaultSecretRequest(server string, tenantId TenantID, projectId
 	}
 
 	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCheckProjectPermissionsRequest calls the generic CheckProjectPermissions builder with application/json body
+func NewCheckProjectPermissionsRequest(server string, tenantId TenantID, projectId ProjectID, body CheckProjectPermissionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCheckProjectPermissionsRequestWithBody(server, tenantId, projectId, "application/json", bodyReader)
+}
+
+// NewCheckProjectPermissionsRequestWithBody generates requests for CheckProjectPermissions with any type of body
+func NewCheckProjectPermissionsRequestWithBody(server string, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/permissions:check", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListProjectRoleAssignmentsRequest generates requests for ListProjectRoleAssignments
+func NewListProjectRoleAssignmentsRequest(server string, tenantId TenantID, projectId ProjectID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/role-assignments", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateProjectRoleAssignmentRequest calls the generic CreateProjectRoleAssignment builder with application/json body
+func NewCreateProjectRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, body CreateProjectRoleAssignmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateProjectRoleAssignmentRequestWithBody(server, tenantId, projectId, "application/json", bodyReader)
+}
+
+// NewCreateProjectRoleAssignmentRequestWithBody generates requests for CreateProjectRoleAssignment with any type of body
+func NewCreateProjectRoleAssignmentRequestWithBody(server string, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/role-assignments", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectRoleAssignmentRequest generates requests for DeleteProjectRoleAssignment
+func NewDeleteProjectRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, principalId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "principal_id", principalId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/role-assignments/%s", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -6574,6 +9729,231 @@ func NewGetVirtualMachineRequest(server string, tenantId TenantID, projectId Pro
 	}
 
 	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCheckVMPermissionsRequest calls the generic CheckVMPermissions builder with application/json body
+func NewCheckVMPermissionsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckVMPermissionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCheckVMPermissionsRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCheckVMPermissionsRequestWithBody generates requests for CheckVMPermissions with any type of body
+func NewCheckVMPermissionsRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/virtual-machines/%s/permissions:check", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListVMRoleAssignmentsRequest generates requests for ListVMRoleAssignments
+func NewListVMRoleAssignmentsRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/virtual-machines/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateVMRoleAssignmentRequest calls the generic CreateVMRoleAssignment builder with application/json body
+func NewCreateVMRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateVMRoleAssignmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateVMRoleAssignmentRequestWithBody(server, tenantId, projectId, id, "application/json", bodyReader)
+}
+
+// NewCreateVMRoleAssignmentRequestWithBody generates requests for CreateVMRoleAssignment with any type of body
+func NewCreateVMRoleAssignmentRequestWithBody(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/virtual-machines/%s/role-assignments", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteVMRoleAssignmentRequest generates requests for DeleteVMRoleAssignment
+func NewDeleteVMRoleAssignmentRequest(server string, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "principal_id", principalId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/virtual-machines/%s/role-assignments/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -8168,6 +11548,162 @@ func NewGetSubnetRequest(server string, tenantId TenantID, projectId ProjectID, 
 	return req, nil
 }
 
+// NewListTenantRoleAssignmentsRequest generates requests for ListTenantRoleAssignments
+func NewListTenantRoleAssignmentsRequest(server string, tenantId TenantID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/role-assignments", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateTenantRoleAssignmentRequest calls the generic CreateTenantRoleAssignment builder with application/json body
+func NewCreateTenantRoleAssignmentRequest(server string, tenantId TenantID, body CreateTenantRoleAssignmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateTenantRoleAssignmentRequestWithBody(server, tenantId, "application/json", bodyReader)
+}
+
+// NewCreateTenantRoleAssignmentRequestWithBody generates requests for CreateTenantRoleAssignment with any type of body
+func NewCreateTenantRoleAssignmentRequestWithBody(server string, tenantId TenantID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/role-assignments", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteTenantRoleAssignmentRequest generates requests for DeleteTenantRoleAssignment
+func NewDeleteTenantRoleAssignmentRequest(server string, tenantId TenantID, principalId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "principal_id", principalId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/role-assignments/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListSharedResourcesRequest generates requests for ListSharedResources
+func NewListSharedResourcesRequest(server string, tenantId TenantID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/shared-resources", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -8236,11 +11772,23 @@ type ClientWithResponsesInterface interface {
 	// AuthMeWithResponse request
 	AuthMeWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AuthMeResp, error)
 
+	// ListRoleDefinitionsWithResponse request
+	ListRoleDefinitionsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListRoleDefinitionsResp, error)
+
+	// GetRoleDefinitionWithResponse request
+	GetRoleDefinitionWithResponse(ctx context.Context, key string, reqEditors ...RequestEditorFn) (*GetRoleDefinitionResp, error)
+
 	// ListTenantsWithResponse request
 	ListTenantsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListTenantsResp, error)
 
 	// GetTenantCapUsageWithResponse request
 	GetTenantCapUsageWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*GetTenantCapUsageResp, error)
+
+	// ListDirectoryGroupsWithResponse request
+	ListDirectoryGroupsWithResponse(ctx context.Context, tenantId TenantID, params *ListDirectoryGroupsParams, reqEditors ...RequestEditorFn) (*ListDirectoryGroupsResp, error)
+
+	// ListDirectoryUsersWithResponse request
+	ListDirectoryUsersWithResponse(ctx context.Context, tenantId TenantID, params *ListDirectoryUsersParams, reqEditors ...RequestEditorFn) (*ListDirectoryUsersResp, error)
 
 	// ListImagesWithResponse request
 	ListImagesWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListImagesResp, error)
@@ -8250,19 +11798,13 @@ type ClientWithResponsesInterface interface {
 
 	CreateImageWithResponse(ctx context.Context, tenantId TenantID, body CreateImageJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateImageResp, error)
 
-	// ListMembersWithResponse request
-	ListMembersWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListMembersResp, error)
-
-	// InviteMemberWithBodyWithResponse request with any body
-	InviteMemberWithBodyWithResponse(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InviteMemberResp, error)
-
-	InviteMemberWithResponse(ctx context.Context, tenantId TenantID, body InviteMemberJSONRequestBody, reqEditors ...RequestEditorFn) (*InviteMemberResp, error)
-
-	// RemoveMemberWithResponse request
-	RemoveMemberWithResponse(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*RemoveMemberResp, error)
-
 	// ListNetworksWithResponse request
 	ListNetworksWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListNetworksResp, error)
+
+	// CheckPermissionsWithBodyWithResponse request with any body
+	CheckPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckPermissionsResp, error)
+
+	CheckPermissionsWithResponse(ctx context.Context, tenantId TenantID, body CheckPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckPermissionsResp, error)
 
 	// ListProjectsWithResponse request
 	ListProjectsWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListProjectsResp, error)
@@ -8314,6 +11856,74 @@ type ClientWithResponsesInterface interface {
 	// GetClusterKubeconfigWithResponse request
 	GetClusterKubeconfigWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*GetClusterKubeconfigResp, error)
 
+	// ListNodePoolsWithResponse request
+	ListNodePoolsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*ListNodePoolsResp, error)
+
+	// CreateNodePoolWithBodyWithResponse request with any body
+	CreateNodePoolWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNodePoolResp, error)
+
+	CreateNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, body CreateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNodePoolResp, error)
+
+	// DeleteNodePoolWithResponse request
+	DeleteNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*DeleteNodePoolResp, error)
+
+	// GetNodePoolWithResponse request
+	GetNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*GetNodePoolResp, error)
+
+	// UpdateNodePoolWithBodyWithResponse request with any body
+	UpdateNodePoolWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateNodePoolResp, error)
+
+	UpdateNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, body UpdateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateNodePoolResp, error)
+
+	// CheckClusterPermissionsWithBodyWithResponse request with any body
+	CheckClusterPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckClusterPermissionsResp, error)
+
+	CheckClusterPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckClusterPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckClusterPermissionsResp, error)
+
+	// ListClusterRoleAssignmentsWithResponse request
+	ListClusterRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListClusterRoleAssignmentsResp, error)
+
+	// CreateClusterRoleAssignmentWithBodyWithResponse request with any body
+	CreateClusterRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateClusterRoleAssignmentResp, error)
+
+	CreateClusterRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateClusterRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateClusterRoleAssignmentResp, error)
+
+	// DeleteClusterRoleAssignmentWithResponse request
+	DeleteClusterRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteClusterRoleAssignmentResp, error)
+
+	// ListDatabasesWithResponse request
+	ListDatabasesWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListDatabasesResp, error)
+
+	// CreateDatabaseWithBodyWithResponse request with any body
+	CreateDatabaseWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDatabaseResp, error)
+
+	CreateDatabaseWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateDatabaseJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDatabaseResp, error)
+
+	// DeleteDatabaseWithResponse request
+	DeleteDatabaseWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteDatabaseResp, error)
+
+	// GetDatabaseWithResponse request
+	GetDatabaseWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetDatabaseResp, error)
+
+	// GetDatabaseCredentialsWithResponse request
+	GetDatabaseCredentialsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetDatabaseCredentialsResp, error)
+
+	// CheckDatabasePermissionsWithBodyWithResponse request with any body
+	CheckDatabasePermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckDatabasePermissionsResp, error)
+
+	CheckDatabasePermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckDatabasePermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckDatabasePermissionsResp, error)
+
+	// ListDatabaseRoleAssignmentsWithResponse request
+	ListDatabaseRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListDatabaseRoleAssignmentsResp, error)
+
+	// CreateDatabaseRoleAssignmentWithBodyWithResponse request with any body
+	CreateDatabaseRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDatabaseRoleAssignmentResp, error)
+
+	CreateDatabaseRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateDatabaseRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDatabaseRoleAssignmentResp, error)
+
+	// DeleteDatabaseRoleAssignmentWithResponse request
+	DeleteDatabaseRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteDatabaseRoleAssignmentResp, error)
+
 	// ListKeyVaultsWithResponse request
 	ListKeyVaultsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListKeyVaultsResp, error)
 
@@ -8334,6 +11944,11 @@ type ClientWithResponsesInterface interface {
 	// RotateKeyVaultCredentialsWithResponse request
 	RotateKeyVaultCredentialsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*RotateKeyVaultCredentialsResp, error)
 
+	// CheckKeyVaultPermissionsWithBodyWithResponse request with any body
+	CheckKeyVaultPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckKeyVaultPermissionsResp, error)
+
+	CheckKeyVaultPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckKeyVaultPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckKeyVaultPermissionsResp, error)
+
 	// ListKeyVaultPrivateEndpointsWithResponse request
 	ListKeyVaultPrivateEndpointsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListKeyVaultPrivateEndpointsResp, error)
 
@@ -8347,6 +11962,17 @@ type ClientWithResponsesInterface interface {
 
 	// GetKeyVaultPrivateEndpointWithResponse request
 	GetKeyVaultPrivateEndpointWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, epId openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetKeyVaultPrivateEndpointResp, error)
+
+	// ListKeyVaultRoleAssignmentsWithResponse request
+	ListKeyVaultRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListKeyVaultRoleAssignmentsResp, error)
+
+	// CreateKeyVaultRoleAssignmentWithBodyWithResponse request with any body
+	CreateKeyVaultRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateKeyVaultRoleAssignmentResp, error)
+
+	CreateKeyVaultRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateKeyVaultRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateKeyVaultRoleAssignmentResp, error)
+
+	// DeleteKeyVaultRoleAssignmentWithResponse request
+	DeleteKeyVaultRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteKeyVaultRoleAssignmentResp, error)
 
 	// ListKeyVaultSecretsWithResponse request
 	ListKeyVaultSecretsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, params *ListKeyVaultSecretsParams, reqEditors ...RequestEditorFn) (*ListKeyVaultSecretsResp, error)
@@ -8364,6 +11990,22 @@ type ClientWithResponsesInterface interface {
 
 	// RestoreKeyVaultSecretWithResponse request
 	RestoreKeyVaultSecretWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, key string, reqEditors ...RequestEditorFn) (*RestoreKeyVaultSecretResp, error)
+
+	// CheckProjectPermissionsWithBodyWithResponse request with any body
+	CheckProjectPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckProjectPermissionsResp, error)
+
+	CheckProjectPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, body CheckProjectPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckProjectPermissionsResp, error)
+
+	// ListProjectRoleAssignmentsWithResponse request
+	ListProjectRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListProjectRoleAssignmentsResp, error)
+
+	// CreateProjectRoleAssignmentWithBodyWithResponse request with any body
+	CreateProjectRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectRoleAssignmentResp, error)
+
+	CreateProjectRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateProjectRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectRoleAssignmentResp, error)
+
+	// DeleteProjectRoleAssignmentWithResponse request
+	DeleteProjectRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, principalId string, reqEditors ...RequestEditorFn) (*DeleteProjectRoleAssignmentResp, error)
 
 	// ListSecurityGroupsWithResponse request
 	ListSecurityGroupsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListSecurityGroupsResp, error)
@@ -8419,6 +12061,22 @@ type ClientWithResponsesInterface interface {
 
 	// GetVirtualMachineWithResponse request
 	GetVirtualMachineWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*GetVirtualMachineResp, error)
+
+	// CheckVMPermissionsWithBodyWithResponse request with any body
+	CheckVMPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckVMPermissionsResp, error)
+
+	CheckVMPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckVMPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckVMPermissionsResp, error)
+
+	// ListVMRoleAssignmentsWithResponse request
+	ListVMRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListVMRoleAssignmentsResp, error)
+
+	// CreateVMRoleAssignmentWithBodyWithResponse request with any body
+	CreateVMRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateVMRoleAssignmentResp, error)
+
+	CreateVMRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateVMRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateVMRoleAssignmentResp, error)
+
+	// DeleteVMRoleAssignmentWithResponse request
+	DeleteVMRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteVMRoleAssignmentResp, error)
 
 	// ListVNetsWithResponse request
 	ListVNetsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListVNetsResp, error)
@@ -8521,6 +12179,20 @@ type ClientWithResponsesInterface interface {
 
 	// GetSubnetWithResponse request
 	GetSubnetWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, vnetId VNetID, subnetId openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetSubnetResp, error)
+
+	// ListTenantRoleAssignmentsWithResponse request
+	ListTenantRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListTenantRoleAssignmentsResp, error)
+
+	// CreateTenantRoleAssignmentWithBodyWithResponse request with any body
+	CreateTenantRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateTenantRoleAssignmentResp, error)
+
+	CreateTenantRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, body CreateTenantRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateTenantRoleAssignmentResp, error)
+
+	// DeleteTenantRoleAssignmentWithResponse request
+	DeleteTenantRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*DeleteTenantRoleAssignmentResp, error)
+
+	// ListSharedResourcesWithResponse request
+	ListSharedResourcesWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListSharedResourcesResp, error)
 }
 
 type GetHealthResp struct {
@@ -8744,6 +12416,73 @@ func (r AuthMeResp) ContentType() string {
 	return ""
 }
 
+type ListRoleDefinitionsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		RoleDefinitions []RoleDefinition `json:"role_definitions"`
+	}
+	JSON401 *Unauthorized
+	JSON500 *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListRoleDefinitionsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListRoleDefinitionsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListRoleDefinitionsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetRoleDefinitionResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RoleDefinition
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRoleDefinitionResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRoleDefinitionResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetRoleDefinitionResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListTenantsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -8792,6 +12531,7 @@ type GetTenantCapUsageResp struct {
 		// the `tenant_cap`, `allocated`, `available`, and `requested` fields.
 		Cap TenantCap `json:"cap"`
 	}
+	JSON400 *BadRequest
 	JSON401 *Unauthorized
 	JSON404 *NotFound
 	JSON500 *InternalError
@@ -8815,6 +12555,80 @@ func (r GetTenantCapUsageResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetTenantCapUsageResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListDirectoryGroupsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DirectoryGroupList
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+	JSON501      *DirectoryNotConfigured
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListDirectoryGroupsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListDirectoryGroupsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListDirectoryGroupsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListDirectoryUsersResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DirectoryUserList
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+	JSON501      *DirectoryNotConfigured
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListDirectoryUsersResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListDirectoryUsersResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListDirectoryUsersResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -8886,116 +12700,11 @@ func (r CreateImageResp) ContentType() string {
 	return ""
 }
 
-type ListMembersResp struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		Members *[]RoleAssignment `json:"members,omitempty"`
-	}
-	JSON401 *Unauthorized
-	JSON404 *NotFound
-	JSON500 *InternalError
-}
-
-// Status returns HTTPResponse.Status
-func (r ListMembersResp) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r ListMembersResp) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r ListMembersResp) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type InviteMemberResp struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON201      *RoleAssignment
-	JSON400      *BadRequest
-	JSON401      *Unauthorized
-	JSON403      *Forbidden
-	JSON404      *NotFound
-	JSON409      *Conflict
-	JSON500      *InternalError
-}
-
-// Status returns HTTPResponse.Status
-func (r InviteMemberResp) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r InviteMemberResp) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r InviteMemberResp) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type RemoveMemberResp struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON400      *BadRequest
-	JSON401      *Unauthorized
-	JSON403      *Forbidden
-	JSON404      *NotFound
-	JSON409      *Error
-	JSON500      *InternalError
-}
-
-// Status returns HTTPResponse.Status
-func (r RemoveMemberResp) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r RemoveMemberResp) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r RemoveMemberResp) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
 type ListNetworksResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]Network
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON500      *InternalError
 }
@@ -9024,10 +12733,45 @@ func (r ListNetworksResp) ContentType() string {
 	return ""
 }
 
+type CheckPermissionsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PermissionsCheckResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CheckPermissionsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CheckPermissionsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CheckPermissionsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListProjectsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]Project
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON404      *NotFound
 	JSON500      *InternalError
@@ -9064,6 +12808,7 @@ type CreateProjectResp struct {
 	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON409      *Conflict
 	JSON500      *InternalError
 }
@@ -9095,6 +12840,7 @@ func (r CreateProjectResp) ContentType() string {
 type DeleteProjectResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
@@ -9130,6 +12876,7 @@ type GetProjectResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *Project
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON404      *NotFound
 	JSON500      *InternalError
@@ -9492,11 +13239,635 @@ func (r GetClusterKubeconfigResp) ContentType() string {
 	return ""
 }
 
+type ListNodePoolsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]NodePool
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListNodePoolsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListNodePoolsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListNodePoolsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateNodePoolResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *NodePool
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON409      *Error
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateNodePoolResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateNodePoolResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateNodePoolResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteNodePoolResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *Error
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteNodePoolResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteNodePoolResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteNodePoolResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetNodePoolResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *NodePool
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetNodePoolResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetNodePoolResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetNodePoolResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateNodePoolResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *NodePool
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON409      *Error
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateNodePoolResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateNodePoolResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateNodePoolResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CheckClusterPermissionsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PermissionsCheckResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CheckClusterPermissionsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CheckClusterPermissionsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CheckClusterPermissionsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListClusterRoleAssignmentsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+	}
+	JSON400 *BadRequest
+	JSON401 *Unauthorized
+	JSON404 *NotFound
+	JSON500 *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListClusterRoleAssignmentsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListClusterRoleAssignmentsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListClusterRoleAssignmentsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateClusterRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RoleAssignment
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON422      *InviteEmailUnprocessable
+	JSON500      *InternalError
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateClusterRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateClusterRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateClusterRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteClusterRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteClusterRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteClusterRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteClusterRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListDatabasesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]Database
+	JSON401      *Unauthorized
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListDatabasesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListDatabasesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListDatabasesResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateDatabaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *Database
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON409      *Conflict
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDatabaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDatabaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateDatabaseResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteDatabaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteDatabaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteDatabaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteDatabaseResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetDatabaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Database
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDatabaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDatabaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetDatabaseResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetDatabaseCredentialsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DatabaseCredentials
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Error
+	JSON410      *Error
+	JSON500      *InternalError
+	JSON501      *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDatabaseCredentialsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDatabaseCredentialsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetDatabaseCredentialsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CheckDatabasePermissionsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PermissionsCheckResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CheckDatabasePermissionsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CheckDatabasePermissionsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CheckDatabasePermissionsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListDatabaseRoleAssignmentsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+	}
+	JSON400 *BadRequest
+	JSON401 *Unauthorized
+	JSON404 *NotFound
+	JSON500 *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListDatabaseRoleAssignmentsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListDatabaseRoleAssignmentsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListDatabaseRoleAssignmentsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateDatabaseRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RoleAssignment
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON422      *InviteEmailUnprocessable
+	JSON500      *InternalError
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDatabaseRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDatabaseRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateDatabaseRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteDatabaseRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteDatabaseRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteDatabaseRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteDatabaseRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListKeyVaultsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]KeyVault
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
+	JSON404      *NotFound
 	JSON500      *InternalError
 }
 
@@ -9531,6 +13902,7 @@ type CreateKeyVaultResp struct {
 	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON409      *Conflict
 	JSON500      *InternalError
 }
@@ -9562,6 +13934,7 @@ func (r CreateKeyVaultResp) ContentType() string {
 type DeleteKeyVaultResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
@@ -9596,6 +13969,7 @@ type GetKeyVaultResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *KeyVault
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON404      *NotFound
 	JSON500      *InternalError
@@ -9629,6 +14003,7 @@ type GetKeyVaultCredentialsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *KeyVaultCredentials
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
@@ -9666,6 +14041,7 @@ type RotateKeyVaultCredentialsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *KeyVaultCredentials
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
@@ -9699,10 +14075,45 @@ func (r RotateKeyVaultCredentialsResp) ContentType() string {
 	return ""
 }
 
+type CheckKeyVaultPermissionsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PermissionsCheckResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CheckKeyVaultPermissionsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CheckKeyVaultPermissionsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CheckKeyVaultPermissionsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListKeyVaultPrivateEndpointsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]PrivateEndpoint
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON404      *NotFound
 	JSON500      *InternalError
@@ -9771,6 +14182,7 @@ func (r CreateKeyVaultPrivateEndpointResp) ContentType() string {
 type DeleteKeyVaultPrivateEndpointResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON403      *Forbidden
 	JSON404      *NotFound
@@ -9805,6 +14217,7 @@ type GetKeyVaultPrivateEndpointResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *PrivateEndpoint
+	JSON400      *BadRequest
 	JSON401      *Unauthorized
 	JSON404      *NotFound
 	JSON500      *InternalError
@@ -9828,6 +14241,114 @@ func (r GetKeyVaultPrivateEndpointResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetKeyVaultPrivateEndpointResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListKeyVaultRoleAssignmentsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+	}
+	JSON400 *BadRequest
+	JSON401 *Unauthorized
+	JSON404 *NotFound
+	JSON500 *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListKeyVaultRoleAssignmentsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListKeyVaultRoleAssignmentsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListKeyVaultRoleAssignmentsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateKeyVaultRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RoleAssignment
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON422      *InviteEmailUnprocessable
+	JSON500      *InternalError
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateKeyVaultRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateKeyVaultRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateKeyVaultRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteKeyVaultRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteKeyVaultRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteKeyVaultRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteKeyVaultRoleAssignmentResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -10011,6 +14532,148 @@ func (r RestoreKeyVaultSecretResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r RestoreKeyVaultSecretResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CheckProjectPermissionsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PermissionsCheckResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CheckProjectPermissionsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CheckProjectPermissionsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CheckProjectPermissionsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListProjectRoleAssignmentsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+	}
+	JSON400 *BadRequest
+	JSON401 *Unauthorized
+	JSON404 *NotFound
+	JSON500 *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProjectRoleAssignmentsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProjectRoleAssignmentsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProjectRoleAssignmentsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateProjectRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RoleAssignment
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON422      *InviteEmailUnprocessable
+	JSON500      *InternalError
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateProjectRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateProjectRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateProjectRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteProjectRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteProjectRoleAssignmentResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -10265,6 +14928,7 @@ type ListServiceAccountsResp struct {
 	JSON200      *struct {
 		ServiceAccounts *[]ServiceAccount `json:"service_accounts,omitempty"`
 	}
+	JSON400 *BadRequest
 	JSON401 *Unauthorized
 	JSON404 *NotFound
 	JSON500 *InternalError
@@ -10526,6 +15190,148 @@ func (r GetVirtualMachineResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetVirtualMachineResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CheckVMPermissionsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PermissionsCheckResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CheckVMPermissionsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CheckVMPermissionsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CheckVMPermissionsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListVMRoleAssignmentsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+	}
+	JSON400 *BadRequest
+	JSON401 *Unauthorized
+	JSON404 *NotFound
+	JSON500 *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListVMRoleAssignmentsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListVMRoleAssignmentsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListVMRoleAssignmentsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateVMRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RoleAssignment
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON422      *InviteEmailUnprocessable
+	JSON500      *InternalError
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateVMRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateVMRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateVMRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteVMRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteVMRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteVMRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteVMRoleAssignmentResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -11493,6 +16299,149 @@ func (r GetSubnetResp) ContentType() string {
 	return ""
 }
 
+type ListTenantRoleAssignmentsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+	}
+	JSON400 *BadRequest
+	JSON401 *Unauthorized
+	JSON404 *NotFound
+	JSON500 *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListTenantRoleAssignmentsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListTenantRoleAssignmentsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListTenantRoleAssignmentsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateTenantRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RoleAssignment
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON422      *InviteEmailUnprocessable
+	JSON500      *InternalError
+	JSON502      *DirectoryUpstreamError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateTenantRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateTenantRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateTenantRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteTenantRoleAssignmentResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Error
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteTenantRoleAssignmentResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteTenantRoleAssignmentResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteTenantRoleAssignmentResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListSharedResourcesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]SharedResource
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListSharedResourcesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListSharedResourcesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListSharedResourcesResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 // GetHealthWithResponse request returning *GetHealthResp
 func (c *ClientWithResponses) GetHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetHealthResp, error) {
 	rsp, err := c.GetHealth(ctx, reqEditors...)
@@ -11572,6 +16521,24 @@ func (c *ClientWithResponses) AuthMeWithResponse(ctx context.Context, reqEditors
 	return ParseAuthMeResp(rsp)
 }
 
+// ListRoleDefinitionsWithResponse request returning *ListRoleDefinitionsResp
+func (c *ClientWithResponses) ListRoleDefinitionsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListRoleDefinitionsResp, error) {
+	rsp, err := c.ListRoleDefinitions(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRoleDefinitionsResp(rsp)
+}
+
+// GetRoleDefinitionWithResponse request returning *GetRoleDefinitionResp
+func (c *ClientWithResponses) GetRoleDefinitionWithResponse(ctx context.Context, key string, reqEditors ...RequestEditorFn) (*GetRoleDefinitionResp, error) {
+	rsp, err := c.GetRoleDefinition(ctx, key, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRoleDefinitionResp(rsp)
+}
+
 // ListTenantsWithResponse request returning *ListTenantsResp
 func (c *ClientWithResponses) ListTenantsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListTenantsResp, error) {
 	rsp, err := c.ListTenants(ctx, reqEditors...)
@@ -11588,6 +16555,24 @@ func (c *ClientWithResponses) GetTenantCapUsageWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseGetTenantCapUsageResp(rsp)
+}
+
+// ListDirectoryGroupsWithResponse request returning *ListDirectoryGroupsResp
+func (c *ClientWithResponses) ListDirectoryGroupsWithResponse(ctx context.Context, tenantId TenantID, params *ListDirectoryGroupsParams, reqEditors ...RequestEditorFn) (*ListDirectoryGroupsResp, error) {
+	rsp, err := c.ListDirectoryGroups(ctx, tenantId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDirectoryGroupsResp(rsp)
+}
+
+// ListDirectoryUsersWithResponse request returning *ListDirectoryUsersResp
+func (c *ClientWithResponses) ListDirectoryUsersWithResponse(ctx context.Context, tenantId TenantID, params *ListDirectoryUsersParams, reqEditors ...RequestEditorFn) (*ListDirectoryUsersResp, error) {
+	rsp, err := c.ListDirectoryUsers(ctx, tenantId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDirectoryUsersResp(rsp)
 }
 
 // ListImagesWithResponse request returning *ListImagesResp
@@ -11616,41 +16601,6 @@ func (c *ClientWithResponses) CreateImageWithResponse(ctx context.Context, tenan
 	return ParseCreateImageResp(rsp)
 }
 
-// ListMembersWithResponse request returning *ListMembersResp
-func (c *ClientWithResponses) ListMembersWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListMembersResp, error) {
-	rsp, err := c.ListMembers(ctx, tenantId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListMembersResp(rsp)
-}
-
-// InviteMemberWithBodyWithResponse request with arbitrary body returning *InviteMemberResp
-func (c *ClientWithResponses) InviteMemberWithBodyWithResponse(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InviteMemberResp, error) {
-	rsp, err := c.InviteMemberWithBody(ctx, tenantId, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseInviteMemberResp(rsp)
-}
-
-func (c *ClientWithResponses) InviteMemberWithResponse(ctx context.Context, tenantId TenantID, body InviteMemberJSONRequestBody, reqEditors ...RequestEditorFn) (*InviteMemberResp, error) {
-	rsp, err := c.InviteMember(ctx, tenantId, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseInviteMemberResp(rsp)
-}
-
-// RemoveMemberWithResponse request returning *RemoveMemberResp
-func (c *ClientWithResponses) RemoveMemberWithResponse(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*RemoveMemberResp, error) {
-	rsp, err := c.RemoveMember(ctx, tenantId, principalId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseRemoveMemberResp(rsp)
-}
-
 // ListNetworksWithResponse request returning *ListNetworksResp
 func (c *ClientWithResponses) ListNetworksWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListNetworksResp, error) {
 	rsp, err := c.ListNetworks(ctx, tenantId, reqEditors...)
@@ -11658,6 +16608,23 @@ func (c *ClientWithResponses) ListNetworksWithResponse(ctx context.Context, tena
 		return nil, err
 	}
 	return ParseListNetworksResp(rsp)
+}
+
+// CheckPermissionsWithBodyWithResponse request with arbitrary body returning *CheckPermissionsResp
+func (c *ClientWithResponses) CheckPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckPermissionsResp, error) {
+	rsp, err := c.CheckPermissionsWithBody(ctx, tenantId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckPermissionsResp(rsp)
+}
+
+func (c *ClientWithResponses) CheckPermissionsWithResponse(ctx context.Context, tenantId TenantID, body CheckPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckPermissionsResp, error) {
+	rsp, err := c.CheckPermissions(ctx, tenantId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckPermissionsResp(rsp)
 }
 
 // ListProjectsWithResponse request returning *ListProjectsResp
@@ -11818,6 +16785,224 @@ func (c *ClientWithResponses) GetClusterKubeconfigWithResponse(ctx context.Conte
 	return ParseGetClusterKubeconfigResp(rsp)
 }
 
+// ListNodePoolsWithResponse request returning *ListNodePoolsResp
+func (c *ClientWithResponses) ListNodePoolsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, reqEditors ...RequestEditorFn) (*ListNodePoolsResp, error) {
+	rsp, err := c.ListNodePools(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListNodePoolsResp(rsp)
+}
+
+// CreateNodePoolWithBodyWithResponse request with arbitrary body returning *CreateNodePoolResp
+func (c *ClientWithResponses) CreateNodePoolWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNodePoolResp, error) {
+	rsp, err := c.CreateNodePoolWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateNodePoolResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, body CreateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNodePoolResp, error) {
+	rsp, err := c.CreateNodePool(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateNodePoolResp(rsp)
+}
+
+// DeleteNodePoolWithResponse request returning *DeleteNodePoolResp
+func (c *ClientWithResponses) DeleteNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*DeleteNodePoolResp, error) {
+	rsp, err := c.DeleteNodePool(ctx, tenantId, projectId, id, poolName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteNodePoolResp(rsp)
+}
+
+// GetNodePoolWithResponse request returning *GetNodePoolResp
+func (c *ClientWithResponses) GetNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, reqEditors ...RequestEditorFn) (*GetNodePoolResp, error) {
+	rsp, err := c.GetNodePool(ctx, tenantId, projectId, id, poolName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetNodePoolResp(rsp)
+}
+
+// UpdateNodePoolWithBodyWithResponse request with arbitrary body returning *UpdateNodePoolResp
+func (c *ClientWithResponses) UpdateNodePoolWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateNodePoolResp, error) {
+	rsp, err := c.UpdateNodePoolWithBody(ctx, tenantId, projectId, id, poolName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateNodePoolResp(rsp)
+}
+
+func (c *ClientWithResponses) UpdateNodePoolWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id ResourceID, poolName string, body UpdateNodePoolJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateNodePoolResp, error) {
+	rsp, err := c.UpdateNodePool(ctx, tenantId, projectId, id, poolName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateNodePoolResp(rsp)
+}
+
+// CheckClusterPermissionsWithBodyWithResponse request with arbitrary body returning *CheckClusterPermissionsResp
+func (c *ClientWithResponses) CheckClusterPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckClusterPermissionsResp, error) {
+	rsp, err := c.CheckClusterPermissionsWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckClusterPermissionsResp(rsp)
+}
+
+func (c *ClientWithResponses) CheckClusterPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckClusterPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckClusterPermissionsResp, error) {
+	rsp, err := c.CheckClusterPermissions(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckClusterPermissionsResp(rsp)
+}
+
+// ListClusterRoleAssignmentsWithResponse request returning *ListClusterRoleAssignmentsResp
+func (c *ClientWithResponses) ListClusterRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListClusterRoleAssignmentsResp, error) {
+	rsp, err := c.ListClusterRoleAssignments(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListClusterRoleAssignmentsResp(rsp)
+}
+
+// CreateClusterRoleAssignmentWithBodyWithResponse request with arbitrary body returning *CreateClusterRoleAssignmentResp
+func (c *ClientWithResponses) CreateClusterRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateClusterRoleAssignmentResp, error) {
+	rsp, err := c.CreateClusterRoleAssignmentWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateClusterRoleAssignmentResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateClusterRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateClusterRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateClusterRoleAssignmentResp, error) {
+	rsp, err := c.CreateClusterRoleAssignment(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateClusterRoleAssignmentResp(rsp)
+}
+
+// DeleteClusterRoleAssignmentWithResponse request returning *DeleteClusterRoleAssignmentResp
+func (c *ClientWithResponses) DeleteClusterRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteClusterRoleAssignmentResp, error) {
+	rsp, err := c.DeleteClusterRoleAssignment(ctx, tenantId, projectId, id, principalId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteClusterRoleAssignmentResp(rsp)
+}
+
+// ListDatabasesWithResponse request returning *ListDatabasesResp
+func (c *ClientWithResponses) ListDatabasesWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListDatabasesResp, error) {
+	rsp, err := c.ListDatabases(ctx, tenantId, projectId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDatabasesResp(rsp)
+}
+
+// CreateDatabaseWithBodyWithResponse request with arbitrary body returning *CreateDatabaseResp
+func (c *ClientWithResponses) CreateDatabaseWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDatabaseResp, error) {
+	rsp, err := c.CreateDatabaseWithBody(ctx, tenantId, projectId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDatabaseResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateDatabaseWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateDatabaseJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDatabaseResp, error) {
+	rsp, err := c.CreateDatabase(ctx, tenantId, projectId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDatabaseResp(rsp)
+}
+
+// DeleteDatabaseWithResponse request returning *DeleteDatabaseResp
+func (c *ClientWithResponses) DeleteDatabaseWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteDatabaseResp, error) {
+	rsp, err := c.DeleteDatabase(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteDatabaseResp(rsp)
+}
+
+// GetDatabaseWithResponse request returning *GetDatabaseResp
+func (c *ClientWithResponses) GetDatabaseWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetDatabaseResp, error) {
+	rsp, err := c.GetDatabase(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDatabaseResp(rsp)
+}
+
+// GetDatabaseCredentialsWithResponse request returning *GetDatabaseCredentialsResp
+func (c *ClientWithResponses) GetDatabaseCredentialsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetDatabaseCredentialsResp, error) {
+	rsp, err := c.GetDatabaseCredentials(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDatabaseCredentialsResp(rsp)
+}
+
+// CheckDatabasePermissionsWithBodyWithResponse request with arbitrary body returning *CheckDatabasePermissionsResp
+func (c *ClientWithResponses) CheckDatabasePermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckDatabasePermissionsResp, error) {
+	rsp, err := c.CheckDatabasePermissionsWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckDatabasePermissionsResp(rsp)
+}
+
+func (c *ClientWithResponses) CheckDatabasePermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckDatabasePermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckDatabasePermissionsResp, error) {
+	rsp, err := c.CheckDatabasePermissions(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckDatabasePermissionsResp(rsp)
+}
+
+// ListDatabaseRoleAssignmentsWithResponse request returning *ListDatabaseRoleAssignmentsResp
+func (c *ClientWithResponses) ListDatabaseRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListDatabaseRoleAssignmentsResp, error) {
+	rsp, err := c.ListDatabaseRoleAssignments(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDatabaseRoleAssignmentsResp(rsp)
+}
+
+// CreateDatabaseRoleAssignmentWithBodyWithResponse request with arbitrary body returning *CreateDatabaseRoleAssignmentResp
+func (c *ClientWithResponses) CreateDatabaseRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDatabaseRoleAssignmentResp, error) {
+	rsp, err := c.CreateDatabaseRoleAssignmentWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDatabaseRoleAssignmentResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateDatabaseRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateDatabaseRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDatabaseRoleAssignmentResp, error) {
+	rsp, err := c.CreateDatabaseRoleAssignment(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDatabaseRoleAssignmentResp(rsp)
+}
+
+// DeleteDatabaseRoleAssignmentWithResponse request returning *DeleteDatabaseRoleAssignmentResp
+func (c *ClientWithResponses) DeleteDatabaseRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteDatabaseRoleAssignmentResp, error) {
+	rsp, err := c.DeleteDatabaseRoleAssignment(ctx, tenantId, projectId, id, principalId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteDatabaseRoleAssignmentResp(rsp)
+}
+
 // ListKeyVaultsWithResponse request returning *ListKeyVaultsResp
 func (c *ClientWithResponses) ListKeyVaultsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListKeyVaultsResp, error) {
 	rsp, err := c.ListKeyVaults(ctx, tenantId, projectId, reqEditors...)
@@ -11880,6 +17065,23 @@ func (c *ClientWithResponses) RotateKeyVaultCredentialsWithResponse(ctx context.
 	return ParseRotateKeyVaultCredentialsResp(rsp)
 }
 
+// CheckKeyVaultPermissionsWithBodyWithResponse request with arbitrary body returning *CheckKeyVaultPermissionsResp
+func (c *ClientWithResponses) CheckKeyVaultPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckKeyVaultPermissionsResp, error) {
+	rsp, err := c.CheckKeyVaultPermissionsWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckKeyVaultPermissionsResp(rsp)
+}
+
+func (c *ClientWithResponses) CheckKeyVaultPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckKeyVaultPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckKeyVaultPermissionsResp, error) {
+	rsp, err := c.CheckKeyVaultPermissions(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckKeyVaultPermissionsResp(rsp)
+}
+
 // ListKeyVaultPrivateEndpointsWithResponse request returning *ListKeyVaultPrivateEndpointsResp
 func (c *ClientWithResponses) ListKeyVaultPrivateEndpointsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListKeyVaultPrivateEndpointsResp, error) {
 	rsp, err := c.ListKeyVaultPrivateEndpoints(ctx, tenantId, projectId, id, reqEditors...)
@@ -11922,6 +17124,41 @@ func (c *ClientWithResponses) GetKeyVaultPrivateEndpointWithResponse(ctx context
 		return nil, err
 	}
 	return ParseGetKeyVaultPrivateEndpointResp(rsp)
+}
+
+// ListKeyVaultRoleAssignmentsWithResponse request returning *ListKeyVaultRoleAssignmentsResp
+func (c *ClientWithResponses) ListKeyVaultRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListKeyVaultRoleAssignmentsResp, error) {
+	rsp, err := c.ListKeyVaultRoleAssignments(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListKeyVaultRoleAssignmentsResp(rsp)
+}
+
+// CreateKeyVaultRoleAssignmentWithBodyWithResponse request with arbitrary body returning *CreateKeyVaultRoleAssignmentResp
+func (c *ClientWithResponses) CreateKeyVaultRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateKeyVaultRoleAssignmentResp, error) {
+	rsp, err := c.CreateKeyVaultRoleAssignmentWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateKeyVaultRoleAssignmentResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateKeyVaultRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateKeyVaultRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateKeyVaultRoleAssignmentResp, error) {
+	rsp, err := c.CreateKeyVaultRoleAssignment(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateKeyVaultRoleAssignmentResp(rsp)
+}
+
+// DeleteKeyVaultRoleAssignmentWithResponse request returning *DeleteKeyVaultRoleAssignmentResp
+func (c *ClientWithResponses) DeleteKeyVaultRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteKeyVaultRoleAssignmentResp, error) {
+	rsp, err := c.DeleteKeyVaultRoleAssignment(ctx, tenantId, projectId, id, principalId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteKeyVaultRoleAssignmentResp(rsp)
 }
 
 // ListKeyVaultSecretsWithResponse request returning *ListKeyVaultSecretsResp
@@ -11975,6 +17212,58 @@ func (c *ClientWithResponses) RestoreKeyVaultSecretWithResponse(ctx context.Cont
 		return nil, err
 	}
 	return ParseRestoreKeyVaultSecretResp(rsp)
+}
+
+// CheckProjectPermissionsWithBodyWithResponse request with arbitrary body returning *CheckProjectPermissionsResp
+func (c *ClientWithResponses) CheckProjectPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckProjectPermissionsResp, error) {
+	rsp, err := c.CheckProjectPermissionsWithBody(ctx, tenantId, projectId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckProjectPermissionsResp(rsp)
+}
+
+func (c *ClientWithResponses) CheckProjectPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, body CheckProjectPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckProjectPermissionsResp, error) {
+	rsp, err := c.CheckProjectPermissions(ctx, tenantId, projectId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckProjectPermissionsResp(rsp)
+}
+
+// ListProjectRoleAssignmentsWithResponse request returning *ListProjectRoleAssignmentsResp
+func (c *ClientWithResponses) ListProjectRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListProjectRoleAssignmentsResp, error) {
+	rsp, err := c.ListProjectRoleAssignments(ctx, tenantId, projectId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProjectRoleAssignmentsResp(rsp)
+}
+
+// CreateProjectRoleAssignmentWithBodyWithResponse request with arbitrary body returning *CreateProjectRoleAssignmentResp
+func (c *ClientWithResponses) CreateProjectRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectRoleAssignmentResp, error) {
+	rsp, err := c.CreateProjectRoleAssignmentWithBody(ctx, tenantId, projectId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectRoleAssignmentResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateProjectRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, body CreateProjectRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectRoleAssignmentResp, error) {
+	rsp, err := c.CreateProjectRoleAssignment(ctx, tenantId, projectId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectRoleAssignmentResp(rsp)
+}
+
+// DeleteProjectRoleAssignmentWithResponse request returning *DeleteProjectRoleAssignmentResp
+func (c *ClientWithResponses) DeleteProjectRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, principalId string, reqEditors ...RequestEditorFn) (*DeleteProjectRoleAssignmentResp, error) {
+	rsp, err := c.DeleteProjectRoleAssignment(ctx, tenantId, projectId, principalId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectRoleAssignmentResp(rsp)
 }
 
 // ListSecurityGroupsWithResponse request returning *ListSecurityGroupsResp
@@ -12150,6 +17439,58 @@ func (c *ClientWithResponses) GetVirtualMachineWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseGetVirtualMachineResp(rsp)
+}
+
+// CheckVMPermissionsWithBodyWithResponse request with arbitrary body returning *CheckVMPermissionsResp
+func (c *ClientWithResponses) CheckVMPermissionsWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckVMPermissionsResp, error) {
+	rsp, err := c.CheckVMPermissionsWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckVMPermissionsResp(rsp)
+}
+
+func (c *ClientWithResponses) CheckVMPermissionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CheckVMPermissionsJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckVMPermissionsResp, error) {
+	rsp, err := c.CheckVMPermissions(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckVMPermissionsResp(rsp)
+}
+
+// ListVMRoleAssignmentsWithResponse request returning *ListVMRoleAssignmentsResp
+func (c *ClientWithResponses) ListVMRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ListVMRoleAssignmentsResp, error) {
+	rsp, err := c.ListVMRoleAssignments(ctx, tenantId, projectId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListVMRoleAssignmentsResp(rsp)
+}
+
+// CreateVMRoleAssignmentWithBodyWithResponse request with arbitrary body returning *CreateVMRoleAssignmentResp
+func (c *ClientWithResponses) CreateVMRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateVMRoleAssignmentResp, error) {
+	rsp, err := c.CreateVMRoleAssignmentWithBody(ctx, tenantId, projectId, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateVMRoleAssignmentResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateVMRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, body CreateVMRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateVMRoleAssignmentResp, error) {
+	rsp, err := c.CreateVMRoleAssignment(ctx, tenantId, projectId, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateVMRoleAssignmentResp(rsp)
+}
+
+// DeleteVMRoleAssignmentWithResponse request returning *DeleteVMRoleAssignmentResp
+func (c *ClientWithResponses) DeleteVMRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, id openapi_types.UUID, principalId string, reqEditors ...RequestEditorFn) (*DeleteVMRoleAssignmentResp, error) {
+	rsp, err := c.DeleteVMRoleAssignment(ctx, tenantId, projectId, id, principalId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteVMRoleAssignmentResp(rsp)
 }
 
 // ListVNetsWithResponse request returning *ListVNetsResp
@@ -12476,6 +17817,50 @@ func (c *ClientWithResponses) GetSubnetWithResponse(ctx context.Context, tenantI
 	return ParseGetSubnetResp(rsp)
 }
 
+// ListTenantRoleAssignmentsWithResponse request returning *ListTenantRoleAssignmentsResp
+func (c *ClientWithResponses) ListTenantRoleAssignmentsWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListTenantRoleAssignmentsResp, error) {
+	rsp, err := c.ListTenantRoleAssignments(ctx, tenantId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListTenantRoleAssignmentsResp(rsp)
+}
+
+// CreateTenantRoleAssignmentWithBodyWithResponse request with arbitrary body returning *CreateTenantRoleAssignmentResp
+func (c *ClientWithResponses) CreateTenantRoleAssignmentWithBodyWithResponse(ctx context.Context, tenantId TenantID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateTenantRoleAssignmentResp, error) {
+	rsp, err := c.CreateTenantRoleAssignmentWithBody(ctx, tenantId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateTenantRoleAssignmentResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateTenantRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, body CreateTenantRoleAssignmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateTenantRoleAssignmentResp, error) {
+	rsp, err := c.CreateTenantRoleAssignment(ctx, tenantId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateTenantRoleAssignmentResp(rsp)
+}
+
+// DeleteTenantRoleAssignmentWithResponse request returning *DeleteTenantRoleAssignmentResp
+func (c *ClientWithResponses) DeleteTenantRoleAssignmentWithResponse(ctx context.Context, tenantId TenantID, principalId string, reqEditors ...RequestEditorFn) (*DeleteTenantRoleAssignmentResp, error) {
+	rsp, err := c.DeleteTenantRoleAssignment(ctx, tenantId, principalId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteTenantRoleAssignmentResp(rsp)
+}
+
+// ListSharedResourcesWithResponse request returning *ListSharedResourcesResp
+func (c *ClientWithResponses) ListSharedResourcesWithResponse(ctx context.Context, tenantId TenantID, reqEditors ...RequestEditorFn) (*ListSharedResourcesResp, error) {
+	rsp, err := c.ListSharedResources(ctx, tenantId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListSharedResourcesResp(rsp)
+}
+
 // ParseGetHealthResp parses an HTTP response from a GetHealthWithResponse call
 func ParseGetHealthResp(rsp *http.Response) (*GetHealthResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -12720,6 +18105,95 @@ func ParseAuthMeResp(rsp *http.Response) (*AuthMeResp, error) {
 	return response, nil
 }
 
+// ParseListRoleDefinitionsResp parses an HTTP response from a ListRoleDefinitionsWithResponse call
+func ParseListRoleDefinitionsResp(rsp *http.Response) (*ListRoleDefinitionsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListRoleDefinitionsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			RoleDefinitions []RoleDefinition `json:"role_definitions"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRoleDefinitionResp parses an HTTP response from a GetRoleDefinitionWithResponse call
+func ParseGetRoleDefinitionResp(rsp *http.Response) (*GetRoleDefinitionResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRoleDefinitionResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RoleDefinition
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListTenantsResp parses an HTTP response from a ListTenantsWithResponse call
 func ParseListTenantsResp(rsp *http.Response) (*ListTenantsResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -12793,6 +18267,13 @@ func ParseGetTenantCapUsageResp(rsp *http.Response) (*GetTenantCapUsageResp, err
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -12813,6 +18294,156 @@ func ParseGetTenantCapUsageResp(rsp *http.Response) (*GetTenantCapUsageResp, err
 			return nil, err
 		}
 		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListDirectoryGroupsResp parses an HTTP response from a ListDirectoryGroupsWithResponse call
+func ParseListDirectoryGroupsResp(rsp *http.Response) (*ListDirectoryGroupsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDirectoryGroupsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DirectoryGroupList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest DirectoryNotConfigured
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListDirectoryUsersResp parses an HTTP response from a ListDirectoryUsersWithResponse call
+func ParseListDirectoryUsersResp(rsp *http.Response) (*ListDirectoryUsersResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDirectoryUsersResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DirectoryUserList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest DirectoryNotConfigured
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
 
 	}
 
@@ -12906,184 +18537,6 @@ func ParseCreateImageResp(rsp *http.Response) (*CreateImageResp, error) {
 	return response, nil
 }
 
-// ParseListMembersResp parses an HTTP response from a ListMembersWithResponse call
-func ParseListMembersResp(rsp *http.Response) (*ListMembersResp, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &ListMembersResp{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			Members *[]RoleAssignment `json:"members,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest Unauthorized
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFound
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseInviteMemberResp parses an HTTP response from a InviteMemberWithResponse call
-func ParseInviteMemberResp(rsp *http.Response) (*InviteMemberResp, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &InviteMemberResp{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest RoleAssignment
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON201 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest BadRequest
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest Unauthorized
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
-		var dest Forbidden
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON403 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFound
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
-		var dest Conflict
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON409 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseRemoveMemberResp parses an HTTP response from a RemoveMemberWithResponse call
-func ParseRemoveMemberResp(rsp *http.Response) (*RemoveMemberResp, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &RemoveMemberResp{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest BadRequest
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest Unauthorized
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
-		var dest Forbidden
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON403 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFound
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON409 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseListNetworksResp parses an HTTP response from a ListNetworksWithResponse call
 func ParseListNetworksResp(rsp *http.Response) (*ListNetworksResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -13105,12 +18558,73 @@ func ParseListNetworksResp(rsp *http.Response) (*ListNetworksResp, error) {
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCheckPermissionsResp parses an HTTP response from a CheckPermissionsWithResponse call
+func ParseCheckPermissionsResp(rsp *http.Response) (*CheckPermissionsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CheckPermissionsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PermissionsCheckResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -13144,6 +18658,13 @@ func ParseListProjectsResp(rsp *http.Response) (*ListProjectsResp, error) {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
@@ -13213,6 +18734,13 @@ func ParseCreateProjectResp(rsp *http.Response) (*CreateProjectResp, error) {
 		}
 		response.JSON403 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
 		var dest Conflict
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -13246,6 +18774,13 @@ func ParseDeleteProjectResp(rsp *http.Response) (*DeleteProjectResp, error) {
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -13306,6 +18841,13 @@ func ParseGetProjectResp(rsp *http.Response) (*GetProjectResp, error) {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
@@ -13824,6 +19366,1024 @@ func ParseGetClusterKubeconfigResp(rsp *http.Response) (*GetClusterKubeconfigRes
 	return response, nil
 }
 
+// ParseListNodePoolsResp parses an HTTP response from a ListNodePoolsWithResponse call
+func ParseListNodePoolsResp(rsp *http.Response) (*ListNodePoolsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListNodePoolsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []NodePool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateNodePoolResp parses an HTTP response from a CreateNodePoolWithResponse call
+func ParseCreateNodePoolResp(rsp *http.Response) (*CreateNodePoolResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateNodePoolResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest NodePool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteNodePoolResp parses an HTTP response from a DeleteNodePoolWithResponse call
+func ParseDeleteNodePoolResp(rsp *http.Response) (*DeleteNodePoolResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteNodePoolResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetNodePoolResp parses an HTTP response from a GetNodePoolWithResponse call
+func ParseGetNodePoolResp(rsp *http.Response) (*GetNodePoolResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetNodePoolResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest NodePool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateNodePoolResp parses an HTTP response from a UpdateNodePoolWithResponse call
+func ParseUpdateNodePoolResp(rsp *http.Response) (*UpdateNodePoolResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateNodePoolResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest NodePool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCheckClusterPermissionsResp parses an HTTP response from a CheckClusterPermissionsWithResponse call
+func ParseCheckClusterPermissionsResp(rsp *http.Response) (*CheckClusterPermissionsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CheckClusterPermissionsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PermissionsCheckResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListClusterRoleAssignmentsResp parses an HTTP response from a ListClusterRoleAssignmentsWithResponse call
+func ParseListClusterRoleAssignmentsResp(rsp *http.Response) (*ListClusterRoleAssignmentsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListClusterRoleAssignmentsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateClusterRoleAssignmentResp parses an HTTP response from a CreateClusterRoleAssignmentWithResponse call
+func ParseCreateClusterRoleAssignmentResp(rsp *http.Response) (*CreateClusterRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateClusterRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RoleAssignment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest InviteEmailUnprocessable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteClusterRoleAssignmentResp parses an HTTP response from a DeleteClusterRoleAssignmentWithResponse call
+func ParseDeleteClusterRoleAssignmentResp(rsp *http.Response) (*DeleteClusterRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteClusterRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListDatabasesResp parses an HTTP response from a ListDatabasesWithResponse call
+func ParseListDatabasesResp(rsp *http.Response) (*ListDatabasesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDatabasesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []Database
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateDatabaseResp parses an HTTP response from a CreateDatabaseWithResponse call
+func ParseCreateDatabaseResp(rsp *http.Response) (*CreateDatabaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDatabaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest Database
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteDatabaseResp parses an HTTP response from a DeleteDatabaseWithResponse call
+func ParseDeleteDatabaseResp(rsp *http.Response) (*DeleteDatabaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteDatabaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDatabaseResp parses an HTTP response from a GetDatabaseWithResponse call
+func ParseGetDatabaseResp(rsp *http.Response) (*GetDatabaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDatabaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Database
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDatabaseCredentialsResp parses an HTTP response from a GetDatabaseCredentialsWithResponse call
+func ParseGetDatabaseCredentialsResp(rsp *http.Response) (*GetDatabaseCredentialsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDatabaseCredentialsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DatabaseCredentials
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 410:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON410 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCheckDatabasePermissionsResp parses an HTTP response from a CheckDatabasePermissionsWithResponse call
+func ParseCheckDatabasePermissionsResp(rsp *http.Response) (*CheckDatabasePermissionsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CheckDatabasePermissionsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PermissionsCheckResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListDatabaseRoleAssignmentsResp parses an HTTP response from a ListDatabaseRoleAssignmentsWithResponse call
+func ParseListDatabaseRoleAssignmentsResp(rsp *http.Response) (*ListDatabaseRoleAssignmentsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDatabaseRoleAssignmentsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateDatabaseRoleAssignmentResp parses an HTTP response from a CreateDatabaseRoleAssignmentWithResponse call
+func ParseCreateDatabaseRoleAssignmentResp(rsp *http.Response) (*CreateDatabaseRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDatabaseRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RoleAssignment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest InviteEmailUnprocessable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteDatabaseRoleAssignmentResp parses an HTTP response from a DeleteDatabaseRoleAssignmentWithResponse call
+func ParseDeleteDatabaseRoleAssignmentResp(rsp *http.Response) (*DeleteDatabaseRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteDatabaseRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListKeyVaultsResp parses an HTTP response from a ListKeyVaultsWithResponse call
 func ParseListKeyVaultsResp(rsp *http.Response) (*ListKeyVaultsResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -13845,12 +20405,26 @@ func ParseListKeyVaultsResp(rsp *http.Response) (*ListKeyVaultsResp, error) {
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -13906,6 +20480,13 @@ func ParseCreateKeyVaultResp(rsp *http.Response) (*CreateKeyVaultResp, error) {
 		}
 		response.JSON403 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
 		var dest Conflict
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -13939,6 +20520,13 @@ func ParseDeleteKeyVaultResp(rsp *http.Response) (*DeleteKeyVaultResp, error) {
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -13993,6 +20581,13 @@ func ParseGetKeyVaultResp(rsp *http.Response) (*GetKeyVaultResp, error) {
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -14039,6 +20634,13 @@ func ParseGetKeyVaultCredentialsResp(rsp *http.Response) (*GetKeyVaultCredential
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
@@ -14115,6 +20717,13 @@ func ParseRotateKeyVaultCredentialsResp(rsp *http.Response) (*RotateKeyVaultCred
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -14169,6 +20778,60 @@ func ParseRotateKeyVaultCredentialsResp(rsp *http.Response) (*RotateKeyVaultCred
 	return response, nil
 }
 
+// ParseCheckKeyVaultPermissionsResp parses an HTTP response from a CheckKeyVaultPermissionsWithResponse call
+func ParseCheckKeyVaultPermissionsResp(rsp *http.Response) (*CheckKeyVaultPermissionsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CheckKeyVaultPermissionsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PermissionsCheckResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListKeyVaultPrivateEndpointsResp parses an HTTP response from a ListKeyVaultPrivateEndpointsWithResponse call
 func ParseListKeyVaultPrivateEndpointsResp(rsp *http.Response) (*ListKeyVaultPrivateEndpointsResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -14189,6 +20852,13 @@ func ParseListKeyVaultPrivateEndpointsResp(rsp *http.Response) (*ListKeyVaultPri
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
@@ -14298,6 +20968,13 @@ func ParseDeleteKeyVaultPrivateEndpointResp(rsp *http.Response) (*DeleteKeyVault
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -14352,12 +21029,211 @@ func ParseGetKeyVaultPrivateEndpointResp(rsp *http.Response) (*GetKeyVaultPrivat
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListKeyVaultRoleAssignmentsResp parses an HTTP response from a ListKeyVaultRoleAssignmentsWithResponse call
+func ParseListKeyVaultRoleAssignmentsResp(rsp *http.Response) (*ListKeyVaultRoleAssignmentsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListKeyVaultRoleAssignmentsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateKeyVaultRoleAssignmentResp parses an HTTP response from a CreateKeyVaultRoleAssignmentWithResponse call
+func ParseCreateKeyVaultRoleAssignmentResp(rsp *http.Response) (*CreateKeyVaultRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateKeyVaultRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RoleAssignment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest InviteEmailUnprocessable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteKeyVaultRoleAssignmentResp parses an HTTP response from a DeleteKeyVaultRoleAssignmentWithResponse call
+func ParseDeleteKeyVaultRoleAssignmentResp(rsp *http.Response) (*DeleteKeyVaultRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteKeyVaultRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest NotFound
@@ -14733,6 +21609,252 @@ func ParseRestoreKeyVaultSecretResp(rsp *http.Response) (*RestoreKeyVaultSecretR
 			return nil, err
 		}
 		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCheckProjectPermissionsResp parses an HTTP response from a CheckProjectPermissionsWithResponse call
+func ParseCheckProjectPermissionsResp(rsp *http.Response) (*CheckProjectPermissionsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CheckProjectPermissionsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PermissionsCheckResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProjectRoleAssignmentsResp parses an HTTP response from a ListProjectRoleAssignmentsWithResponse call
+func ParseListProjectRoleAssignmentsResp(rsp *http.Response) (*ListProjectRoleAssignmentsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProjectRoleAssignmentsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateProjectRoleAssignmentResp parses an HTTP response from a CreateProjectRoleAssignmentWithResponse call
+func ParseCreateProjectRoleAssignmentResp(rsp *http.Response) (*CreateProjectRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateProjectRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RoleAssignment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest InviteEmailUnprocessable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectRoleAssignmentResp parses an HTTP response from a DeleteProjectRoleAssignmentWithResponse call
+func ParseDeleteProjectRoleAssignmentResp(rsp *http.Response) (*DeleteProjectRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
 
 	}
 
@@ -15168,6 +22290,13 @@ func ParseListServiceAccountsResp(rsp *http.Response) (*ListServiceAccountsResp,
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -15566,6 +22695,252 @@ func ParseGetVirtualMachineResp(rsp *http.Response) (*GetVirtualMachineResp, err
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCheckVMPermissionsResp parses an HTTP response from a CheckVMPermissionsWithResponse call
+func ParseCheckVMPermissionsResp(rsp *http.Response) (*CheckVMPermissionsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CheckVMPermissionsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PermissionsCheckResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListVMRoleAssignmentsResp parses an HTTP response from a ListVMRoleAssignmentsWithResponse call
+func ParseListVMRoleAssignmentsResp(rsp *http.Response) (*ListVMRoleAssignmentsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListVMRoleAssignmentsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateVMRoleAssignmentResp parses an HTTP response from a CreateVMRoleAssignmentWithResponse call
+func ParseCreateVMRoleAssignmentResp(rsp *http.Response) (*CreateVMRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateVMRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RoleAssignment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest InviteEmailUnprocessable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteVMRoleAssignmentResp parses an HTTP response from a DeleteVMRoleAssignmentWithResponse call
+func ParseDeleteVMRoleAssignmentResp(rsp *http.Response) (*DeleteVMRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteVMRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
 
 	}
 
@@ -17141,6 +24516,259 @@ func ParseGetSubnetResp(rsp *http.Response) (*GetSubnetResp, error) {
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListTenantRoleAssignmentsResp parses an HTTP response from a ListTenantRoleAssignmentsWithResponse call
+func ParseListTenantRoleAssignmentsResp(rsp *http.Response) (*ListTenantRoleAssignmentsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListTenantRoleAssignmentsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			RoleAssignments *[]RoleAssignment `json:"role_assignments,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateTenantRoleAssignmentResp parses an HTTP response from a CreateTenantRoleAssignmentWithResponse call
+func ParseCreateTenantRoleAssignmentResp(rsp *http.Response) (*CreateTenantRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateTenantRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RoleAssignment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest InviteEmailUnprocessable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest DirectoryUpstreamError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteTenantRoleAssignmentResp parses an HTTP response from a DeleteTenantRoleAssignmentWithResponse call
+func ParseDeleteTenantRoleAssignmentResp(rsp *http.Response) (*DeleteTenantRoleAssignmentResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteTenantRoleAssignmentResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListSharedResourcesResp parses an HTTP response from a ListSharedResourcesWithResponse call
+func ParseListSharedResourcesResp(rsp *http.Response) (*ListSharedResourcesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListSharedResourcesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []SharedResource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
 
 	}
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -32,3 +32,16 @@ failure mode.
 7. **Go module path `github.com/wso2/dc-api`.** The logical module name is fixed
    independent of where the repo is hosted; change it with
    `go mod edit -module` only if the canonical import path changes.
+
+8. **IdP directory reads are proxied, never stored.** dc-api reads users and
+   groups from the IdP over SCIM2 (read-only) to power the invite picker and
+   invite-by-email. Reads are live and discarded: the database stores only the
+   OIDC `sub` and the inviter-typed `display_alias` (on an email invite with
+   no alias, the directory display name or email is copied once at grant time
+   as the default — never synced). Responses expose minimal fields only
+   (display name, email/username, `sub`/id, group names). Directory listing is
+   gated to roles that perform invitations
+   (`authorization/roleAssignments/write`), the M2M credential carries
+   read-only VIEW scopes, and the IdP stays swappable behind the
+   `internal/directory` SCIM2 interface. The feature is entirely dark when the
+   `DCAPI_IDP_*` config is unset.

--- a/docs/rbac-v2.md
+++ b/docs/rbac-v2.md
@@ -413,6 +413,28 @@ DELETE /v1/tenants/{tid}/role-definitions/{id}
 holds a set of assignments — changing access = add one / remove one. The v1
 remove-then-re-add dance (and its access-gap window) disappears by construction.
 
+### 9.1 Invite by email
+
+The role-assignment POST endpoints accept **either** `user_sub` **or** `user_email`, but not both:
+
+```json
+{
+  "user_email": "alice@example.com",
+  "role_definition": "Contributor"
+}
+```
+
+When `user_email` is supplied, dc-api resolves it to an OIDC `sub` via the optional SCIM2 directory provider (all four `DCAPI_IDP_*` environment variables must be configured). If the directory is not configured, or if the email does not match exactly one user, the API returns `422 Unprocessable Entity`.
+
+Fallback when email invite fails: grant by raw `user_sub` instead, which always works.
+
+**Error responses:**
+- `422` — directory not configured, or email is ambiguous / not found
+- `501` — directory provider is disabled (feature dark)
+- `502` — directory provider is configured but the IdP upstream request failed
+
+The directory endpoints themselves (`GET /v1/tenants/{tenant_id}/directory/users` and `.../directory/groups`) are gated to principals holding `authorization/roleAssignments/write` — the inviter roles (Owner, User Access Administrator). See [rbac.md IdP Directory Configuration](rbac.md#idp-directory-configuration-optional) for the full setup guide.
+
 ---
 
 ## 10. How this wires to the UI (and CLI)

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -6,6 +6,8 @@ date: 2026-05-09
 
 # M1.5 RBAC — Membership and Roles
 
+> **Note:** Role vocabulary has moved to RBAC v2. See [rbac-v2.md](rbac-v2.md) for the current action-based model and role catalog. This document covers M1.5 semantics and the autoprovision / member-invite workflow; it uses examples from the v1 era and will be superseded when v2 fully ships.
+
 **Related design doc:** [MILESTONES.md § M1.5](../MILESTONES.md#m15--full-rbac-before-m2-after-m1-e2e-test-passes)
 
 ## What This Is
@@ -125,10 +127,16 @@ dcctl login
 If autoprovision is off, an existing tenant owner invites the user:
 
 ```bash
-dcctl tenant add-member alice@acme.com --role member --tenant acme
+dcctl tenant member create alice@acme.com --role Contributor --tenant acme
 ```
 
 This inserts a `role_assignments` row even if the user has never logged in. When they do log in later, they'll have access.
+
+**Email-based invites** require the directory provider to be configured (all four `DCAPI_IDP_*` environment variables must be set; see the "IdP Directory Configuration" section below). If the directory is not configured, or if the email does not resolve to exactly one user, the API returns 422; in that case, invite the user by their OIDC `sub` instead:
+
+```bash
+dcctl tenant member create 01abc123-0000-0000-0000-user000000001 --role Contributor --tenant acme
+```
 
 ## Autoprovision Explained
 
@@ -161,7 +169,7 @@ This inserts a `role_assignments` row even if the user has never logged in. When
 - Complies with zero-trust onboarding policies
 
 **Cons:**
-- Higher overhead (owner must run `dcctl tenant add-member` for each hire)
+- Higher overhead (owner must run `dcctl tenant member create` for each hire)
 - Requires coordination between teams
 
 **When to use:** Production, regulated industries, multi-tenant platforms.
@@ -179,31 +187,37 @@ When you flip `DCAPI_RBAC_AUTOPROVISION=false` for the first time:
 
 ## Roles in Practice
 
-### Add a member
+### Add a contributor
 
 ```bash
-dcctl tenant add-member bob@acme.com --role member --tenant acme
+dcctl tenant member create bob@acme.com --role Contributor --tenant acme
 ```
 
 Output:
 ```
-Added bob@acme.com as member in tenant acme
-Role assignments ID: 550e8400-e29b-41d4-a716-446655440000
+Granted Contributor to bob@acme.com on tenant acme (principal 01abc123-0000-0000-0000-user000000002).
 ```
 
 What it does:
-- Inserts a `role_assignments` row with `scope_type=tenant`, `scope_id=acme`, `role=member`
-- If a row with the same (principal_id, scope_type, scope_id, role) already exists: returns 200 (idempotent, no error)
-- Appends an audit event: actor=you, action=MEMBER_ADDED
-- Prints the new role assignment ID
+- Inserts a `role_assignments` row with `scope_type=tenant`, `scope_uuid=<acme-uuid>`, `role_definition=Contributor`
+- If a row with the same (principal_id, scope_type, scope_uuid, role_definition) already exists: returns 200 (idempotent, no error)
+- Appends an audit event: actor=you, action=ROLE_ASSIGNMENT_CREATED
+- Prints the principal ID (the OIDC `sub` if granted by email, or the `user_sub` directly)
 
-### Add a viewer
+A Contributor can create, read, and update resources but cannot delete them or manage access:
+- `dcctl create vm ...` ✓
+- `dcctl get vm <id>` ✓
+- `dcctl list vms` ✓
+- `dcctl delete vm <id>` ✗ (403)
+- `dcctl tenant member create ...` ✗ (403)
+
+### Add a reader
 
 ```bash
-dcctl tenant add-member audit@acme.com --role viewer --tenant acme
+dcctl tenant member create audit@acme.com --role Reader --tenant acme
 ```
 
-The viewer can read everything but can't create, update, or delete:
+A Reader can inspect resources but cannot create, update, or delete:
 - `dcctl get vm <id>` ✓
 - `dcctl list vms` ✓
 - `dcctl create vm ...` ✗ (403)
@@ -212,47 +226,47 @@ The viewer can read everything but can't create, update, or delete:
 ### Add an owner
 
 ```bash
-dcctl tenant add-member cto@acme.com --role owner --tenant acme
+dcctl tenant member create cto@acme.com --role Owner --tenant acme
 ```
 
-Owners can invite/remove members, delete resources, etc. Only other owners can invite a new owner (one owner can always do what other owners can do).
+Owners can invite/remove members, manage all resources, delete resources, etc. Only other owners can invite a new owner (one owner can always do what other owners can do).
 
 ### List members
 
 ```bash
-dcctl tenant list-members --tenant acme
+dcctl tenant member list --tenant acme
 ```
 
 Output:
 ```
-PRINCIPAL_ID              ROLE      GRANTED_AT            GRANTED_BY
-alice@acme.com            member    2026-05-09T10:00:00Z  admin@wso2.com
-bob@acme.com              member    2026-05-09T10:02:00Z  alice@acme.com
-cto@acme.com              owner     2026-05-09T10:05:00Z  admin@wso2.com
+PRINCIPAL_ID                        ALIAS          ROLE           GRANTED_AT            GRANTED_BY
+01abc123-0000-0000-0000-user000000001  alice          Contributor    2026-05-09T10:00:00Z  admin@wso2.com
+01abc123-0000-0000-0000-user000000002  bob            Contributor    2026-05-09T10:02:00Z  alice@acme.com
+01abc123-0000-0000-0000-user000000003  CTO (external) Owner          2026-05-09T10:05:00Z  admin@wso2.com
 ```
 
 Service accounts also appear here if they're assigned roles:
 
 ```
-SERVICE_ACCOUNT_ID                        ROLE      GRANTED_AT            GRANTED_BY
-550e8400-e29b-41d4-a716-446655440000      member    2026-05-09T11:00:00Z  cto@acme.com
+PRINCIPAL_ID                        ALIAS            ROLE         GRANTED_AT            GRANTED_BY
+550e8400-e29b-41d4-a716-446655440000  ci-deployer    Contributor  2026-05-09T11:00:00Z  cto@acme.com
 ```
 
 ## Removing Members
 
 ```bash
-dcctl tenant remove-member alice@acme.com --tenant acme
+dcctl tenant member delete 01abc123-0000-0000-0000-user000000001 --tenant acme
 ```
 
-This deletes **all** `role_assignments` rows for that principal in that tenant scope (she might have had multiple roles; now they're all gone). Rows are deleted, audit event is appended.
+This deletes **all** `role_assignments` rows for that principal in that tenant scope (they might have held multiple roles; now they're all gone). Rows are deleted, audit event is appended. The argument is the principal's `sub` (the opaque OIDC subject returned when the member was invited).
 
 ### The "last owner" guard
 
-You cannot remove the last owner of a tenant. If only `cto@acme.com` is an owner:
+You cannot remove the last owner of a tenant. If only one principal holds an Owner role at tenant scope:
 
 ```bash
-dcctl tenant remove-member cto@acme.com --tenant acme
-# Error: cannot remove the last owner of tenant acme
+dcctl tenant member delete 01abc123-0000-0000-0000-cto000000001 --tenant acme
+# Error: cannot remove the last principal holding authorization/roleAssignments/write at tenant scope
 ```
 
 **Rationale:** prevents locking out the entire tenant. If you need to transfer ownership, add a new owner first, then remove the old one.
@@ -363,8 +377,9 @@ The token is immediately revoked. Any request with the deleted SA's token will g
 Members of the Asgardeo group `dc-admin` are **platform admins**. They bypass all role assignment checks:
 
 ```bash
-# In Asgardeo:
-dcctl tenant add-member admin@wso2.com --role owner --tenant acme
+# In Asgardeo, add admin@wso2.com to the dc-admin group.
+# Then, optionally (for audit purposes), grant them an explicit Owner role:
+dcctl tenant member create admin@wso2.com --role Owner --tenant acme
 # But if admin@wso2.com is in dc-admin group, the role row is optional.
 # They have access to all tenants regardless.
 ```
@@ -408,7 +423,7 @@ If an employee leaves and you remove them from the `dc-tenant-acme` group in Asg
 **What happens:**
 - If the JWT doesn't contain the `dc-tenant-acme` group, the user's effective role is empty
 - They get 403 on any `dcctl` command
-- An owner can explicitly remove them with `dcctl tenant remove-member`
+- An owner can explicitly remove them with `dcctl tenant member delete <sub>`
 
 This is by design: the removal audit trail is permanent.
 
@@ -421,7 +436,7 @@ Don't try to reuse a deleted SA's name and expect the old token to work. Once de
 Once you remove someone from the IdP, revoke their DC-API membership explicitly:
 
 ```bash
-dcctl tenant remove-member alice@acme.com --tenant acme
+dcctl tenant member delete 01abc123-0000-0000-0000-user000000001 --tenant acme
 ```
 
 If you don't, the row sits in the audit trail forever (which is fine — it documents they once had access). It just doesn't grant access anymore because the JWT won't authenticate.
@@ -456,13 +471,39 @@ Service account creation, deletion, and token usage are also audited. The `last_
 
 ## Environment Variables (DC-API)
 
+### RBAC Core
+
 | Variable | Default | Notes |
 |---|---|---|
 | `DCAPI_RBAC_AUTOPROVISION` | `true` | `true` = auto-grant member on first login; `false` = require explicit invite |
-| `DCAPI_TENANT_GROUP_PREFIX` | `dc-tenant-` | Asgardeo group prefix for tenant mapping |
-| `DCAPI_ADMIN_GROUP` | `dc-admin` | Asgardeo group name for platform admins |
+| `DCAPI_TENANT_GROUP_PREFIX` | `dc-tenant-` | IdP group prefix that identifies tenants (e.g. `dc-tenant-acme` maps to tenant `acme`) |
+| `DCAPI_ADMIN_GROUP` | `dc-admin` | IdP group name for platform admins |
 
 Change these if your IdP uses different naming conventions.
+
+### IdP Directory Configuration (Optional)
+
+When all four of these variables are set, dc-api enables live directory browsing for invite pickers and email-based role assignments:
+
+| Variable | Required | Notes |
+|---|---|---|
+| `DCAPI_IDP_SCIM_BASE_URL` | If any are set | SCIM2 endpoint URL of your IdP (e.g. `https://api.asgardeo.io/t/<org>/scim2`). The four `*_BASE_URL`/`*_TOKEN_URL`/`*_CLIENT_ID`/`*_CLIENT_SECRET` variables must be set together or all unset; partial sets cause startup failure. |
+| `DCAPI_IDP_TOKEN_URL` | If any are set | OAuth2 token endpoint for the machine-to-machine credential (e.g. `https://api.asgardeo.io/t/<org>/oauth2/token`). |
+| `DCAPI_IDP_CLIENT_ID` | If any are set | Client ID of a machine-to-machine OAuth2 app with user/group VIEW scopes only (never write). |
+| `DCAPI_IDP_CLIENT_SECRET` | If any are set | Client secret for the above app. |
+| `DCAPI_IDP_SCOPES` | For Asgardeo / WSO2 IS | OAuth2 scopes requested with the client_credentials grant (space- or comma-separated). **Required for Asgardeo and WSO2 Identity Server**, which only attach SCIM permissions to the token when scopes are explicitly requested — without them every SCIM call returns 403. Other IdPs may need none. Optional and excluded from the all-or-nothing startup check. Grant LIST/VIEW scopes ONLY. Asgardeo value: `internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view`. |
+| `DCAPI_IDP_USERSTORE_DOMAIN` | No (default `DEFAULT`) | Restricts directory reads to one userstore via the WSO2 SCIM2 `domain` query parameter. Without it the IdP returns every account in the organization — including console administrators and collaborators, who are not invite candidates. `DEFAULT` is Asgardeo's consumer-user store; on-prem WSO2 Identity Server typically wants `PRIMARY`. Set explicitly empty to list all stores; non-WSO2 SCIM servers ignore the parameter. |
+
+**Granting the SCIM scopes (Asgardeo console):** open your M2M app → **API Authorization** → authorize the **SCIM2 Users API** (`internal_user_mgt_list`, `internal_user_mgt_view`) and the **SCIM2 Groups API** (`internal_group_mgt_view`), then set those three on `DCAPI_IDP_SCOPES`. Do not authorize any create/update/delete SCIM scopes — dc-api never writes to the IdP.
+
+**What this enables:**
+- `GET /v1/tenants/{tenant_id}/directory/users` — searchable user listing (for invite-by-email type-ahead in cloud-ui and dcctl)
+- `GET /v1/tenants/{tenant_id}/directory/groups` — group listing
+- Email-based invites: `dcctl tenant member create alice@example.com --role Contributor` — the email is resolved to an OIDC `sub` at invite time via SCIM2
+
+**When disabled** (all four unset): the feature is dark. Directory endpoints return `501 Not Implemented`, and role assignment requests must use `user_sub` instead of `user_email`.
+
+**Guardrails:** dc-api proxies SCIM2 reads live and stores nothing. Only the OIDC `sub` (and an inviter-provided `display_alias`) are persisted. See [decisions.md decision #8](decisions.md).
 
 ## See Also
 

--- a/examples/consumer/flux/platform-overlay/kustomization.yaml
+++ b/examples/consumer/flux/platform-overlay/kustomization.yaml
@@ -52,6 +52,24 @@ patches:
         path: /data/DCAPI_VPC_EXTERNAL_GATEWAY
         value: "CHANGE-ME-gateway"
 
+  # IdP directory (optional): uncomment to enable invite-by-email and the
+  # member picker. dc-api FAILS FAST when DCAPI_IDP_* is half-configured —
+  # only set these once `init-flux.sh seal` has also sealed
+  # DCAPI_IDP_CLIENT_ID/SECRET (it auto-pulls them from the asgardeo-auth
+  # layer's directory_client_id/_secret outputs when that env registers a
+  # read-only directory M2M app).
+  # - target: { kind: ConfigMap, name: dc-api-config }
+  #   patch: |-
+  #     - op: replace
+  #       path: /data/DCAPI_IDP_SCIM_BASE_URL
+  #       value: "https://api.asgardeo.io/t/CHANGE-ME-asgardeo-org/scim2"
+  #     - op: replace
+  #       path: /data/DCAPI_IDP_TOKEN_URL
+  #       value: "https://api.asgardeo.io/t/CHANGE-ME-asgardeo-org/oauth2/token"
+  #     - op: replace
+  #       path: /data/DCAPI_IDP_SCOPES
+  #       value: "internal_user_mgt_list internal_user_mgt_view internal_group_mgt_view"
+
   - target: { kind: Ingress, name: dc-api }
     patch: |-
       - op: replace

--- a/flux/platform/dc-api/base/configmap.yaml
+++ b/flux/platform/dc-api/base/configmap.yaml
@@ -28,3 +28,9 @@ data:
   DCAPI_VPC_EXTERNAL_GATEWAY: ""
   DCAPI_VPC_EXTERNAL_RESERVED_IPS: ""
   DCAPI_VPC_EXTERNAL_VLAN_ID: "0"
+  # IdP directory (SCIM2) — optional. Left empty (with the
+  # DCAPI_IDP_CLIENT_ID/SECRET secret keys absent) the directory feature
+  # stays dark and invites require a raw OIDC sub.
+  DCAPI_IDP_SCIM_BASE_URL: ""
+  DCAPI_IDP_TOKEN_URL: ""
+  DCAPI_IDP_SCOPES: ""

--- a/flux/platform/dc-api/base/deployment.yaml
+++ b/flux/platform/dc-api/base/deployment.yaml
@@ -50,6 +50,10 @@ spec:
             - { name: DCAPI_BFF_SESSION_SECRET,           valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_BFF_SESSION_SECRET } } }
             - { name: DCAPI_OPERATOR_SSH_KEY,             valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_OPERATOR_SSH_KEY, optional: true } } }
             - { name: DCAPI_OPERATOR_PASSWORD,            valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_OPERATOR_PASSWORD, optional: true } } }
+            # Optional: read-only IdP directory credential (SCIM2). Absent
+            # keys keep the directory feature dark — see configmap.yaml.
+            - { name: DCAPI_IDP_CLIENT_ID,                valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_IDP_CLIENT_ID, optional: true } } }
+            - { name: DCAPI_IDP_CLIENT_SECRET,            valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_IDP_CLIENT_SECRET, optional: true } } }
           readinessProbe:
             httpGet: { path: /healthz, port: 8080 }
             initialDelaySeconds: 5

--- a/scripts/init-flux.sh
+++ b/scripts/init-flux.sh
@@ -615,6 +615,19 @@ cmd_seal() {
   auto_or_ask        rancher_oidc_client_id "Asgardeo rancher-sso client_id"    "asgardeo-auth"  "client_id"
   auto_or_ask        cloud_ui_client_id     "Asgardeo cloud-ui SPA client_id"   "asgardeo-auth"  "cloud_ui_client_id"
 
+  # IdP directory M2M credential (optional feature) — TF-only, never a
+  # prompt: when the asgardeo-auth layer registers no directory app, the
+  # keys are sealed empty and the feature stays dark. dc-api fails fast on
+  # a HALF-configured DCAPI_IDP_* set, so if the overlay patches the
+  # SCIM/token URLs into dc-api-config these creds must resolve here.
+  idp_client_id="$(tf_get asgardeo-auth directory_client_id)"
+  idp_client_secret="$(tf_get asgardeo-auth directory_client_secret)"
+  if [[ -n "$idp_client_id" && -n "$idp_client_secret" ]]; then
+    echo "  ✓ IdP directory client_id/client_secret  ← from TF (asgardeo-auth.directory_client_id/_secret) [sensitive, not displayed]"
+  else
+    echo "  –  IdP directory credential not in asgardeo-auth TF outputs — sealing empty (directory feature stays dark)"
+  fi
+
   # Cluster-only / operator-only — stay prompts.
 
   echo
@@ -661,8 +674,23 @@ cmd_seal() {
     --fetch-cert > "$cert_pem"
   echo "  ✓ fetched sealed-secrets controller cert"
 
-  postgres_password="$(openssl rand -hex 12)"
-  bff_session_secret="$(openssl rand -base64 32)"
+  # Re-sealing a LIVE env must not rotate the Postgres password: the DB
+  # initialised with the existing one, and a rotated Secret breaks dc-api's
+  # DB auth until an operator ALTERs the role. Reuse the live values when
+  # the cluster has them; only a fresh env generates new ones. (The BFF
+  # session secret is preserved too so a re-seal doesn't log everyone out.)
+  postgres_password="$(kubectl get secret -n dc-system dc-postgres-secret -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || true)"
+  if [[ -n "$postgres_password" ]]; then
+    echo "  ✓ Postgres password  ← live cluster Secret (preserved, not rotated)"
+  else
+    postgres_password="$(openssl rand -hex 12)"
+  fi
+  bff_session_secret="$(kubectl get secret -n dc-system dc-api-secrets -o jsonpath='{.data.DCAPI_BFF_SESSION_SECRET}' 2>/dev/null | base64 -d || true)"
+  if [[ -n "$bff_session_secret" ]]; then
+    echo "  ✓ BFF session secret ← live cluster Secret (preserved)"
+  else
+    bff_session_secret="$(openssl rand -base64 32)"
+  fi
   oidc_audience="$rancher_oidc_client_id,$bff_client_id,$cloud_ui_client_id"
 
   seal() {
@@ -699,6 +727,8 @@ cmd_seal() {
        --from-literal=DCAPI_BFF_CLIENT_ID="$bff_client_id" \
        --from-literal=DCAPI_BFF_CLIENT_SECRET="$bff_client_secret" \
        --from-literal=DCAPI_BFF_SESSION_SECRET="$bff_session_secret" \
+       --from-literal=DCAPI_IDP_CLIENT_ID="$idp_client_id" \
+       --from-literal=DCAPI_IDP_CLIENT_SECRET="$idp_client_secret" \
        --from-file=DCAPI_HARVESTER_KUBECONFIG="$harvester_kubeconfig_path"
 
   seal_dockerconfig sealed-ghcr-pull-secret.yaml             ghcr-pull-secret dc-system   "$ghcr_org" "$ghcr_pat"


### PR DESCRIPTION
## What this does

Inviting someone to a tenant previously required pasting their raw OIDC `sub` — an opaque UUID the inviter had to dig out of the invitee's JWT. This PR lets dc-api read users and groups from the IdP (read-only, over SCIM2), so inviters can grant roles by email or by browsing a member picker, the way Azure's "Add role assignment" works.

## Privacy guardrails (enforced in code)

Directory reads are proxied live and never persisted — the database stores only the OIDC `sub` and a display alias copied once at grant time. Responses expose minimal fields only (name, email, sub, group names). Directory listing is gated to principals holding `authorization/roleAssignments/write`, and the machine-to-machine credential carries read-only VIEW scopes. The feature is entirely dark when the `DCAPI_IDP_*` config is unset. Recorded as decision 8 in `docs/decisions.md`.

## The pieces

**dc-api** — new `internal/directory` package (Provider interface + SCIM2 client with OAuth2 client_credentials and a short-TTL cache), configured by four optional `DCAPI_IDP_*` variables; completely dark when unset. `POST …/role-assignments` accepts `user_email` as an alternative to `user_sub` (resolved to the sub at grant time; 422 when the email doesn't match exactly one user or no directory is configured). New `GET /v1/tenants/{id}/directory/users|groups` endpoints: paginated, filterable, 501 when unconfigured (the feature-detection signal clients probe), 502 with a generic body on IdP failure (upstream detail only in server logs).

**cloud-ui** — the Add role assignment dialog gains an Azure-style member picker: a panel listing the directory on open with search and pagination; picking a user pins the resolved sub and uses their IdP display name as the alias (the manual display-name field is gone). Deployments without a directory keep the old raw-sub input.

**dcctl** — `tenant member create alice@example.com --role Contributor` now works (email is the documented primary form). The member commands were also migrated off the removed v1 members API onto role-assignments with RBAC v2 role keys, and the generated client was refreshed from the current spec.

**Deployment wiring** — the Flux base carries the new config (`dc-api-config` placeholders + optional `secretKeyRef` entries; absent values keep the feature dark), the consumer overlay template documents how to enable it, and `init-flux.sh seal` auto-pulls the directory credential from the asgardeo-auth layer's terraform outputs. The seal flow also now preserves the live Postgres password and BFF session secret on re-runs (re-sealing a live environment used to rotate the DB password out from under dc-api) and drops the retired ARC runner PAT, whose orphaned SealedSecret failed the whole platform Kustomization apply.

**Also fixed in passing**: the contract-test tag list still referenced the v1 `members` tag, which no longer exists in the spec — role-assignment operations had silently dropped out of contract coverage. The tag is now `roleAssignments` (+ `directory`), raising covered operations from 30 to 50.

## Verification

Unit: dc-api suite green including 9 SCIM2 client tests (httptest mock IdP) and 20 handler tests. Integration: 13 new tests for email invites + directory endpoints, run green in cluster-free mode against real Postgres. Contract: schemathesis, 50 operations / 4864 generated cases, 0 failures. Live: verified end-to-end on a local stack against a mock SCIM2 IdP — directory list/filter/paging, email invite happy path, ambiguous and unknown email 422s, dark-mode 501/422, raw-sub regression, dcctl CLI flow, and a DB check confirming only the sub and alias are persisted. cloud-ui: tsc, eslint, vitest clean; dcctl: builds with go vet clean.

**Note**: rebased on controlplane after #147 merged — the diff is now the feature only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)