### PR TITLE
Remove the Option D design shorthand from public text

### DIFF
--- a/dc-api/internal/api/auth/oidc.go
+++ b/dc-api/internal/api/auth/oidc.go
@@ -56,8 +56,8 @@ type Config struct {
 	AdminGroup string
 
 	// PlatformAdminSubs is the same env-driven set the auth middleware
-	// uses (Option D). When the caller's IdP sub is in this set, IsAdmin
-	// is true regardless of group membership.
+	// uses. When the caller's IdP sub is in this set, IsAdmin is true
+	// regardless of group membership.
 	PlatformAdminSubs map[string]struct{}
 }
 

--- a/dc-api/internal/db/schema.sql
+++ b/dc-api/internal/db/schema.sql
@@ -561,7 +561,7 @@ ALTER TABLE peerings                ADD COLUMN IF NOT EXISTS message TEXT;
 ALTER TABLE private_dns_zones       ADD COLUMN IF NOT EXISTS message TEXT;
 ALTER TABLE network_security_groups ADD COLUMN IF NOT EXISTS message TEXT;
 
--- Option D — admin-set mnemonic for principals (no IdP-sourced PII stored).
+-- Admin-set mnemonic for principals (no IdP-sourced PII stored).
 -- Optional. When set, cloud-ui shows this string instead of the opaque sub
 -- in the members list. Operator's own bookkeeping; nothing in dc-api
 -- derives behaviour from it.

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -725,7 +725,7 @@ paths:
         already holds that role at the virtual machine.
 
         The URL `{tenant_id}` must match the caller's own tenant context
-        (Option D: derived from a `role_assignments` row, not from any
+        (derived from a `role_assignments` row, not from any
         IdP group). Platform admins may operate on any tenant.
 
         **Required role**: `owner` at this scope or inherited from the
@@ -1202,7 +1202,7 @@ paths:
         already holds that role at the cluster.
 
         The URL `{tenant_id}` must match the caller's own tenant context
-        (Option D: derived from a `role_assignments` row, not from any
+        (derived from a `role_assignments` row, not from any
         IdP group). Platform admins may operate on any tenant.
 
         **Required role**: `owner` at this scope or inherited from the
@@ -1688,7 +1688,7 @@ paths:
         registration.
 
         The URL `{tenant_id}` must match the caller's own tenant context
-        (Option D: derived from a `role_assignments` row, not from any
+        (derived from a `role_assignments` row, not from any
         IdP group). Platform admins may operate on any tenant.
 
         **Required role**: `owner` (or platform admin).
@@ -2028,7 +2028,7 @@ paths:
         if the user already holds that role at the project.
 
         The URL `{tenant_id}` must match the caller's own tenant context
-        (Option D: derived from a `role_assignments` row, not from any
+        (derived from a `role_assignments` row, not from any
         IdP group). Platform admins may operate on any tenant.
 
         **Required role**: `owner` at this scope or inherited from the
@@ -2423,8 +2423,8 @@ paths:
         Use this endpoint when an admin wants the tenant discoverable
         before inviting anyone.
 
-        Does **not** create any Asgardeo group — Option D treats the
-        IdP as authentication-only. Membership lives in dc-api
+        Does **not** create any IdP group — the IdP is
+        authentication-only. Membership lives in dc-api
         (`role_assignments`).
 
         **Required auth**: platform admin (sub in
@@ -4015,7 +4015,7 @@ paths:
         already holds that role at the key vault.
 
         The URL `{tenant_id}` must match the caller's own tenant context
-        (Option D: derived from a `role_assignments` row, not from any
+        (derived from a `role_assignments` row, not from any
         IdP group). Platform admins may operate on any tenant.
 
         **Required role**: `owner` at this scope or inherited from the
@@ -5264,7 +5264,7 @@ paths:
         already holds that role at the database.
 
         The URL `{tenant_id}` must match the caller's own tenant context
-        (Option D: derived from a `role_assignments` row, not from any
+        (derived from a `role_assignments` row, not from any
         IdP group). Platform admins may operate on any tenant.
 
         **Required role**: `owner` at this scope or inherited from the

--- a/dc-api/test/integration/apiclient.go
+++ b/dc-api/test/integration/apiclient.go
@@ -722,7 +722,7 @@ func (c *APIClient) InviteMember(ctx context.Context, tenantID, userSub, roleDef
 	return c.InviteMemberWithAlias(ctx, tenantID, userSub, roleDefinition, "")
 }
 
-// InviteMemberWithAlias is InviteMember with the Option D display_alias
+// InviteMemberWithAlias is InviteMember with the display_alias
 // field set. Empty alias produces the same body InviteMember sends.
 func (c *APIClient) InviteMemberWithAlias(ctx context.Context, tenantID, userSub, roleDefinition, displayAlias string) (MemberResponse, []byte, int, error) {
 	path := fmt.Sprintf("/v1/tenants/%s/role-assignments", tenantID)

--- a/dc-api/test/integration/fixtures.go
+++ b/dc-api/test/integration/fixtures.go
@@ -65,7 +65,7 @@ func clientForTenant(t *testing.T, tenantID string) *APIClient {
 	// Phase 6a: TenantContext refuses any /v1/tenants/{tid}/... request
 	// whose slug isn't registered in the `tenants` table. Tests that mint a
 	// JWT used to rely on autoprovision in middleware to seed both
-	// `role_assignments` AND the `tenants` registry; Option D removed that
+	// `role_assignments` AND the `tenants` registry; the invite-based model removed that
 	// path for production, so the test helper UPSERTs explicitly here.
 	if _, err := env.DB.UpsertTenant(
 		context.Background(), tenantID, tenantID, "dc-tenant-"+tenantID, "test-fixture",

--- a/dc-api/test/integration/identity_decoupling_test.go
+++ b/dc-api/test/integration/identity_decoupling_test.go
@@ -2,9 +2,10 @@
 
 package integration
 
-// option_d_test.go — Option D verification.
+// identity_decoupling_test.go — IdP-decoupled identity verification.
 //
-// Three behaviours that distinguish Option D from earlier models:
+// Three behaviours that pin dc-api's identity model (the IdP is
+// authentication-only; tenancy and admin status live in dc-api):
 //
 //  1. PlatformAdminSubs env-var-driven admin promotion: a user with no
 //     dc-admin group claim but whose `sub` is listed in the AuthConfig's
@@ -30,10 +31,10 @@ import (
 	"github.com/wso2/dc-api/internal/models"
 )
 
-// optionDSubEnv builds a sub-env with autoprovision off (Option D default)
-// and the supplied platform-admin sub list. AdminGroup is left at its
-// default so the legacy fallback path stays functional.
-func optionDSubEnv(t *testing.T, platformAdminSubs ...string) *TestEnv {
+// identitySubEnv builds a sub-env with the supplied platform-admin sub
+// list. AdminGroup is left at its default so the group path stays
+// functional.
+func identitySubEnv(t *testing.T, platformAdminSubs ...string) *TestEnv {
 	t.Helper()
 	subs := make(map[string]struct{}, len(platformAdminSubs))
 	for _, s := range platformAdminSubs {
@@ -45,18 +46,18 @@ func optionDSubEnv(t *testing.T, platformAdminSubs ...string) *TestEnv {
 	})
 }
 
-// TestOptionD_PlatformAdminSubsPromotesWithoutGroup verifies that a user
+// TestIdentity_PlatformAdminSubsPromotesWithoutGroup verifies that a user
 // with NO dc-admin group claim — but whose sub is in PlatformAdminSubs —
 // is treated as platform admin (sees the full tenants registry).
-func TestOptionD_PlatformAdminSubsPromotesWithoutGroup(t *testing.T) {
+func TestIdentity_PlatformAdminSubsPromotesWithoutGroup(t *testing.T) {
 	t.Parallel()
 
-	suffix := randomName("optd-envadmin")
+	suffix := randomName("ident-envadmin")
 	envAdminSub := "sub-env-admin-" + suffix
-	subEnv := optionDSubEnv(t, envAdminSub)
+	subEnv := identitySubEnv(t, envAdminSub)
 
-	tenantA := randomTenantID("optd-env-a")
-	tenantB := randomTenantID("optd-env-b")
+	tenantA := randomTenantID("ident-env-a")
+	tenantB := randomTenantID("ident-env-b")
 	insertRole(t, subEnv, "seed-a-"+suffix, tenantA, models.RoleOwner)
 	insertRole(t, subEnv, "seed-b-"+suffix, tenantB, models.RoleMember)
 
@@ -84,15 +85,15 @@ func TestOptionD_PlatformAdminSubsPromotesWithoutGroup(t *testing.T) {
 	require.True(t, got[tenantB], "PlatformAdminSubs admin should see tenant B; got=%v", got)
 }
 
-// TestOptionD_DisplayAliasRoundTrip verifies display_alias survives
+// TestIdentity_DisplayAliasRoundTrip verifies display_alias survives
 // POST → GET unchanged.
-func TestOptionD_DisplayAliasRoundTrip(t *testing.T) {
+func TestIdentity_DisplayAliasRoundTrip(t *testing.T) {
 	t.Parallel()
-	subEnv := optionDSubEnv(t)
+	subEnv := identitySubEnv(t)
 
-	tenantID := randomTenantID("optd-alias")
-	ownerSub := "sub-optd-alias-owner-" + randomName("u")
-	inviteeSub := "sub-optd-alias-invitee-" + randomName("u")
+	tenantID := randomTenantID("ident-alias")
+	ownerSub := "sub-ident-alias-owner-" + randomName("u")
+	inviteeSub := "sub-ident-alias-invitee-" + randomName("u")
 	alias := "alice-laptop"
 
 	insertRole(t, subEnv, ownerSub, tenantID, models.RoleOwner)
@@ -121,20 +122,20 @@ func TestOptionD_DisplayAliasRoundTrip(t *testing.T) {
 	require.Equal(t, alias, found.DisplayAlias, "GET response must round-trip display_alias")
 }
 
-// TestOptionD_InviteUpsertsTenantsRegistry verifies that inviting a
+// TestIdentity_InviteUpsertsTenantsRegistry verifies that inviting a
 // member to a previously-unregistered tenant makes the tenant visible to
 // platform admins via GET /v1/tenants, without a separate
 // POST /v1/admin/tenants call.
-func TestOptionD_InviteUpsertsTenantsRegistry(t *testing.T) {
+func TestIdentity_InviteUpsertsTenantsRegistry(t *testing.T) {
 	t.Parallel()
 
-	suffix := randomName("optd-invite-reg")
-	adminSub := "sub-optd-inv-admin-" + suffix
-	subEnv := optionDSubEnv(t, adminSub)
+	suffix := randomName("ident-invite-reg")
+	adminSub := "sub-ident-inv-admin-" + suffix
+	subEnv := identitySubEnv(t, adminSub)
 
-	tenantID := randomTenantID("optd-inv-reg")
-	ownerSub := "sub-optd-inv-owner-" + suffix
-	inviteeSub := "sub-optd-inv-invitee-" + suffix
+	tenantID := randomTenantID("ident-inv-reg")
+	ownerSub := "sub-ident-inv-owner-" + suffix
+	inviteeSub := "sub-ident-inv-invitee-" + suffix
 
 	insertRole(t, subEnv, ownerSub, tenantID, models.RoleOwner)
 

--- a/docs/defense-in-depth.md
+++ b/docs/defense-in-depth.md
@@ -33,7 +33,7 @@ ordering is by leverage (cheap + high value first), not by dependency.
 
 What's already protecting tenants:
 
-- **dc-api enforces RBAC** via `role_assignments` (Option D, just shipped):
+- **dc-api enforces RBAC** via `role_assignments`:
   `requireTenantRole(owner|member|viewer)` on every write path.
 - **TenantContext middleware** sets `tenant_id` from the URL path and
   refuses any request whose JWT/SA doesn't have a role row for that


### PR DESCRIPTION
## What this does

"Option D" was the label of the winning alternative in an internal RBAC design discussion. The losing options A–C were never published, so every public artifact that says "Option D" references a conversation readers can't see. This sweep replaces the label with self-contained wording — same class of cleanup as the earlier docs scrub, applied to the older merged content.

Touched: seven `openapi.yaml` operation descriptions (the tenant-context wording and the admin-tenant-create note), comments in `internal/api/auth/oidc.go` and `db/schema.sql`, one line in `docs/defense-in-depth.md`, and the integration tests — `option_d_test.go` becomes `identity_decoupling_test.go` with identical coverage (env-var admin promotion, display_alias round-trip, invite-upserts-registry), with test names and fixtures renamed to match.

No behaviour changes anywhere; this is comment/description text only. Generated clients refreshed from the reworded spec.

## Verification

dc-api unit suite green (11 packages); integration and contract test packages compile under their build tags; spec lints clean; cloud-ui regen + CI typecheck clean; dcctl regen + build + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)