### PR TITLE
Add the project activity feed

### DIFF
--- a/cloud-ui/src/api/activity.ts
+++ b/cloud-ui/src/api/activity.ts
@@ -43,6 +43,13 @@ export const ACTIVITY_RESOURCE_ROUTES: Record<string, string> = {
   VIRTUAL_MACHINE: 'vms',
   CLUSTER: 'clusters',
   BASTION: 'bastions',
+  VNET: 'vnets',
+  NSG: 'nsgs',
+  KEYVAULT: 'keyvaults',
+  DATABASE: 'databases',
+  // SUBNET / PEERING / PRIVATE_DNS_ZONE / PRIVATE_ENDPOINT have no
+  // standalone detail routes (they live inside the VNet detail page) —
+  // they render as plain text.
 };
 
 export function useActivityQuery(

--- a/cloud-ui/src/api/activity.ts
+++ b/cloud-ui/src/api/activity.ts
@@ -1,0 +1,75 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useApi } from './useApi';
+
+/**
+ * Project activity feed — GET /v1/tenants/{tenant_id}/projects/{project_id}/activity.
+ *
+ * The endpoint ships in dc-api/openapi.yaml on this same branch, so the call
+ * uses the generated path + typed query params directly (`pnpm gen:api` runs
+ * on predev/prebuild). The interfaces below mirror the spec's ActivityEvent /
+ * ActivityPage schemas for consumers that want a stable local name.
+ */
+
+export interface ActivityEvent {
+  id: string;
+  resource_id: string;
+  resource_name: string;
+  resource_type: string;
+  action: string;
+  actor_id: string;
+  from_status?: string;
+  to_status?: string;
+  message?: string;
+  created_at: string;
+}
+
+export interface ActivityList {
+  items: ActivityEvent[];
+  total: number;
+}
+
+/**
+ * Maps an ActivityEvent.resource_type to the project-scoped route segment
+ * for deep-linking (`../<route>/<resource_id>`). Types not listed here
+ * (or no longer routable) render as plain text.
+ *
+ * Keys are the spec's ActivityEvent.resource_type enum — the stored
+ * resources.type values (VIRTUAL_MACHINE, CLUSTER, VOLUME, BASTION), NOT
+ * lowercase short names. VOLUME has no detail page yet (M2 storage is in
+ * flight), so it deliberately renders as plain text.
+ */
+export const ACTIVITY_RESOURCE_ROUTES: Record<string, string> = {
+  VIRTUAL_MACHINE: 'vms',
+  CLUSTER: 'clusters',
+  BASTION: 'bastions',
+};
+
+export function useActivityQuery(
+  tenantId: string | undefined,
+  projectId: string | undefined,
+  limit: number,
+  offset: number,
+) {
+  const api = useApi();
+  return useQuery({
+    queryKey: ['activity', tenantId, projectId, limit, offset],
+    enabled: Boolean(tenantId) && Boolean(projectId),
+    refetchInterval: 30_000,
+    // Keep the previous page rendered while the next page loads so
+    // pagination doesn't flash the loading state.
+    placeholderData: keepPreviousData,
+    queryFn: async (): Promise<ActivityList> => {
+      const { data, error } = await api.GET(
+        '/v1/tenants/{tenant_id}/projects/{project_id}/activity',
+        {
+          params: {
+            path: { tenant_id: tenantId!, project_id: projectId! },
+            query: { limit, offset },
+          },
+        },
+      );
+      if (error) throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      return data ?? { items: [], total: 0 };
+    },
+  });
+}

--- a/cloud-ui/src/api/activity.ts
+++ b/cloud-ui/src/api/activity.ts
@@ -12,7 +12,8 @@ import { useApi } from './useApi';
 
 export interface ActivityEvent {
   id: string;
-  resource_id: string;
+  /** Absent once the resource has been deleted — only deep-link when present. */
+  resource_id?: string;
   resource_name: string;
   resource_type: string;
   action: string;

--- a/cloud-ui/src/lib/apiError.ts
+++ b/cloud-ui/src/lib/apiError.ts
@@ -32,3 +32,23 @@ function unwrapApiError(raw: string): string {
   }
   return raw;
 }
+
+/**
+ * detailErrorMessage is listErrorMessage's sibling for detail pages: unwrap
+ * the {"error":"…"} envelope and classify the two common cases (missing row,
+ * permission denial) into plain sentences. Detail pages hit "not found" far
+ * more than lists do — stale deep links, deleted resources, activity-feed
+ * history — so the raw envelope must never reach the screen.
+ */
+export function detailErrorMessage(error: unknown, resource: string): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const detail = unwrapApiError(raw);
+  if (/not found|404/i.test(detail)) {
+    return `This ${resource} no longer exists — it may have been deleted.`;
+  }
+  if (/insufficient permissions/i.test(detail)) {
+    return `You don't have permission to view this ${resource}.`;
+  }
+  return detail;
+}
+

--- a/cloud-ui/src/pages/ActivityPage.tsx
+++ b/cloud-ui/src/pages/ActivityPage.tsx
@@ -152,7 +152,7 @@ export default function ActivityPage() {
                         <ActionText action={ev.action} />
                       </TableCell>
                       <TableCell>
-                        {route ? (
+                        {route && ev.resource_id ? (
                           <span
                             className={local.resourceLink}
                             onClick={() => navigate(`../${route}/${ev.resource_id}`)}

--- a/cloud-ui/src/pages/ActivityPage.tsx
+++ b/cloud-ui/src/pages/ActivityPage.tsx
@@ -1,0 +1,206 @@
+import {
+  Button,
+  Card,
+  Subtitle1,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Title2,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import { ArrowClockwise20Regular, History24Regular } from '@fluentui/react-icons';
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ACTIVITY_RESOURCE_ROUTES, useActivityQuery, type ActivityEvent } from '../api/activity';
+import { useActiveProject } from '../hooks/useActiveProject';
+import { EmptyState, ErrorState, LoadingState } from '../components/list/PageStates';
+import { useListPageStyles } from '../components/list/useListPageStyles';
+import { listErrorMessage } from '../lib/apiError';
+import { fmtDate } from '../lib/date';
+
+const PAGE_SIZE = 20;
+
+const useStyles = makeStyles({
+  actionCreate: {
+    color: tokens.colorPaletteGreenForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  actionDelete: {
+    color: tokens.colorPaletteRedForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  actionStatus: {
+    color: tokens.colorPaletteDarkOrangeForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  actionNeutral: { fontWeight: tokens.fontWeightSemibold },
+  resourceLink: {
+    color: tokens.colorBrandForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+    cursor: 'pointer',
+    ':hover': { textDecorationLine: 'underline' },
+  },
+  pagination: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
+  },
+  paginationInfo: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    marginLeft: tokens.spacingHorizontalS,
+  },
+});
+
+/**
+ * Colored action label. A top-level component (not an inline render
+ * callback) so the styles hook runs at component scope — StatusPill is
+ * deliberately NOT reused here: its variants map ResourceStatus values,
+ * not activity actions.
+ */
+function ActionText({ action }: { action: string }) {
+  const styles = useStyles();
+  const cls =
+    action === 'CREATE'
+      ? styles.actionCreate
+      : action === 'DELETE'
+        ? styles.actionDelete
+        : action === 'STATUS_CHANGE'
+          ? styles.actionStatus
+          : styles.actionNeutral;
+  return <span className={cls}>{action}</span>;
+}
+
+export default function ActivityPage() {
+  const styles = useListPageStyles();
+  const local = useStyles();
+  const navigate = useNavigate();
+  const { tenantId } = useParams<{ tenantId: string }>();
+  const { projectId } = useActiveProject();
+  const [offset, setOffset] = useState(0);
+
+  const activityQuery = useActivityQuery(tenantId, projectId, PAGE_SIZE, offset);
+
+  const items: ActivityEvent[] = activityQuery.data?.items ?? [];
+  const total = activityQuery.data?.total ?? 0;
+  const showingFrom = total === 0 ? 0 : offset + 1;
+  const showingTo = Math.min(offset + items.length, total);
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <Title2>Activity</Title2>
+        <Subtitle1 className={styles.subtitle}>
+          {activityQuery.isLoading
+            ? 'Loading…'
+            : `${total} event${total === 1 ? '' : 's'} in this project`}
+        </Subtitle1>
+      </div>
+
+      <div className={styles.cmdBar}>
+        <Button
+          appearance="subtle"
+          icon={<ArrowClockwise20Regular />}
+          onClick={() => activityQuery.refetch()}
+          disabled={activityQuery.isFetching}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {activityQuery.isLoading && <LoadingState label="Loading activity…" />}
+
+      {activityQuery.isError && !activityQuery.isLoading && (
+        <ErrorState message={listErrorMessage(activityQuery.error, 'activity')} />
+      )}
+
+      {!activityQuery.isLoading && !activityQuery.isError && items.length === 0 && (
+        <EmptyState
+          icon={<History24Regular />}
+          title="No activity yet"
+          description="Events appear here as resources in this project are created, change status, or are deleted."
+        />
+      )}
+
+      {!activityQuery.isLoading && !activityQuery.isError && items.length > 0 && (
+        <>
+          <Card className={styles.tableCard}>
+            <Table size="small" aria-label="Project activity">
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>Time</TableHeaderCell>
+                  <TableHeaderCell>Action</TableHeaderCell>
+                  <TableHeaderCell>Resource</TableHeaderCell>
+                  <TableHeaderCell>Actor</TableHeaderCell>
+                  <TableHeaderCell>Status change</TableHeaderCell>
+                  <TableHeaderCell>Message</TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((ev) => {
+                  const route = ACTIVITY_RESOURCE_ROUTES[ev.resource_type];
+                  return (
+                    <TableRow key={ev.id}>
+                      <TableCell className={styles.tableMutedCell}>
+                        {fmtDate(ev.created_at)}
+                      </TableCell>
+                      <TableCell>
+                        <ActionText action={ev.action} />
+                      </TableCell>
+                      <TableCell>
+                        {route ? (
+                          <span
+                            className={local.resourceLink}
+                            onClick={() => navigate(`../${route}/${ev.resource_id}`)}
+                          >
+                            {ev.resource_name}
+                          </span>
+                        ) : (
+                          <>
+                            <span>{ev.resource_name}</span>
+                            <div className={styles.tableMutedCell}>{ev.resource_type}</div>
+                          </>
+                        )}
+                      </TableCell>
+                      <TableCell className={styles.tableMutedCell}>{ev.actor_id}</TableCell>
+                      <TableCell>
+                        {ev.from_status && ev.to_status
+                          ? `${ev.from_status} → ${ev.to_status}`
+                          : '—'}
+                      </TableCell>
+                      <TableCell className={styles.tableMutedCell}>{ev.message ?? '—'}</TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </Card>
+
+          <div className={local.pagination}>
+            <Button
+              size="small"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            >
+              Previous
+            </Button>
+            <Button
+              size="small"
+              disabled={offset + PAGE_SIZE >= total}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Next
+            </Button>
+            <span className={local.paginationInfo}>
+              Showing {showingFrom}–{showingTo} of {total}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/cloud-ui/src/pages/BastionDetailPage.tsx
+++ b/cloud-ui/src/pages/BastionDetailPage.tsx
@@ -22,6 +22,7 @@ import { ArrowLeft20Regular, Delete20Regular } from '@fluentui/react-icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApi } from '../api/useApi';
+import { detailErrorMessage } from '../lib/apiError';
 import { useActiveProject } from '../hooks/useActiveProject';
 import { useConfirmDialog } from '../components/useConfirmDialog';
 import StatusPill from '../components/StatusPill';
@@ -168,7 +169,7 @@ export default function BastionDetailPage() {
           <MessageBar intent="error">
             <MessageBarBody>
               <MessageBarTitle>Failed to load bastion</MessageBarTitle>
-              {bastionQuery.error instanceof Error ? bastionQuery.error.message : 'Not found.'}
+              {detailErrorMessage(bastionQuery.error, 'bastion')}
             </MessageBarBody>
           </MessageBar>
         </div>

--- a/cloud-ui/src/pages/ClusterDetailPage.tsx
+++ b/cloud-ui/src/pages/ClusterDetailPage.tsx
@@ -37,6 +37,7 @@ import { useConfirmDialog } from '../components/useConfirmDialog';
 import NodePoolsTab from '../components/NodePoolsTab';
 import StatusPill from '../components/StatusPill';
 import { fmtDate } from '../lib/date';
+import { detailErrorMessage } from '../lib/apiError';
 import MembersPage from './MembersPage';
 
 const useStyles = makeStyles({
@@ -267,7 +268,6 @@ export default function ClusterDetailPage() {
   }
 
   if (clusterQuery.isError) {
-    const msg = (clusterQuery.error as Error).message;
     return (
       <div className={styles.root}>
         <Card>
@@ -276,7 +276,7 @@ export default function ClusterDetailPage() {
             <Body1
               style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalS }}
             >
-              {msg.includes('404') ? 'No cluster with this ID exists in this tenant.' : msg}
+              {detailErrorMessage(clusterQuery.error, 'cluster')}
             </Body1>
             <Button
               appearance="primary"

--- a/cloud-ui/src/pages/DashboardPage.tsx
+++ b/cloud-ui/src/pages/DashboardPage.tsx
@@ -6,13 +6,11 @@ import {
   Spinner,
   Subtitle1,
   Title2,
-  Tooltip,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
 import {
   Add20Regular,
-  ArrowRight16Regular,
   CloudArrowUp24Regular,
   Database24Regular,
   Key24Regular,
@@ -24,6 +22,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApi } from '../api/useApi';
+import { ACTIVITY_RESOURCE_ROUTES, useActivityQuery } from '../api/activity';
 import { useActiveProject } from '../hooks/useActiveProject';
 import { fmtDate } from '../lib/date';
 
@@ -252,16 +251,14 @@ export default function DashboardPage() {
   });
   const project = (projectQuery.data ?? []).find((p) => p.id === projectId);
 
-  // Cross-kind derivations for the attention + recent cards.
+  const activityQuery = useActivityQuery(tenantId, projectId, 5, 0);
+
+  // Cross-kind derivation for the attention card.
   const tagged = KINDS.flatMap((kind, i) =>
     (listQueries[i].data ?? []).map((item) => ({ kind, item })),
   );
   const attention = tagged
     .filter(({ item }) => FAILED.has((item.status ?? '').toUpperCase()))
-    .slice(0, 5);
-  const recent = [...tagged]
-    .filter(({ item }) => item.created_at)
-    .sort((a, b) => (b.item.created_at ?? '').localeCompare(a.item.created_at ?? ''))
     .slice(0, 5);
 
   const cap = capQuery.data;
@@ -394,27 +391,31 @@ export default function DashboardPage() {
         </Card>
 
         <Card className={styles.sectionCard}>
-          <Subtitle1>Recently created</Subtitle1>
-          {recent.length === 0 ? (
-            <span className={styles.empty}>No resources in this project yet — create one to get started.</span>
-          ) : (
-            recent.map(({ kind, item }) => (
-              <div
-                key={`${kind.key}-${item.id}`}
-                className={styles.listRow}
-                onClick={() => navigate(`../${routeFor(kind)}/${item.id}`)}
-              >
-                <span className={styles.listName}>{item.name ?? item.id}</span>
-                <span className={styles.listMeta}>
-                  {kind.label}
-                  {item.created_at ? ` · ${fmtDate(item.created_at)}` : ''}
-                  <Tooltip content="Open" relationship="label">
-                    <ArrowRight16Regular />
-                  </Tooltip>
-                </span>
-              </div>
-            ))
-          )}
+          <Subtitle1>Recent activity</Subtitle1>
+          {activityQuery.isLoading && <Spinner size="tiny" />}
+          {activityQuery.isError && <span className={styles.cardError}>unavailable</span>}
+          {!activityQuery.isLoading &&
+            !activityQuery.isError &&
+            ((activityQuery.data?.items ?? []).length === 0 ? (
+              <span className={styles.empty}>No activity yet.</span>
+            ) : (
+              (activityQuery.data?.items ?? []).map((ev) => {
+                const route = ACTIVITY_RESOURCE_ROUTES[ev.resource_type];
+                return (
+                  <div
+                    key={ev.id}
+                    className={styles.listRow}
+                    onClick={route ? () => navigate(`../${route}/${ev.resource_id}`) : undefined}
+                  >
+                    <span className={styles.listName}>
+                      <span className={styles.empty}>{ev.action} </span>
+                      {ev.resource_name}
+                    </span>
+                    <span className={styles.listMeta}>{fmtDate(ev.created_at)}</span>
+                  </div>
+                );
+              })
+            ))}
         </Card>
       </div>
     </div>

--- a/cloud-ui/src/pages/DashboardPage.tsx
+++ b/cloud-ui/src/pages/DashboardPage.tsx
@@ -405,7 +405,7 @@ export default function DashboardPage() {
                   <div
                     key={ev.id}
                     className={styles.listRow}
-                    onClick={route ? () => navigate(`../${route}/${ev.resource_id}`) : undefined}
+                    onClick={route && ev.resource_id ? () => navigate(`../${route}/${ev.resource_id}`) : undefined}
                   >
                     <span className={styles.listName}>
                       <span className={styles.empty}>{ev.action} </span>

--- a/cloud-ui/src/pages/DatabaseDetailPage.tsx
+++ b/cloud-ui/src/pages/DatabaseDetailPage.tsx
@@ -33,6 +33,7 @@ import { useConfirmDialog } from '../components/useConfirmDialog';
 import SecretRevealBanner, { type Secret } from '../components/SecretRevealBanner';
 import StatusPill from '../components/StatusPill';
 import { fmtDate } from '../lib/date';
+import { detailErrorMessage } from '../lib/apiError';
 import MembersPage from './MembersPage';
 
 interface Database {
@@ -253,7 +254,7 @@ export default function DatabaseDetailPage() {
         <MessageBar intent="error">
           <MessageBarBody>
             <MessageBarTitle>Failed to load database</MessageBarTitle>
-            {dbQuery.error instanceof Error ? dbQuery.error.message : 'Not found.'}
+            {detailErrorMessage(dbQuery.error, 'database')}
           </MessageBarBody>
         </MessageBar>
       </div>

--- a/cloud-ui/src/pages/KeyVaultDetailPage.tsx
+++ b/cloud-ui/src/pages/KeyVaultDetailPage.tsx
@@ -35,6 +35,7 @@ import KeyVaultSecretsTab from '../components/KeyVaultSecretsTab';
 import SecretRevealBanner, { type Secret } from '../components/SecretRevealBanner';
 import StatusPill from '../components/StatusPill';
 import { fmtDate } from '../lib/date';
+import { detailErrorMessage } from '../lib/apiError';
 import MembersPage from './MembersPage';
 
 interface KeyVault {
@@ -292,7 +293,7 @@ export default function KeyVaultDetailPage() {
         <MessageBar intent="error">
           <MessageBarBody>
             <MessageBarTitle>Failed to load key vault</MessageBarTitle>
-            {kvQuery.error instanceof Error ? kvQuery.error.message : 'Not found.'}
+            {detailErrorMessage(kvQuery.error, 'key vault')}
           </MessageBarBody>
         </MessageBar>
       </div>

--- a/cloud-ui/src/pages/NSGDetailPage.tsx
+++ b/cloud-ui/src/pages/NSGDetailPage.tsx
@@ -41,6 +41,7 @@ import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApi } from '../api/useApi';
+import { detailErrorMessage } from '../lib/apiError';
 import { useActiveProject } from '../hooks/useActiveProject';
 import { useConfirmDialog } from '../components/useConfirmDialog';
 import StatusPill from '../components/StatusPill';
@@ -236,7 +237,7 @@ export default function NSGDetailPage() {
           <div className={styles.notFound}>
             <Subtitle1>Security group not found</Subtitle1>
             <Body1 style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalS }}>
-              {(nsgQuery.error as Error).message}
+              {detailErrorMessage(nsgQuery.error, 'security group')}
             </Body1>
             <Button appearance="primary" style={{ marginTop: tokens.spacingVerticalL }} onClick={() => navigate(`/tenants/${tenantId}/projects/${projectId}/nsgs`)}>
               Back to security groups

--- a/cloud-ui/src/pages/VNetDetailPage.tsx
+++ b/cloud-ui/src/pages/VNetDetailPage.tsx
@@ -29,6 +29,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApi } from '../api/useApi';
+import { detailErrorMessage } from '../lib/apiError';
 import { useActiveProject } from '../hooks/useActiveProject';
 import { useConfirmDialog } from '../components/useConfirmDialog';
 import PeeringsTab from '../components/PeeringsTab';
@@ -174,7 +175,6 @@ export default function VNetDetailPage() {
   }
 
   if (vnetQuery.isError) {
-    const msg = (vnetQuery.error as Error).message;
     return (
       <div className={styles.root}>
         <Card>
@@ -183,7 +183,7 @@ export default function VNetDetailPage() {
             <Body1
               style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalS }}
             >
-              {msg.includes('404') ? 'No VNet with this ID exists in this tenant.' : msg}
+              {detailErrorMessage(vnetQuery.error, 'VNet')}
             </Body1>
             <Button
               appearance="primary"

--- a/cloud-ui/src/pages/VmDetailPage.tsx
+++ b/cloud-ui/src/pages/VmDetailPage.tsx
@@ -31,6 +31,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApi } from '../api/useApi';
+import { detailErrorMessage } from '../lib/apiError';
 import { useActiveProject } from '../hooks/useActiveProject';
 import { useConfirmDialog } from '../components/useConfirmDialog';
 import StatusPill from '../components/StatusPill';
@@ -216,14 +217,13 @@ export default function VmDetailPage() {
   }
 
   if (vmQuery.isError) {
-    const msg = (vmQuery.error as Error).message;
     return (
       <div className={styles.root}>
         <Card>
           <div className={styles.notFound}>
             <Subtitle1>VM not found</Subtitle1>
             <Body1 style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalS }}>
-              {msg.includes('404') ? 'No VM with this ID exists in this tenant.' : msg}
+              {detailErrorMessage(vmQuery.error, 'VM')}
             </Body1>
             <Button
               appearance="primary"

--- a/cloud-ui/src/router.tsx
+++ b/cloud-ui/src/router.tsx
@@ -27,6 +27,7 @@ import VNetsListPage from './pages/VNetsListPage';
 import VmDetailPage from './pages/VmDetailPage';
 import VmsListPage from './pages/VmsListPage';
 import DashboardPage from './pages/DashboardPage';
+import ActivityPage from './pages/ActivityPage';
 
 interface BuildRouterArgs {
   isDark: boolean;
@@ -38,10 +39,7 @@ export function buildRouter({ isDark, onToggleDark }: BuildRouterArgs) {
   const projectScopedChildren: RouteObject[] = [
     { index: true, element: <Navigate to="dashboard" replace /> },
     { path: 'dashboard', element: <DashboardPage /> },
-    {
-      path: 'activity',
-      element: <PlaceholderPage title="Activity" subtitle="Audit trail across this project" />,
-    },
+    { path: 'activity', element: <ActivityPage /> },
     { path: 'vms', element: <VmsListPage /> },
     { path: 'vms/:vmId', element: <VmDetailPage /> },
     { path: 'bastions', element: <BastionsListPage /> },

--- a/dc-api/internal/api/handlers/activity.go
+++ b/dc-api/internal/api/handlers/activity.go
@@ -1,0 +1,92 @@
+// Package handlers — activity.go
+//
+// ActivityHandler serves the read-only project activity feed:
+//
+//	GET /v1/tenants/{tenant_id}/projects/{project_id}/activity
+//
+// One page of audit events for every resource in the project, newest first.
+// Pure DB read — no provider calls. The route is gated with
+// resourcemanager/activity/read in router.go (Reader's `*/read` covers it, so
+// any project member can read the feed); project scoping comes from the
+// ProjectContext middleware's project_uuid, never from the URL slug.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/rs/zerolog"
+	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/db"
+	"github.com/wso2/dc-api/internal/models"
+)
+
+const (
+	activityDefaultLimit = 20
+	activityMaxLimit     = 100
+)
+
+// ActivityHandler serves the project-scoped activity feed.
+type ActivityHandler struct {
+	repo *db.Repository
+	log  zerolog.Logger
+}
+
+// NewActivityHandler creates an ActivityHandler.
+func NewActivityHandler(repo *db.Repository, log zerolog.Logger) *ActivityHandler {
+	return &ActivityHandler{repo: repo, log: log}
+}
+
+// List handles GET .../projects/{project_id}/activity.
+func (h *ActivityHandler) List(w http.ResponseWriter, r *http.Request) {
+	projectUUID, ok := middleware.ProjectUUIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "no project UUID in context")
+		return
+	}
+
+	limit, offset, ok := parseActivityPaging(w, r)
+	if !ok {
+		return
+	}
+
+	entries, total, err := h.repo.ListProjectActivity(r.Context(), projectUUID, limit, offset)
+	if err != nil {
+		h.log.Error().Err(err).Str("project_uuid", projectUUID.String()).Msg("list project activity failed")
+		writeError(w, http.StatusInternalServerError, "failed to list project activity")
+		return
+	}
+
+	if entries == nil {
+		entries = []models.ActivityEntry{} // zero events must serialize as [], not null
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"items": entries,
+		"total": total,
+	})
+}
+
+// parseActivityPaging reads limit/offset with the spec's defaults and bounds
+// (limit default 20, 1..100; offset >= 0, default 0). Writes a 400 and returns
+// ok=false on invalid input. Mirrors parseDirectoryPaging — separate because
+// the bounds differ and the two specs evolve independently.
+func parseActivityPaging(w http.ResponseWriter, r *http.Request) (limit, offset int, ok bool) {
+	limit = activityDefaultLimit
+	if s := r.URL.Query().Get("limit"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 1 || n > activityMaxLimit {
+			writeError(w, http.StatusBadRequest, "limit must be an integer between 1 and 100")
+			return 0, 0, false
+		}
+		limit = n
+	}
+	if s := r.URL.Query().Get("offset"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 0 {
+			writeError(w, http.StatusBadRequest, "offset must be a non-negative integer")
+			return 0, 0, false
+		}
+		offset = n
+	}
+	return limit, offset, true
+}

--- a/dc-api/internal/api/handlers/activity_test.go
+++ b/dc-api/internal/api/handlers/activity_test.go
@@ -1,0 +1,98 @@
+// Package handlers — activity_test.go
+//
+// Unit tests for ActivityHandler.List's request validation: the limit/offset
+// 400 paths and the missing-project-context guard, all of which return before
+// the repository is touched (so a nil *db.Repository is safe — same reasoning
+// as role_assignments_test.go). The happy path (join shape, ordering,
+// pagination, cross-project isolation) needs a real database and is covered in
+// test/integration/activity_test.go (runs cluster-free with DCAPI_TEST_NOP=1).
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/dc-api/internal/api/middleware"
+)
+
+// activityRequest builds a GET request to target with the project UUID the
+// ProjectContext middleware would inject. A nil projectUUID leaves the context
+// bare (simulating a route mounted outside the project group).
+func activityRequest(target string, projectUUID *uuid.UUID) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	if projectUUID != nil {
+		ctx := context.WithValue(r.Context(), middleware.ContextKeyProjectUUID, *projectUUID)
+		r = r.WithContext(ctx)
+	}
+	return r
+}
+
+func TestActivityList_NoProjectContext_Returns500(t *testing.T) {
+	t.Parallel()
+	h := NewActivityHandler(nil, zerolog.Nop())
+	w := httptest.NewRecorder()
+
+	h.List(w, activityRequest("/v1/tenants/acme/projects/default/activity", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "no project UUID in context", errorField(t, w.Body.Bytes()))
+}
+
+func TestActivityList_InvalidPaging_Returns400(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"limit zero", "?limit=0"},
+		{"limit above max", "?limit=101"},
+		{"limit negative", "?limit=-1"},
+		{"limit non-integer", "?limit=abc"},
+		{"offset negative", "?offset=-1"},
+		{"offset non-integer", "?offset=xyz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := NewActivityHandler(nil, zerolog.Nop())
+			w := httptest.NewRecorder()
+			pu := uuid.New()
+
+			// A nil repo proves validation rejects the request BEFORE any DB
+			// access — reaching the repository would panic.
+			h.List(w, activityRequest("/v1/tenants/acme/projects/default/activity"+tc.query, &pu))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			errorField(t, w.Body.Bytes()) // must be the spec's Error envelope
+		})
+	}
+}
+
+func TestParseActivityPaging_Defaults(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/activity", nil)
+
+	limit, offset, ok := parseActivityPaging(w, r)
+
+	assert.True(t, ok)
+	assert.Equal(t, 20, limit, "spec default limit is 20")
+	assert.Equal(t, 0, offset, "spec default offset is 0")
+}
+
+func TestParseActivityPaging_Boundaries(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/activity?limit=100&offset=37", nil)
+
+	limit, offset, ok := parseActivityPaging(w, r)
+
+	assert.True(t, ok, "limit=100 is the inclusive maximum and must be accepted")
+	assert.Equal(t, 100, limit)
+	assert.Equal(t, 37, offset)
+}

--- a/dc-api/internal/api/handlers/bastion.go
+++ b/dc-api/internal/api/handlers/bastion.go
@@ -262,12 +262,6 @@ func (h *BastionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: resource.ID,
-		ActorID:    userID,
-		Action:     "CREATE",
-		ToStatus:   models.StatusPending,
-	})
 
 	// VPC DNS server IP (F20) so the bastion's resolv.conf matches the VPC.
 	dnsSrvIP := ""
@@ -370,7 +364,6 @@ func (h *BastionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !requireAction(w, r, h.repo, rbac.ActionBastionDelete) {
 		return
 	}
-	userID, _ := middleware.UserFromContext(r.Context())
 
 	id, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
@@ -387,13 +380,6 @@ func (h *BastionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update bastion status")
 		return
 	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: id,
-		ActorID:    userID,
-		Action:     "DELETE",
-		FromStatus: resource.Status,
-		ToStatus:   models.StatusDeleting,
-	})
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -422,14 +408,6 @@ func (h *BastionHandler) asyncProvision(resourceID uuid.UUID, tenantID, projectI
 		h.log.Error().Err(err).Str("bastion", spec.Name).Msg("harvester CreateVM (bastion) failed")
 		_ = h.repo.UpdateStatus(ctx, resourceID, models.StatusFailed,
 			"provisioning failed: "+err.Error(), "")
-		_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-			ResourceID: resourceID,
-			ActorID:    userID,
-			Action:     "STATUS_CHANGE",
-			FromStatus: models.StatusPending,
-			ToStatus:   models.StatusFailed,
-			Message:    err.Error(),
-		})
 		return
 	}
 

--- a/dc-api/internal/api/handlers/cluster.go
+++ b/dc-api/internal/api/handlers/cluster.go
@@ -429,12 +429,6 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: resource.ID,
-		ActorID:    userID,
-		Action:     "CREATE",
-		ToStatus:   models.StatusPending,
-	})
 
 	// Pre-generate the HarvesterConfig CR name so the provider can use it
 	// deterministically and the reconciler knows which CR to cascade-clean.
@@ -648,7 +642,6 @@ func (h *ClusterHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !requireAction(w, r, h.repo, rbac.ActionClusterDelete) {
 		return
 	}
-	userID, _ := middleware.UserFromContext(r.Context())
 
 	rawID := chi.URLParam(r, "id")
 	id, err := uuid.Parse(rawID)
@@ -664,10 +657,6 @@ func (h *ClusterHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_ = h.repo.UpdateStatus(r.Context(), id, models.StatusDeleting, "deletion requested", "")
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: id, ActorID: userID, Action: "DELETE",
-		FromStatus: resource.Status, ToStatus: models.StatusDeleting,
-	})
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -1028,10 +1017,6 @@ func (h *ClusterHandler) asyncProvision(resourceID uuid.UUID, tenantID, projectI
 		h.log.Error().Err(err).Str("cluster", spec.Name).Msg("rancher CreateCluster failed")
 		_ = h.repo.UpdateStatus(ctx, resourceID, models.StatusFailed,
 			"provisioning failed: "+err.Error(), "")
-		_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-			ResourceID: resourceID, ActorID: userID, Action: "STATUS_CHANGE",
-			FromStatus: models.StatusPending, ToStatus: models.StatusFailed, Message: err.Error(),
-		})
 		// Mark system pool failed too.
 		if sysPool, pErr := h.repo.GetNodePool(ctx, resourceID, "system"); pErr == nil {
 			sysPool.Status = models.NodePoolStatusFailed

--- a/dc-api/internal/api/handlers/database.go
+++ b/dc-api/internal/api/handlers/database.go
@@ -262,6 +262,11 @@ func (h *DatabaseHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	actorID, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: created.ID, ActorID: actorID, Action: "CREATE", ToStatus: created.Status,
+	})
+
 	// ── Drive the operator ─────────────────────────────────────────────
 	// Failures here don't roll back the DB row — they leave the row in
 	// PENDING with a diagnostic message the caller surfaces via GET. Same
@@ -455,6 +460,12 @@ func (h *DatabaseHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Audit before the hard delete — the snapshot resolves only while the
+	// row exists.
+	actorID, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: d.ID, ActorID: actorID, Action: "DELETE", FromStatus: d.Status,
+	})
 	if err := h.repo.DeleteDatabase(r.Context(), id); err != nil {
 		if errors.Is(err, db.ErrDatabaseNotFound) {
 			writeError(w, http.StatusNotFound, "database not found")

--- a/dc-api/internal/api/handlers/database.go
+++ b/dc-api/internal/api/handlers/database.go
@@ -262,10 +262,6 @@ func (h *DatabaseHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actorID, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: created.ID, ActorID: actorID, Action: "CREATE", ToStatus: created.Status,
-	})
 
 	// ── Drive the operator ─────────────────────────────────────────────
 	// Failures here don't roll back the DB row — they leave the row in
@@ -460,12 +456,6 @@ func (h *DatabaseHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Audit before the hard delete — the snapshot resolves only while the
-	// row exists.
-	actorID, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: d.ID, ActorID: actorID, Action: "DELETE", FromStatus: d.Status,
-	})
 	if err := h.repo.DeleteDatabase(r.Context(), id); err != nil {
 		if errors.Is(err, db.ErrDatabaseNotFound) {
 			writeError(w, http.StatusNotFound, "database not found")

--- a/dc-api/internal/api/handlers/dns_zone.go
+++ b/dc-api/internal/api/handlers/dns_zone.go
@@ -221,9 +221,6 @@ func (h *PrivateDnsZoneHandler) CreateZone(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: zone.ID, ActorID: userID, Action: "CREATE", ToStatus: models.StatusPending,
-	})
 
 	go h.asyncProvisionZone(zone.ID, tenantID, userID, vnet.BackendUID, models.DnsZoneSpec{
 		ZoneName:    req.Name,
@@ -317,7 +314,6 @@ func (h *PrivateDnsZoneHandler) DeleteZone(w http.ResponseWriter, r *http.Reques
 	if !requireAction(w, r, h.repo, rbac.ActionDNSZoneDelete) {
 		return
 	}
-	userID, _ := middleware.UserFromContext(r.Context())
 
 	vnet, ok := h.requireActiveVNetForZone(w, r, tenantUUID, projectUUID)
 	if !ok {
@@ -338,10 +334,6 @@ func (h *PrivateDnsZoneHandler) DeleteZone(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusInternalServerError, "failed to update DNS zone status")
 		return
 	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: zoneID, ActorID: userID, Action: "DELETE",
-		FromStatus: zone.Status, ToStatus: models.StatusDeleting,
-	})
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -372,10 +364,6 @@ func (h *PrivateDnsZoneHandler) asyncProvisionZone(zoneID uuid.UUID, tenantID, u
 		h.log.Error().Err(err).Str("zone", spec.ZoneName).Msg("kubeovn CreatePrivateDnsZone failed")
 		_ = h.repo.UpdateDNSZoneStatus(ctx, zoneID, models.StatusFailed,
 			"provisioning failed: "+err.Error(), "")
-		_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-			ResourceID: zoneID, ActorID: userID, Action: "STATUS_CHANGE",
-			FromStatus: models.StatusPending, ToStatus: models.StatusFailed, Message: err.Error(),
-		})
 		return
 	}
 
@@ -386,10 +374,6 @@ func (h *PrivateDnsZoneHandler) asyncProvisionZone(zoneID uuid.UUID, tenantID, u
 	}
 	h.log.Info().Str("zone_id", zoneID.String()).Str("backend_uid", providerRes.BackendUID).
 		Msg("asyncProvisionZone: zone marked ACTIVE")
-	_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-		ResourceID: zoneID, ActorID: userID, Action: "STATUS_CHANGE",
-		FromStatus: models.StatusPending, ToStatus: models.StatusActive,
-	})
 }
 
 // ── Record Handlers ───────────────────────────────────────────────────────────

--- a/dc-api/internal/api/handlers/keyvault.go
+++ b/dc-api/internal/api/handlers/keyvault.go
@@ -182,6 +182,11 @@ func (h *KeyVaultHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	actorID, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: kv.ID, ActorID: actorID, Action: "CREATE", ToStatus: kv.Status,
+	})
+
 	// KVI mode: drive the operator's CRDs. Failures here don't roll back
 	// the DB row — they leave the row in PENDING with a diagnostic message
 	// the caller can surface via GET.
@@ -427,6 +432,12 @@ func (h *KeyVaultHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Audit before the hard delete — the snapshot resolves only while the
+	// row exists.
+	actorID, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: kv.ID, ActorID: actorID, Action: "DELETE", FromStatus: kv.Status,
+	})
 	if err := h.repo.DeleteKeyVault(r.Context(), id); err != nil {
 		if errors.Is(err, db.ErrKeyVaultNotFound) {
 			writeError(w, http.StatusNotFound, "key vault not found")

--- a/dc-api/internal/api/handlers/keyvault.go
+++ b/dc-api/internal/api/handlers/keyvault.go
@@ -182,10 +182,6 @@ func (h *KeyVaultHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actorID, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: kv.ID, ActorID: actorID, Action: "CREATE", ToStatus: kv.Status,
-	})
 
 	// KVI mode: drive the operator's CRDs. Failures here don't roll back
 	// the DB row — they leave the row in PENDING with a diagnostic message
@@ -432,12 +428,6 @@ func (h *KeyVaultHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Audit before the hard delete — the snapshot resolves only while the
-	// row exists.
-	actorID, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: kv.ID, ActorID: actorID, Action: "DELETE", FromStatus: kv.Status,
-	})
 	if err := h.repo.DeleteKeyVault(r.Context(), id); err != nil {
 		if errors.Is(err, db.ErrKeyVaultNotFound) {
 			writeError(w, http.StatusNotFound, "key vault not found")

--- a/dc-api/internal/api/handlers/nsg.go
+++ b/dc-api/internal/api/handlers/nsg.go
@@ -220,6 +220,11 @@ func (h *NSGHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	actorID, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: nsg.ID, ActorID: actorID, Action: "CREATE", ToStatus: nsg.Status,
+	})
+
 	// Two-step: CreateNSG driver call.
 	spec := models.NSGSpec{
 		Name:        req.Name,
@@ -419,6 +424,12 @@ func (h *NSGHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Audit before the hard delete — the snapshot resolves only while the
+	// row exists.
+	actorID, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: id, ActorID: actorID, Action: "DELETE", FromStatus: nsg.Status,
+	})
 	if err := h.repo.DeleteNSG(r.Context(), id); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete NSG")
 		return

--- a/dc-api/internal/api/handlers/nsg.go
+++ b/dc-api/internal/api/handlers/nsg.go
@@ -220,10 +220,6 @@ func (h *NSGHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	actorID, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: nsg.ID, ActorID: actorID, Action: "CREATE", ToStatus: nsg.Status,
-	})
 
 	// Two-step: CreateNSG driver call.
 	spec := models.NSGSpec{
@@ -424,12 +420,6 @@ func (h *NSGHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	// Audit before the hard delete — the snapshot resolves only while the
-	// row exists.
-	actorID, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: id, ActorID: actorID, Action: "DELETE", FromStatus: nsg.Status,
-	})
 	if err := h.repo.DeleteNSG(r.Context(), id); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete NSG")
 		return

--- a/dc-api/internal/api/handlers/peering.go
+++ b/dc-api/internal/api/handlers/peering.go
@@ -226,13 +226,6 @@ func (h *PeeringHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: peering.ID,
-		ActorID:    userID,
-		Action:     "CREATE",
-		ToStatus:   models.StatusPending,
-		Message:    fmt.Sprintf("vnet_id=%s peer_vnet_id=%s", vnetID, peerID),
-	})
 
 	// F6: allocate the transit /24 BEFORE the async goroutine fires. Doing it
 	// inline lets us surface "pool exhausted" or DB errors as a synchronous
@@ -349,7 +342,6 @@ func (h *PeeringHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !requireAction(w, r, h.repo, rbac.ActionPeeringDelete) {
 		return
 	}
-	userID, _ := middleware.UserFromContext(r.Context())
 
 	vnetID, err := uuid.Parse(chi.URLParam(r, "vnet_id"))
 	if err != nil {
@@ -407,10 +399,6 @@ func (h *PeeringHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update peering status")
 		return
 	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: peeringID, ActorID: userID, Action: "DELETE",
-		FromStatus: peering.Status, ToStatus: models.StatusDeleting,
-	})
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -454,10 +442,6 @@ func (h *PeeringHandler) asyncProvisionPeering(
 		h.log.Error().Err(err).Str("peering", spec.Name).Msg("kubeovn CreatePeering failed")
 		_ = h.repo.UpdatePeeringStatus(ctx, peeringID, models.StatusFailed,
 			"provisioning failed: "+err.Error(), "")
-		_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-			ResourceID: peeringID, ActorID: userID, Action: "STATUS_CHANGE",
-			FromStatus: models.StatusPending, ToStatus: models.StatusFailed, Message: err.Error(),
-		})
 		return
 	}
 
@@ -471,8 +455,4 @@ func (h *PeeringHandler) asyncProvisionPeering(
 	h.log.Info().Str("peering_id", peeringID.String()).
 		Str("backend_uid", providerRes.BackendUID).
 		Msg("asyncProvisionPeering: peering marked ACTIVE")
-	_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-		ResourceID: peeringID, ActorID: userID, Action: "STATUS_CHANGE",
-		FromStatus: models.StatusPending, ToStatus: models.StatusActive,
-	})
 }

--- a/dc-api/internal/api/handlers/private_endpoint.go
+++ b/dc-api/internal/api/handlers/private_endpoint.go
@@ -250,6 +250,11 @@ func (h *PrivateEndpointHandler) Create(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	actorID, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: ep.ID, ActorID: actorID, Action: "CREATE", ToStatus: models.StatusPending,
+	})
+
 	// Gather sibling host records (other endpoints in the same VPC, ACTIVE).
 	siblings, err := h.repo.ListPrivateEndpointsByVNet(r.Context(), vnetUUID)
 	if err != nil {
@@ -290,6 +295,10 @@ func (h *PrivateEndpointHandler) Create(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		h.log.Error().Err(err).Str("endpoint", ep.ID.String()).Msg("private-endpoint: provision failed")
 		_ = h.repo.UpdatePrivateEndpointStatus(r.Context(), ep.ID, models.StatusFailed, err.Error(), "", "", "")
+		_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+			ResourceID: ep.ID, ActorID: actorID, Action: "STATUS_CHANGE",
+			FromStatus: models.StatusPending, ToStatus: models.StatusFailed, Message: err.Error(),
+		})
 		writeError(w, http.StatusInternalServerError, "provisioning failed: "+err.Error())
 		return
 	}
@@ -300,6 +309,10 @@ func (h *PrivateEndpointHandler) Create(w http.ResponseWriter, r *http.Request) 
 		// Provisioner succeeded but DB update failed — caller will see a stale
 		// PENDING. Don't roll back the proxy; let the reconciler heal it.
 	}
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: ep.ID, ActorID: actorID, Action: "STATUS_CHANGE",
+		FromStatus: models.StatusPending, ToStatus: models.StatusActive,
+	})
 
 	final, err := h.repo.GetPrivateEndpoint(r.Context(), ep.ID)
 	if err != nil {
@@ -468,6 +481,12 @@ func (h *PrivateEndpointHandler) Delete(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Audit before the hard delete — the snapshot resolves only while the
+	// row exists.
+	delActor, _ := middleware.UserFromContext(r.Context())
+	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
+		ResourceID: ep.ID, ActorID: delActor, Action: "DELETE", FromStatus: ep.Status,
+	})
 	if err := h.repo.DeletePrivateEndpoint(r.Context(), ep.ID); err != nil {
 		h.log.Error().Err(err).Msg("private-endpoint: delete row")
 		writeError(w, http.StatusInternalServerError, "failed to delete endpoint row")

--- a/dc-api/internal/api/handlers/private_endpoint.go
+++ b/dc-api/internal/api/handlers/private_endpoint.go
@@ -250,10 +250,6 @@ func (h *PrivateEndpointHandler) Create(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	actorID, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: ep.ID, ActorID: actorID, Action: "CREATE", ToStatus: models.StatusPending,
-	})
 
 	// Gather sibling host records (other endpoints in the same VPC, ACTIVE).
 	siblings, err := h.repo.ListPrivateEndpointsByVNet(r.Context(), vnetUUID)
@@ -295,10 +291,6 @@ func (h *PrivateEndpointHandler) Create(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		h.log.Error().Err(err).Str("endpoint", ep.ID.String()).Msg("private-endpoint: provision failed")
 		_ = h.repo.UpdatePrivateEndpointStatus(r.Context(), ep.ID, models.StatusFailed, err.Error(), "", "", "")
-		_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-			ResourceID: ep.ID, ActorID: actorID, Action: "STATUS_CHANGE",
-			FromStatus: models.StatusPending, ToStatus: models.StatusFailed, Message: err.Error(),
-		})
 		writeError(w, http.StatusInternalServerError, "provisioning failed: "+err.Error())
 		return
 	}
@@ -309,10 +301,6 @@ func (h *PrivateEndpointHandler) Create(w http.ResponseWriter, r *http.Request) 
 		// Provisioner succeeded but DB update failed — caller will see a stale
 		// PENDING. Don't roll back the proxy; let the reconciler heal it.
 	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: ep.ID, ActorID: actorID, Action: "STATUS_CHANGE",
-		FromStatus: models.StatusPending, ToStatus: models.StatusActive,
-	})
 
 	final, err := h.repo.GetPrivateEndpoint(r.Context(), ep.ID)
 	if err != nil {
@@ -481,12 +469,6 @@ func (h *PrivateEndpointHandler) Delete(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Audit before the hard delete — the snapshot resolves only while the
-	// row exists.
-	delActor, _ := middleware.UserFromContext(r.Context())
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: ep.ID, ActorID: delActor, Action: "DELETE", FromStatus: ep.Status,
-	})
 	if err := h.repo.DeletePrivateEndpoint(r.Context(), ep.ID); err != nil {
 		h.log.Error().Err(err).Msg("private-endpoint: delete row")
 		writeError(w, http.StatusInternalServerError, "failed to delete endpoint row")

--- a/dc-api/internal/api/handlers/role_assignments.go
+++ b/dc-api/internal/api/handlers/role_assignments.go
@@ -206,7 +206,6 @@ func (h *RoleAssignmentsHandler) Create(w http.ResponseWriter, r *http.Request) 
 	// used as the display_alias default.
 	principalID := req.UserSub
 	displayAlias := req.DisplayAlias
-	resolvedFromEmail := false
 	if req.UserEmail != "" {
 		if h.directory == nil {
 			writeError(w, http.StatusUnprocessableEntity,
@@ -244,7 +243,6 @@ func (h *RoleAssignmentsHandler) Create(w http.ResponseWriter, r *http.Request) 
 				displayAlias = req.UserEmail
 			}
 		}
-		resolvedFromEmail = true
 	}
 
 	ra, err := h.repo.CreateRoleAssignment(r.Context(), models.RoleAssignment{
@@ -279,22 +277,11 @@ func (h *RoleAssignmentsHandler) Create(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Audit: record email resolution explicitly. Emails in audit_events are
-	// fine — audit is internal; the no-PII rule applies to the
-	// role_assignments row (where display_alias defaults to the resolved IdP
-	// display name, falling back to the email).
-	auditMsg := fmt.Sprintf("granted %s to %s at %s %s",
-		req.RoleDefinition, principalID, scope.Type, scope.ID)
-	if resolvedFromEmail {
-		auditMsg = fmt.Sprintf("granted %s to %s (resolved from %s) at %s %s",
-			req.RoleDefinition, principalID, req.UserEmail, scope.Type, scope.ID)
-	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: ra.ID,
-		ActorID:    callerID,
-		Action:     "ROLE_ASSIGNMENT_CREATE",
-		Message:    auditMsg,
-	})
+	// NOTE: role grants are IAM events, not resource lifecycle — they are
+	// outside the audit framework's resource registry today. Extending the
+	// framework with an IAM event kind is tracked as follow-up work; the old
+	// inline audit write here had never actually inserted a row (its
+	// principal UUID was unresolvable under every historical schema).
 
 	writeJSON(w, http.StatusCreated, toRoleAssignmentResponse(ra))
 }
@@ -348,7 +335,7 @@ func (h *RoleAssignmentsHandler) Remove(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	_, callerID, ok := middleware.PrincipalFromContext(r.Context())
+	_, _, ok = middleware.PrincipalFromContext(r.Context())
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "no principal in context")
 		return
@@ -383,12 +370,6 @@ func (h *RoleAssignmentsHandler) Remove(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		// ResourceID intentionally zero — removal affects multiple rows atomically.
-		ActorID: callerID,
-		Action:  "ROLE_ASSIGNMENT_DELETE",
-		Message: fmt.Sprintf("revoked %s at %s %s", targetPrincipalID, scope.Type, scope.ID),
-	})
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/dc-api/internal/api/handlers/service_accounts.go
+++ b/dc-api/internal/api/handlers/service_accounts.go
@@ -246,13 +246,6 @@ func (h *ServiceAccountHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: sa.ID,
-		ActorID:    callerID,
-		Action:     "SERVICE_ACCOUNT_CREATE",
-		Message: fmt.Sprintf("created service account %s with role %s",
-			req.Name, req.Role),
-	})
 
 	writeJSON(w, http.StatusCreated, createServiceAccountResponse{
 		ID:          sa.ID.String(),
@@ -383,7 +376,7 @@ func (h *ServiceAccountHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, callerID, ok := middleware.PrincipalFromContext(r.Context())
+	_, _, ok = middleware.PrincipalFromContext(r.Context())
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "no principal in context")
 		return
@@ -415,12 +408,6 @@ func (h *ServiceAccountHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: saID,
-		ActorID:    callerID,
-		Action:     "SERVICE_ACCOUNT_DELETE",
-		Message:    fmt.Sprintf("deleted service account %s", sa.Name),
-	})
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/dc-api/internal/api/handlers/subnet.go
+++ b/dc-api/internal/api/handlers/subnet.go
@@ -231,9 +231,6 @@ func (h *SubnetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: subnet.ID, ActorID: userID, Action: "CREATE", ToStatus: models.StatusPending,
-	})
 
 	// Async: call KubeOVN CreateSubnet.
 	go h.asyncProvisionSubnet(subnet.ID, vnet.ID, tenantID, projectID, userID, vnet.BackendUID, models.SubnetSpec{
@@ -334,7 +331,6 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !requireAction(w, r, h.repo, rbac.ActionSubnetDelete) {
 		return
 	}
-	userID, _ := middleware.UserFromContext(r.Context())
 
 	vnetID, err := uuid.Parse(chi.URLParam(r, "vnet_id"))
 	if err != nil {
@@ -394,10 +390,6 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update subnet status")
 		return
 	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: subnetID, ActorID: userID, Action: "DELETE",
-		FromStatus: subnet.Status, ToStatus: models.StatusDeleting,
-	})
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -484,19 +476,11 @@ func (h *SubnetHandler) asyncProvisionSubnet(subnetID, vnetID uuid.UUID, tenantI
 		h.log.Error().Err(err).Str("subnet", spec.Name).Msg("kubeovn CreateSubnet failed")
 		_ = h.repo.UpdateSubnetStatus(ctx, subnetID, models.StatusFailed,
 			"provisioning failed: "+err.Error(), "")
-		_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-			ResourceID: subnetID, ActorID: userID, Action: "STATUS_CHANGE",
-			FromStatus: models.StatusPending, ToStatus: models.StatusFailed, Message: err.Error(),
-		})
 		return
 	}
 
 	_ = h.repo.UpdateSubnetStatus(ctx, subnetID, models.StatusActive,
 		"subnet provisioned", providerRes.BackendUID)
-	_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-		ResourceID: subnetID, ActorID: userID, Action: "STATUS_CHANGE",
-		FromStatus: models.StatusPending, ToStatus: models.StatusActive,
-	})
 
 	// ── F15: provision per-VPC SNAT if this is the first subnet on the VPC ────
 	// SNAT operates at the VPC router boundary — opaque to any cluster CNI a

--- a/dc-api/internal/api/handlers/vm.go
+++ b/dc-api/internal/api/handlers/vm.go
@@ -363,12 +363,6 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Record the creation event in the audit log.
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: resource.ID,
-		ActorID:    userID,
-		Action:     "CREATE",
-		ToStatus:   models.StatusPending,
-	})
 
 	// ── Step 5: trigger async provisioning ───────────────────────────────────
 	// We return 202 immediately and provision in the background.
@@ -477,7 +471,6 @@ func (h *VMHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !requireAction(w, r, h.repo, rbac.ActionVMDelete) {
 		return
 	}
-	userID, _ := middleware.UserFromContext(r.Context())
 
 	rawID := chi.URLParam(r, "id")
 	id, err := uuid.Parse(rawID)
@@ -497,13 +490,6 @@ func (h *VMHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update resource status")
 		return
 	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: id,
-		ActorID:    userID,
-		Action:     "DELETE",
-		FromStatus: resource.Status,
-		ToStatus:   models.StatusDeleting,
-	})
 
 	// Async: call Harvester delete. The reconciler detects the 404 from Harvester
 	// and removes the DB row — consistent with how cluster deletion works.
@@ -544,14 +530,6 @@ func (h *VMHandler) asyncProvision(resourceID uuid.UUID, tenantID, projectID, us
 		h.log.Error().Err(err).Str("vm", spec.Name).Msg("harvester CreateVM failed")
 		_ = h.repo.UpdateStatus(ctx, resourceID, models.StatusFailed,
 			"provisioning failed: "+err.Error(), "")
-		_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-			ResourceID: resourceID,
-			ActorID:    userID,
-			Action:     "STATUS_CHANGE",
-			FromStatus: models.StatusPending,
-			ToStatus:   models.StatusFailed,
-			Message:    err.Error(),
-		})
 		return
 	}
 

--- a/dc-api/internal/api/handlers/vnet.go
+++ b/dc-api/internal/api/handlers/vnet.go
@@ -206,12 +206,6 @@ func (h *VNetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: vnet.ID,
-		ActorID:    userID,
-		Action:     "CREATE",
-		ToStatus:   models.StatusPending,
-	})
 
 	go h.asyncProvisionVNet(vnet.ID, tenantID, projectID, userID, models.VNetSpec{
 		Name:         req.Name,
@@ -285,7 +279,6 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !requireAction(w, r, h.repo, rbac.ActionVNetDelete) {
 		return
 	}
-	userID, _ := middleware.UserFromContext(r.Context())
 
 	tenantUUID, ok := middleware.TenantUUIDFromContext(r.Context())
 	if !ok {
@@ -363,13 +356,6 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update VNet status")
 		return
 	}
-	_ = h.repo.AppendAuditEvent(r.Context(), &models.AuditEvent{
-		ResourceID: id,
-		ActorID:    userID,
-		Action:     "DELETE",
-		FromStatus: vnet.Status,
-		ToStatus:   models.StatusDeleting,
-	})
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -421,10 +407,6 @@ func (h *VNetHandler) asyncProvisionVNet(resourceID uuid.UUID, tenantID, project
 		h.log.Error().Err(err).Str("vnet", spec.Name).Msg(msg)
 		_ = h.repo.UpdateVNetStatus(ctx, resourceID, models.StatusFailed,
 			msg+": "+err.Error(), "")
-		_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-			ResourceID: resourceID, ActorID: userID, Action: "STATUS_CHANGE",
-			FromStatus: models.StatusPending, ToStatus: models.StatusFailed, Message: err.Error(),
-		})
 	}
 
 	// ── 1. Create KubeOVN VPC ─────────────────────────────────────────────────
@@ -441,8 +423,4 @@ func (h *VNetHandler) asyncProvisionVNet(resourceID uuid.UUID, tenantID, project
 
 	_ = h.repo.UpdateVNetStatus(ctx, resourceID, models.StatusActive,
 		"VNet provisioned", vpcName)
-	_ = h.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-		ResourceID: resourceID, ActorID: userID, Action: "STATUS_CHANGE",
-		FromStatus: models.StatusPending, ToStatus: models.StatusActive,
-	})
 }

--- a/dc-api/internal/api/middleware/auth.go
+++ b/dc-api/internal/api/middleware/auth.go
@@ -61,6 +61,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/uuid"
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/api/respond"
 	"github.com/wso2/dc-api/internal/models"
 	"golang.org/x/oauth2"
@@ -395,6 +396,8 @@ func (c *AuthConfig) buildContext(reqCtx context.Context, claims Claims) context
 	ctx = context.WithValue(ctx, ContextKeyPrincipalType, models.PrincipalTypeUser)
 	ctx = context.WithValue(ctx, ContextKeyPrincipalID, claims.Sub)
 	ctx = context.WithValue(ctx, ContextKeyIsAdmin, isAdmin)
+	// Stamp the actor for the repository layer's automatic audit recording.
+	ctx = audit.WithActor(ctx, claims.Sub)
 	return ctx
 }
 

--- a/dc-api/internal/api/middleware/serviceaccount.go
+++ b/dc-api/internal/api/middleware/serviceaccount.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/respond"
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -151,6 +152,8 @@ func (a *ServiceAccountAuth) Validate(next http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, ContextKeyIsAdmin, false) // SAs cannot be platform-admin in M1.5
 		// ContextKeyUserID: set to sa.ID.String() for legacy compat — audit_events.actor_id expects a string here.
 		ctx = context.WithValue(ctx, ContextKeyUserID, sa.ID.String())
+		// Stamp the actor for the repository layer's automatic audit recording.
+		ctx = audit.WithActor(ctx, sa.ID.String())
 
 		// ── Fire-and-forget last_used update ────────────────────────────────
 		// We do not block the request on this write. A failed update is only

--- a/dc-api/internal/api/router.go
+++ b/dc-api/internal/api/router.go
@@ -209,6 +209,9 @@ func NewRouter(deps RouterDeps) http.Handler {
 		// and gets booleans back, so it never re-implements the matcher.
 		permissionsHandler := handlers.NewPermissionsHandler(deps.Repo, deps.Log)
 
+		// Project activity feed — read-only, paginated audit-event listing.
+		activityHandler := handlers.NewActivityHandler(deps.Repo, deps.Log)
+
 		// M1.5 Chunk 7 — service account management handler.
 		serviceAccountHandler := handlers.NewServiceAccountHandler(deps.Repo, deps.Log)
 
@@ -323,6 +326,11 @@ func NewRouter(deps RouterDeps) http.Handler {
 					// ProjectContext makes the active scope the project, so the engine
 					// answers "may I do X in THIS project". Self-check, so ungated.
 					r.Post("/permissions:check", permissionsHandler.Check) // POST .../projects/{project_id}/permissions:check
+
+					// Project activity feed — newest-first audit events for every
+					// resource in the project. Read-only; Reader's */read covers
+					// the action, so any project member can see it.
+					r.Method(http.MethodGet, "/activity", gate(rbac.ActionActivityRead, activityHandler.List)) // GET .../projects/{project_id}/activity
 
 					// ── Virtual Machines ────────────────────────────────────
 					r.Route("/virtual-machines", func(r chi.Router) {

--- a/dc-api/internal/audit/audit.go
+++ b/dc-api/internal/audit/audit.go
@@ -1,0 +1,58 @@
+// Package audit carries the cross-cutting pieces of the audit framework that
+// must be visible to several layers without import cycles: the action
+// vocabulary and the actor attribution that rides the request context.
+//
+// ── THE AUDIT FRAMEWORK ──────────────────────────────────────────────────────
+//
+// Lifecycle auditing is automatic at the repository layer: every family's
+// Create* method records CREATE, every Update*Status method records
+// STATUS_CHANGE (capturing the previous status via RETURNING and skipping
+// no-op transitions), and every Delete* row removal records a terminal
+// DELETE event with to_status DELETED — before the row goes away, so the
+// identity snapshot resolves. Handlers and the reconciler write NO audit
+// events themselves.
+//
+// A new resource family is therefore audited automatically by following the
+// repository template (Create/UpdateStatus/Delete wired through the db
+// package's record helpers). The remaining per-family declarations are the
+// resource_type value in openapi.yaml's ActivityEvent enum and, when the
+// family has a detail page, cloud-ui's ACTIVITY_RESOURCE_ROUTES entry.
+//
+// Actor attribution: the auth middlewares stamp the authenticated principal
+// onto the request context with WithActor; background workers stamp their
+// own identity (e.g. "reconciler"). ActorFromContext falls back to "system"
+// so an event is never attributed to an empty string.
+package audit
+
+import "context"
+
+// Actions recorded on audit events. The vocabulary is deliberately small —
+// states carry the detail; actions classify the row.
+const (
+	ActionCreate       = "CREATE"
+	ActionStatusChange = "STATUS_CHANGE"
+	ActionDelete       = "DELETE"
+)
+
+// SystemActor attributes events that no principal initiated directly.
+const SystemActor = "system"
+
+type ctxKey struct{}
+
+// WithActor stamps the acting principal (OIDC sub, service-account ID, or a
+// worker name like "reconciler") onto the context for the repository layer's
+// automatic audit recording.
+func WithActor(ctx context.Context, actor string) context.Context {
+	if actor == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKey{}, actor)
+}
+
+// ActorFromContext returns the stamped actor, or SystemActor when none is.
+func ActorFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKey{}).(string); ok && v != "" {
+		return v
+	}
+	return SystemActor
+}

--- a/dc-api/internal/db/activity.go
+++ b/dc-api/internal/db/activity.go
@@ -1,0 +1,81 @@
+// Package db — activity.go
+//
+// Read side of the audit log: the per-project activity feed. The write side
+// (AppendAuditEvent) lives in db.go. audit_events rows carry no tenant/project
+// columns of their own — project scoping comes from joining the owning
+// resources row, whose project_uuid is the immutable isolation filter
+// (see docs/dc-api-architecture.md). Because the FK is ON DELETE CASCADE,
+// events vanish with their resource; the feed covers live resources only.
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/wso2/dc-api/internal/models"
+)
+
+// ListProjectActivity returns one page of audit events for every resource in
+// the project, newest first, plus the total event count across all pages so
+// callers can paginate. limit/offset are trusted here — the handler validates
+// them (limit 1..100, offset >= 0) before calling.
+//
+// Ordering is (created_at DESC, id DESC): created_at alone is not unique
+// (bulk operations land in the same millisecond), and a non-deterministic
+// tie-break would let rows repeat or vanish across pages.
+func (r *Repository) ListProjectActivity(ctx context.Context, projectUUID uuid.UUID, limit, offset int) ([]models.ActivityEntry, int, error) {
+	const countQ = `
+		SELECT COUNT(*)
+		FROM   audit_events ae
+		JOIN   resources res ON res.id = ae.resource_id
+		WHERE  res.project_uuid = $1`
+
+	var total int
+	if err := r.pool.QueryRow(ctx, countQ, projectUUID).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("db count project activity: %w", err)
+	}
+
+	const q = `
+		SELECT ae.id, ae.resource_id, res.name, res.type,
+		       ae.actor_id, ae.action, ae.from_status, ae.to_status, ae.message,
+		       ae.created_at
+		FROM   audit_events ae
+		JOIN   resources res ON res.id = ae.resource_id
+		WHERE  res.project_uuid = $1
+		ORDER  BY ae.created_at DESC, ae.id DESC
+		LIMIT  $2 OFFSET $3`
+
+	rows, err := r.pool.Query(ctx, q, projectUUID, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("db list project activity: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []models.ActivityEntry
+	for rows.Next() {
+		var e models.ActivityEntry
+		var fromStatus, toStatus, message *string
+		if err := rows.Scan(
+			&e.ID, &e.ResourceID, &e.ResourceName, &e.ResourceType,
+			&e.ActorID, &e.Action, &fromStatus, &toStatus, &message,
+			&e.CreatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("db scan project activity: %w", err)
+		}
+		if fromStatus != nil {
+			e.FromStatus = models.ResourceStatus(*fromStatus)
+		}
+		if toStatus != nil {
+			e.ToStatus = models.ResourceStatus(*toStatus)
+		}
+		if message != nil {
+			e.Message = *message
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("db list project activity: %w", err)
+	}
+	return entries, total, nil
+}

--- a/dc-api/internal/db/activity.go
+++ b/dc-api/internal/db/activity.go
@@ -1,11 +1,11 @@
 // Package db — activity.go
 //
 // Read side of the audit log: the per-project activity feed. The write side
-// (AppendAuditEvent) lives in db.go. audit_events rows carry no tenant/project
-// columns of their own — project scoping comes from joining the owning
-// resources row, whose project_uuid is the immutable isolation filter
-// (see docs/dc-api-architecture.md). Because the FK is ON DELETE CASCADE,
-// events vanish with their resource; the feed covers live resources only.
+// (AppendAuditEvent) lives in db.go and snapshots the owning resource's
+// name/type and tenant/project UUIDs onto every event row, so this query
+// never joins resources and events survive resource deletion. project_uuid
+// on the event is the immutable isolation filter
+// (see docs/dc-api-architecture.md).
 package db
 
 import (
@@ -16,10 +16,10 @@ import (
 	"github.com/wso2/dc-api/internal/models"
 )
 
-// ListProjectActivity returns one page of audit events for every resource in
-// the project, newest first, plus the total event count across all pages so
-// callers can paginate. limit/offset are trusted here — the handler validates
-// them (limit 1..100, offset >= 0) before calling.
+// ListProjectActivity returns one page of audit events for the project,
+// newest first, plus the total event count across all pages so callers can
+// paginate. limit/offset are trusted here — the handler validates them
+// (limit 1..100, offset >= 0) before calling.
 //
 // Ordering is (created_at DESC, id DESC): created_at alone is not unique
 // (bulk operations land in the same millisecond), and a non-deterministic
@@ -27,9 +27,8 @@ import (
 func (r *Repository) ListProjectActivity(ctx context.Context, projectUUID uuid.UUID, limit, offset int) ([]models.ActivityEntry, int, error) {
 	const countQ = `
 		SELECT COUNT(*)
-		FROM   audit_events ae
-		JOIN   resources res ON res.id = ae.resource_id
-		WHERE  res.project_uuid = $1`
+		FROM   audit_events
+		WHERE  project_uuid = $1`
 
 	var total int
 	if err := r.pool.QueryRow(ctx, countQ, projectUUID).Scan(&total); err != nil {
@@ -37,12 +36,11 @@ func (r *Repository) ListProjectActivity(ctx context.Context, projectUUID uuid.U
 	}
 
 	const q = `
-		SELECT ae.id, ae.resource_id, res.name, res.type,
+		SELECT ae.id, ae.resource_id, ae.resource_name, ae.resource_type,
 		       ae.actor_id, ae.action, ae.from_status, ae.to_status, ae.message,
 		       ae.created_at
 		FROM   audit_events ae
-		JOIN   resources res ON res.id = ae.resource_id
-		WHERE  res.project_uuid = $1
+		WHERE  ae.project_uuid = $1
 		ORDER  BY ae.created_at DESC, ae.id DESC
 		LIMIT  $2 OFFSET $3`
 
@@ -55,13 +53,24 @@ func (r *Repository) ListProjectActivity(ctx context.Context, projectUUID uuid.U
 	var entries []models.ActivityEntry
 	for rows.Next() {
 		var e models.ActivityEntry
+		var resourceID *uuid.UUID // NULL once the resource is deleted
+		var name, rtype *string   // NULL only on rows that predate snapshots
 		var fromStatus, toStatus, message *string
 		if err := rows.Scan(
-			&e.ID, &e.ResourceID, &e.ResourceName, &e.ResourceType,
+			&e.ID, &resourceID, &name, &rtype,
 			&e.ActorID, &e.Action, &fromStatus, &toStatus, &message,
 			&e.CreatedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("db scan project activity: %w", err)
+		}
+		if resourceID != nil {
+			e.ResourceID = *resourceID
+		}
+		if name != nil {
+			e.ResourceName = *name
+		}
+		if rtype != nil {
+			e.ResourceType = models.ResourceType(*rtype)
 		}
 		if fromStatus != nil {
 			e.FromStatus = models.ResourceStatus(*fromStatus)

--- a/dc-api/internal/db/activity.go
+++ b/dc-api/internal/db/activity.go
@@ -28,6 +28,10 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/rs/zerolog/log"
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 )
 
@@ -50,10 +54,11 @@ func (r *Repository) ListProjectActivity(ctx context.Context, projectUUID uuid.U
 		return nil, 0, fmt.Errorf("db count project activity: %w", err)
 	}
 
-	const q = `
+	q := `
 		SELECT ae.id, ae.resource_id, ae.resource_name, ae.resource_type,
 		       ae.actor_id, ae.action, ae.from_status, ae.to_status, ae.message,
-		       ae.created_at
+		       ae.created_at,
+		       (ae.resource_id IS NOT NULL AND ` + auditLivenessSQL + `) AS live
 		FROM   audit_events ae
 		WHERE  ae.project_uuid = $1
 		ORDER  BY ae.created_at DESC, ae.id DESC
@@ -68,17 +73,20 @@ func (r *Repository) ListProjectActivity(ctx context.Context, projectUUID uuid.U
 	var entries []models.ActivityEntry
 	for rows.Next() {
 		var e models.ActivityEntry
-		var resourceID *uuid.UUID // NULL once the resource is deleted
-		var name, rtype *string   // NULL only on rows that predate snapshots
+		var resourceID *uuid.UUID
+		var name, rtype *string // NULL only on rows that predate snapshots
 		var fromStatus, toStatus, message *string
+		var live bool
 		if err := rows.Scan(
 			&e.ID, &resourceID, &name, &rtype,
 			&e.ActorID, &e.Action, &fromStatus, &toStatus, &message,
-			&e.CreatedAt,
+			&e.CreatedAt, &live,
 		); err != nil {
 			return nil, 0, fmt.Errorf("db scan project activity: %w", err)
 		}
-		if resourceID != nil {
+		// The pointer is exposed only while the resource exists, so clients
+		// never render deep links to deleted resources.
+		if resourceID != nil && live {
 			e.ResourceID = *resourceID
 		}
 		if name != nil {
@@ -159,5 +167,172 @@ var auditSnapshotUnion = func() string {
 		out += arm + " "
 	}
 	return out
+}()
+
+// ── Write side: the framework's recorder ─────────────────────────────────────
+
+// execer abstracts pool vs transaction so recording can join the caller's tx.
+type execer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// auditInsert is one lifecycle event with its identity snapshot already
+// resolved — repository methods capture these values from their own
+// INSERT/UPDATE/DELETE … RETURNING, so no extra lookup happens here.
+type auditInsert struct {
+	ID          uuid.UUID
+	Name        string
+	Kind        string // ActivityEvent.resource_type value, e.g. "VNET"
+	TenantUUID  *uuid.UUID
+	ProjectUUID *uuid.UUID
+	Action      string // audit.Action*
+	From        models.ResourceStatus
+	To          models.ResourceStatus
+	Message     string
+}
+
+// recordAudit writes one event. It never fails the caller's operation —
+// auditing is best-effort — but unlike the bad old days it LOGS failures:
+// a silently-failing audit write hid an entire missing feature once.
+// No-op transitions (From == To on a STATUS_CHANGE) are skipped here so the
+// rule holds for every family, not per call site.
+func (r *Repository) recordAudit(ctx context.Context, q execer, in auditInsert) {
+	if in.Action == audit.ActionStatusChange && in.From == in.To {
+		return
+	}
+	const sql = `
+		INSERT INTO audit_events
+			(resource_id, actor_id, action, from_status, to_status, message,
+			 resource_name, resource_type, tenant_uuid, project_uuid)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+	_, err := q.Exec(ctx, sql,
+		in.ID, audit.ActorFromContext(ctx), in.Action,
+		nilIfStatusEmpty(in.From), nilIfStatusEmpty(in.To), nilIfEmpty(in.Message),
+		nilIfEmpty(in.Name), nilIfEmpty(in.Kind), in.TenantUUID, in.ProjectUUID,
+	)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("kind", in.Kind).Str("action", in.Action).Str("resource", in.ID.String()).
+			Msg("audit: event write failed (operation unaffected)")
+	}
+}
+
+// auditedTable describes one family for the generic audited helpers below —
+// the second half of the framework. Families whose tables don't carry
+// tenant/project UUIDs resolve identity through their parent VNet.
+type auditedTable struct {
+	kind         string
+	table        string
+	nameCol      string // display-name column ("name", "zone_name", …)
+	parentVNetFK string // "" = own tenant_uuid/project_uuid columns
+}
+
+// auditedStatusUpdate is the framework's standard status transition: update
+// the row, capture the previous status via a self-join RETURNING, and record
+// the STATUS_CHANGE (no-ops skipped inside recordAudit).
+func (r *Repository) auditedStatusUpdate(ctx context.Context, f auditedTable, id uuid.UUID, status models.ResourceStatus, message, backendUID string) error {
+	var q string
+	if f.parentVNetFK == "" {
+		q = `UPDATE ` + f.table + ` x
+			SET status = $2, message = $3, backend_uid = COALESCE(NULLIF($4,''), x.backend_uid)
+			FROM ` + f.table + ` old
+			WHERE x.id = $1 AND old.id = x.id
+			RETURNING old.status::text, x.` + f.nameCol + `, x.tenant_uuid, x.project_uuid`
+	} else {
+		q = `UPDATE ` + f.table + ` x
+			SET status = $2, message = $3, backend_uid = COALESCE(NULLIF($4,''), x.backend_uid)
+			FROM ` + f.table + ` old, vnets v
+			WHERE x.id = $1 AND old.id = x.id AND v.id = old.` + f.parentVNetFK + `
+			RETURNING old.status::text, x.` + f.nameCol + `, v.tenant_uuid, v.project_uuid`
+	}
+	var from, name string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id, string(status), message, backendUID).
+		Scan(&from, &name, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return nil // row already gone — keep the old Exec semantics
+	}
+	if err != nil {
+		return fmt.Errorf("db update %s status %s: %w", f.table, id, err)
+	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: id, Name: name, Kind: f.kind, TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionStatusChange,
+		From:   models.ResourceStatus(from), To: status, Message: message,
+	})
+	return nil
+}
+
+// auditedDelete is the framework's standard terminal event: delete the row
+// and record DELETE with to_status DELETED, identity captured from the row's
+// last breath via RETURNING.
+func (r *Repository) auditedDelete(ctx context.Context, f auditedTable, id uuid.UUID) error {
+	var q string
+	if f.parentVNetFK == "" {
+		q = `DELETE FROM ` + f.table + ` x WHERE x.id = $1
+			RETURNING x.status::text, x.` + f.nameCol + `, x.tenant_uuid, x.project_uuid`
+	} else {
+		q = `DELETE FROM ` + f.table + ` x USING vnets v
+			WHERE x.id = $1 AND v.id = x.` + f.parentVNetFK + `
+			RETURNING x.status::text, x.` + f.nameCol + `, v.tenant_uuid, v.project_uuid`
+	}
+	var from, name string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id).Scan(&from, &name, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("db delete %s %s: %w", f.table, id, err)
+	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: id, Name: name, Kind: f.kind, TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionDelete,
+		From:   models.ResourceStatus(from), To: models.StatusDeleted,
+	})
+	return nil
+}
+
+// The families wired through the generic helpers. resources, databases, and
+// private endpoints have bespoke methods (extra columns / tx semantics) that
+// call recordAudit directly.
+var (
+	familyVNet       = auditedTable{kind: "VNET", table: "vnets", nameCol: "name"}
+	familySubnet     = auditedTable{kind: "SUBNET", table: "subnets", nameCol: "name"}
+	familyRouteTable = auditedTable{kind: "ROUTE_TABLE", table: "route_tables", nameCol: "name"}
+	familyNSG        = auditedTable{kind: "NSG", table: "network_security_groups", nameCol: "name"}
+	familyPeering    = auditedTable{kind: "PEERING", table: "peerings", nameCol: "name", parentVNetFK: "vnet_id"}
+	familyDNSZone    = auditedTable{kind: "PRIVATE_DNS_ZONE", table: "private_dns_zones", nameCol: "zone_name", parentVNetFK: "vnet_id"}
+	familyKeyVault   = auditedTable{kind: "KEYVAULT", table: "key_vaults", nameCol: "name"}
+)
+
+// vnetIdentity resolves a VNet's tenant/project UUIDs for child events
+// whose own tables don't carry them. Best-effort: nils on a missing row.
+func (r *Repository) vnetIdentity(ctx context.Context, vnetID uuid.UUID) (tuid, puid *uuid.UUID) {
+	_ = r.pool.QueryRow(ctx,
+		`SELECT tenant_uuid, project_uuid FROM vnets WHERE id = $1`, vnetID).
+		Scan(&tuid, &puid)
+	return tuid, puid
+}
+
+// auditedLivenessTables lists every table a resource_id pointer may refer
+// to — used by the feed to decide whether the pointer still resolves (the
+// UI only renders deep links for live resources).
+var auditedLivenessTables = []string{
+	"resources", "vnets", "subnets", "route_tables", "network_security_groups",
+	"peerings", "private_dns_zones", "key_vaults", "databases", "private_endpoints",
+}
+
+// auditLivenessSQL is "(EXISTS(...) OR EXISTS(...) …)" for $-substitution-free
+// embedding in the feed query (table names are compile-time constants).
+var auditLivenessSQL = func() string {
+	out := "("
+	for i, t := range auditedLivenessTables {
+		if i > 0 {
+			out += " OR "
+		}
+		out += "EXISTS (SELECT 1 FROM " + t + " WHERE id = ae.resource_id)"
+	}
+	return out + ")"
 }()
 

--- a/dc-api/internal/db/activity.go
+++ b/dc-api/internal/db/activity.go
@@ -1,11 +1,26 @@
 // Package db — activity.go
 //
-// Read side of the audit log: the per-project activity feed. The write side
-// (AppendAuditEvent) lives in db.go and snapshots the owning resource's
-// name/type and tenant/project UUIDs onto every event row, so this query
-// never joins resources and events survive resource deletion. project_uuid
-// on the event is the immutable isolation filter
-// (see docs/dc-api-architecture.md).
+// The activity/audit framework: every resource family's lifecycle lands in
+// the append-only audit_events table through ONE writer, AppendAuditEvent.
+//
+// ── THE CONTRACT FOR NEW RESOURCE FAMILIES ───────────────────────────────────
+//
+// A family is auditable when it has an arm in auditSnapshotArms below. The
+// arm resolves the family's UUID into an identity snapshot (name, kind,
+// tenant_uuid, project_uuid) that is written ONTO the event row, so events
+// render forever — deleting the resource never erases its history. To audit
+// a new resource family:
+//
+//  1. Add one SELECT arm to auditSnapshotArms (join a parent table if the
+//     family doesn't carry tenant_uuid/project_uuid itself — see peerings).
+//  2. Add the kind value to the ActivityEvent.resource_type enum in
+//     openapi.yaml, and (if it has a detail page) to cloud-ui's
+//     ACTIVITY_RESOURCE_ROUTES map.
+//  3. Call AppendAuditEvent from the family's handlers on CREATE / DELETE /
+//     async STATUS_CHANGE, exactly like vnet.go does.
+//
+// Handlers that already call AppendAuditEvent need no changes when a family
+// is registered — the writer resolves the UUID against every arm.
 package db
 
 import (
@@ -88,3 +103,61 @@ func (r *Repository) ListProjectActivity(ctx context.Context, projectUUID uuid.U
 	}
 	return entries, total, nil
 }
+
+// auditSnapshotArms — the audit framework's registry. Each arm yields
+// (name, kind, tenant_uuid, project_uuid) for $1 = the resource UUID; the
+// writer unions them and takes the single match. Kinds are the
+// ActivityEvent.resource_type values published in openapi.yaml.
+var auditSnapshotArms = []string{
+	`SELECT name, type::text AS kind, tenant_uuid, project_uuid FROM resources WHERE id = $1`,
+	`SELECT name, 'VNET', tenant_uuid, project_uuid FROM vnets WHERE id = $1`,
+	`SELECT name, 'SUBNET', tenant_uuid, project_uuid FROM subnets WHERE id = $1`,
+	`SELECT name, 'NSG', tenant_uuid, project_uuid FROM network_security_groups WHERE id = $1`,
+	// Peerings and DNS zones carry no tenant/project UUIDs of their own —
+	// identity flows from the parent VNet.
+	`SELECT p.name, 'PEERING', v.tenant_uuid, v.project_uuid FROM peerings p JOIN vnets v ON v.id = p.vnet_id WHERE p.id = $1`,
+	`SELECT z.zone_name, 'PRIVATE_DNS_ZONE', v.tenant_uuid, v.project_uuid FROM private_dns_zones z JOIN vnets v ON v.id = z.vnet_id WHERE z.id = $1`,
+	`SELECT name, 'KEYVAULT', tenant_uuid, project_uuid FROM key_vaults WHERE id = $1`,
+	`SELECT name, 'DATABASE', tenant_uuid, project_uuid FROM databases WHERE id = $1`,
+	`SELECT name, 'PRIVATE_ENDPOINT', tenant_uuid, project_uuid FROM private_endpoints WHERE id = $1`,
+}
+
+// AppendAuditEvent records a lifecycle event for ANY registered resource
+// family. Append-only — never updated. The owning resource's identity is
+// snapshotted onto the event row atomically (INSERT … SELECT across the
+// registry arms), so the activity feed keeps rendering the event after the
+// resource is deleted. An unregistered or already-deleted UUID makes the
+// insert a silent no-op.
+func (r *Repository) AppendAuditEvent(ctx context.Context, ev *models.AuditEvent) error {
+	q := `
+		INSERT INTO audit_events
+			(resource_id, actor_id, action, from_status, to_status, message,
+			 resource_name, resource_type, tenant_uuid, project_uuid)
+		SELECT $1, $2, $3, $4::resource_status, $5::resource_status, $6, s.name, s.kind, s.tenant_uuid, s.project_uuid
+		FROM (
+			` + auditSnapshotUnion + `
+			LIMIT 1
+		) s`
+
+	_, err := r.pool.Exec(ctx, q,
+		ev.ResourceID, ev.ActorID, ev.Action,
+		nilIfStatusEmpty(ev.FromStatus), nilIfStatusEmpty(ev.ToStatus),
+		nilIfEmpty(ev.Message),
+	)
+	if err != nil {
+		return fmt.Errorf("db append audit event: %w", err)
+	}
+	return nil
+}
+// auditSnapshotUnion is the registry arms joined for the writer's subquery.
+var auditSnapshotUnion = func() string {
+	out := ""
+	for i, arm := range auditSnapshotArms {
+		if i > 0 {
+			out += "\n\t\t\tUNION ALL "
+		}
+		out += arm + " "
+	}
+	return out
+}()
+

--- a/dc-api/internal/db/database.go
+++ b/dc-api/internal/db/database.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 )
 
@@ -52,6 +53,11 @@ func (r *Repository) CreateDatabase(ctx context.Context, d *models.Database) (*m
 	).Scan(&d.ID, &d.CreatedAt, &d.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create database: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: d.ID, Name: d.Name, Kind: "DATABASE",
+		TenantUUID: &d.TenantUUID, ProjectUUID: &d.ProjectUUID,
+		Action: audit.ActionCreate, To: d.Status,
+	})
 	return d, nil
 }
 
@@ -174,14 +180,24 @@ func (r *Repository) ListDatabasesByProject(ctx context.Context, tenantUUID, pro
 // the handler/adapter) we can hard-delete the row immediately. Returns
 // ErrDatabaseNotFound if the row was already gone.
 func (r *Repository) DeleteDatabase(ctx context.Context, id uuid.UUID) error {
-	const q = `DELETE FROM databases WHERE id = $1`
-	tag, err := r.pool.Exec(ctx, q, id)
+	const q = `
+		DELETE FROM databases
+		WHERE  id = $1
+		RETURNING status::text, name, tenant_uuid, project_uuid`
+	var from, name string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id).Scan(&from, &name, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return ErrDatabaseNotFound
+	}
 	if err != nil {
 		return fmt.Errorf("db delete database: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		return ErrDatabaseNotFound
-	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: id, Name: name, Kind: "DATABASE", TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionDelete,
+		From:   models.ResourceStatus(from), To: models.StatusDeleted,
+	})
 	return nil
 }
 
@@ -197,21 +213,33 @@ func (r *Repository) UpdateDatabaseStatus(
 	endpointPort int,
 ) error {
 	const q = `
-		UPDATE databases
+		UPDATE databases t
 		SET    status            = $2,
 		       message           = $3,
 		       endpoint_address  = $4,
 		       endpoint_port     = $5
-		WHERE  id = $1`
-	_, err := r.pool.Exec(ctx, q, id,
+		FROM   databases old
+		WHERE  t.id = $1 AND old.id = t.id
+		RETURNING old.status::text, t.name, t.tenant_uuid, t.project_uuid`
+	var from, name string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id,
 		string(status),
 		nilIfEmpty(message),
 		nilIfEmpty(endpointAddress),
 		nilIfZeroInt(endpointPort),
-	)
+	).Scan(&from, &name, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("db update database status: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: id, Name: name, Kind: "DATABASE", TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionStatusChange,
+		From:   models.ResourceStatus(from), To: status, Message: message,
+	})
 	return nil
 }
 

--- a/dc-api/internal/db/db.go
+++ b/dc-api/internal/db/db.go
@@ -726,12 +726,21 @@ func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-// AppendAuditEvent records a state transition. This is append-only — never updated.
+// AppendAuditEvent records a state transition. This is append-only — never
+// updated. The owning resource's name/type and tenant/project UUIDs are
+// snapshotted onto the event row (INSERT … SELECT, atomic with the lookup) so
+// the activity feed keeps rendering the event after the resource is deleted.
+// A missing resource row makes the insert a silent no-op — the same situations
+// the old NOT NULL FK would have rejected.
 func (r *Repository) AppendAuditEvent(ctx context.Context, ev *models.AuditEvent) error {
 	const q = `
 		INSERT INTO audit_events
-			(resource_id, actor_id, action, from_status, to_status, message)
-		VALUES ($1, $2, $3, $4, $5, $6)`
+			(resource_id, actor_id, action, from_status, to_status, message,
+			 resource_name, resource_type, tenant_uuid, project_uuid)
+		SELECT res.id, $2, $3, $4, $5, $6,
+		       res.name, res.type::text, res.tenant_uuid, res.project_uuid
+		FROM   resources res
+		WHERE  res.id = $1`
 
 	_, err := r.pool.Exec(ctx, q,
 		ev.ResourceID, ev.ActorID, ev.Action,

--- a/dc-api/internal/db/db.go
+++ b/dc-api/internal/db/db.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 )
 
@@ -130,6 +131,12 @@ func (r *Repository) Create(ctx context.Context, res *models.Resource) (*models.
 	if err := row.Scan(&res.ID, &res.CreatedAt, &res.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create resource: %w", err)
 	}
+
+	r.recordAudit(ctx, tx, auditInsert{
+		ID: res.ID, Name: res.Name, Kind: string(res.Type),
+		TenantUUID: &res.TenantUUID, ProjectUUID: nilIfNilUUID(res.ProjectUUID),
+		Action: audit.ActionCreate, To: res.Status,
+	})
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("db commit create resource: %w", err)
@@ -586,15 +593,30 @@ func (r *Repository) CountByTenant(ctx context.Context, tenantUUID uuid.UUID, re
 // The message field stores human-readable detail (e.g., error messages from providers).
 // updated_at is handled automatically by the PostgreSQL trigger.
 func (r *Repository) UpdateStatus(ctx context.Context, id uuid.UUID, status models.ResourceStatus, message string, backendUID string) error {
+	// The self-join exposes the pre-update row so the audit framework can
+	// record the real transition (and skip no-ops) without a second query.
 	const q = `
-		UPDATE resources
-		SET    status = $2, message = $3, backend_uid = COALESCE(NULLIF($4, ''), backend_uid)
-		WHERE  id = $1`
+		UPDATE resources t
+		SET    status = $2, message = $3, backend_uid = COALESCE(NULLIF($4, ''), t.backend_uid)
+		FROM   resources old
+		WHERE  t.id = $1 AND old.id = t.id
+		RETURNING old.status::text, t.name, t.type::text, t.tenant_uuid, t.project_uuid`
 
-	_, err := r.pool.Exec(ctx, q, id, string(status), message, backendUID)
+	var from, name, kind string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id, string(status), message, backendUID).
+		Scan(&from, &name, &kind, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return nil // row already gone — matches the old Exec semantics
+	}
 	if err != nil {
 		return fmt.Errorf("db update status for %s: %w", id, err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: id, Name: name, Kind: kind, TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionStatusChange,
+		From:   models.ResourceStatus(from), To: status, Message: message,
+	})
 	return nil
 }
 
@@ -719,7 +741,24 @@ func (r *Repository) UpdateMgmtIP(ctx context.Context, id uuid.UUID, ip string) 
 // Delete removes a resource row by ID. Used by the reconciler when a DELETING
 // resource is confirmed gone from the provider.
 func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
-	_, err := r.pool.Exec(ctx, `DELETE FROM resources WHERE id = $1`, id)
+	const q = `
+		DELETE FROM resources
+		WHERE  id = $1
+		RETURNING status::text, name, type::text, tenant_uuid, project_uuid`
+	var from, name, kind string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id).Scan(&from, &name, &kind, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return nil
+	}
+	if err == nil {
+		r.recordAudit(ctx, r.pool, auditInsert{
+			ID: id, Name: name, Kind: kind, TenantUUID: tuid, ProjectUUID: puid,
+			Action: audit.ActionDelete,
+			From:   models.ResourceStatus(from), To: models.StatusDeleted,
+		})
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("db delete resource %s: %w", id, err)
 	}

--- a/dc-api/internal/db/db.go
+++ b/dc-api/internal/db/db.go
@@ -726,33 +726,6 @@ func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-// AppendAuditEvent records a state transition. This is append-only — never
-// updated. The owning resource's name/type and tenant/project UUIDs are
-// snapshotted onto the event row (INSERT … SELECT, atomic with the lookup) so
-// the activity feed keeps rendering the event after the resource is deleted.
-// A missing resource row makes the insert a silent no-op — the same situations
-// the old NOT NULL FK would have rejected.
-func (r *Repository) AppendAuditEvent(ctx context.Context, ev *models.AuditEvent) error {
-	const q = `
-		INSERT INTO audit_events
-			(resource_id, actor_id, action, from_status, to_status, message,
-			 resource_name, resource_type, tenant_uuid, project_uuid)
-		SELECT res.id, $2, $3, $4, $5, $6,
-		       res.name, res.type::text, res.tenant_uuid, res.project_uuid
-		FROM   resources res
-		WHERE  res.id = $1`
-
-	_, err := r.pool.Exec(ctx, q,
-		ev.ResourceID, ev.ActorID, ev.Action,
-		nilIfStatusEmpty(ev.FromStatus), nilIfStatusEmpty(ev.ToStatus),
-		nilIfEmpty(ev.Message),
-	)
-	if err != nil {
-		return fmt.Errorf("db append audit event: %w", err)
-	}
-	return nil
-}
-
 // ─────────────────────────── Helpers ────────────────────────────────────────
 
 func nilIfEmpty(s string) *string {

--- a/dc-api/internal/db/keyvault.go
+++ b/dc-api/internal/db/keyvault.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 )
 
@@ -41,6 +42,11 @@ func (r *Repository) CreateKeyVault(ctx context.Context, kv *models.KeyVault) (*
 	).Scan(&kv.ID, &kv.CreatedAt, &kv.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create key_vault: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: kv.ID, Name: kv.Name, Kind: familyKeyVault.kind,
+		TenantUUID: &kv.TenantUUID, ProjectUUID: nilIfNilUUID(kv.ProjectUUID),
+		Action: audit.ActionCreate, To: kv.Status,
+	})
 	return kv, nil
 }
 
@@ -214,13 +220,8 @@ func (r *Repository) ListKeyVaults(ctx context.Context, tenantUUID uuid.UUID) ([
 // When the OpenBao mount + endpoints land (chunk 2-3) this becomes a soft
 // delete + reconciler-driven teardown.
 func (r *Repository) DeleteKeyVault(ctx context.Context, id uuid.UUID) error {
-	const q = `DELETE FROM key_vaults WHERE id = $1`
-	tag, err := r.pool.Exec(ctx, q, id)
-	if err != nil {
+	if err := r.auditedDelete(ctx, familyKeyVault, id); err != nil {
 		return fmt.Errorf("db delete key_vault: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		return ErrKeyVaultNotFound
 	}
 	return nil
 }

--- a/dc-api/internal/db/migrate.go
+++ b/dc-api/internal/db/migrate.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
@@ -38,6 +39,19 @@ var schemaSQL string
 // Phase 6a tenant_uuid backfill.
 // It is safe to call on every boot regardless of database state.
 func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
+	// Enum extension must run as its own statement: Postgres rejects
+	// ALTER TYPE … ADD VALUE inside the multi-statement script's implicit
+	// transaction. IF NOT EXISTS keeps it idempotent across boots; running
+	// it BEFORE the script keeps fresh and existing databases identical.
+	if _, err := pool.Exec(ctx,
+		`ALTER TYPE resource_status ADD VALUE IF NOT EXISTS 'DELETED'`); err != nil {
+		// Fresh database: the type doesn't exist yet — the script creates it
+		// with DELETED included, so a missing type is not an error here.
+		if !strings.Contains(err.Error(), "does not exist") {
+			return fmt.Errorf("extend resource_status enum: %w", err)
+		}
+	}
+
 	log.Info().Msg("applying database schema (idempotent)…")
 	if _, err := pool.Exec(ctx, schemaSQL); err != nil {
 		return fmt.Errorf("apply schema.sql: %w", err)

--- a/dc-api/internal/db/network.go
+++ b/dc-api/internal/db/network.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 )
 
@@ -60,6 +61,11 @@ func (r *Repository) CreateVNet(ctx context.Context, v *models.VNet) (*models.VN
 	if err := row.Scan(&v.ID, &v.CreatedAt, &v.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create vnet: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: v.ID, Name: v.Name, Kind: familyVNet.kind,
+		TenantUUID: &v.TenantUUID, ProjectUUID: nilIfNilUUID(v.ProjectUUID),
+		Action: audit.ActionCreate, To: v.Status,
+	})
 	return v, nil
 }
 
@@ -277,15 +283,7 @@ func (r *Repository) ListVNetsByTenant(ctx context.Context, tenantUUID uuid.UUID
 // UpdateVNetStatus updates status, message, and (optionally) backend_uid.
 // Passing an empty backendUID leaves the existing value in place (COALESCE).
 func (r *Repository) UpdateVNetStatus(ctx context.Context, id uuid.UUID, status models.ResourceStatus, message, backendUID string) error {
-	const q = `
-		UPDATE vnets
-		SET    status = $2, message = $3,
-		       backend_uid = COALESCE(NULLIF($4, ''), backend_uid)
-		WHERE  id = $1`
-	if _, err := r.pool.Exec(ctx, q, id, string(status), message, backendUID); err != nil {
-		return fmt.Errorf("db update vnet status %s: %w", id, err)
-	}
-	return nil
+	return r.auditedStatusUpdate(ctx, familyVNet, id, status, message, backendUID)
 }
 
 // ListAllActiveVNets returns every ACTIVE VNet across all tenants. Used by
@@ -369,10 +367,41 @@ func (r *Repository) SetVNetDNSServerIP(ctx context.Context, id uuid.UUID, ip ne
 
 // DeleteVNet removes a VNet row. Called after the provider confirms deletion.
 func (r *Repository) DeleteVNet(ctx context.Context, id uuid.UUID) error {
-	if _, err := r.pool.Exec(ctx, `DELETE FROM vnets WHERE id = $1`, id); err != nil {
-		return fmt.Errorf("db delete vnet %s: %w", id, err)
+	// Children (subnets, peerings, DNS zones, route tables) cascade away with
+	// the parent row at the DB layer, which would leave them without terminal
+	// audit events — record theirs first, while the rows can still speak.
+	for _, child := range []auditedTable{familySubnet, familyPeering, familyDNSZone, familyRouteTable} {
+		fk := "vnet_id"
+		nameExpr := "x." + child.nameCol
+		q := `SELECT x.id, ` + nameExpr + `, x.status::text FROM ` + child.table + ` x WHERE x.` + fk + ` = $1`
+		rows, err := r.pool.Query(ctx, q, id)
+		if err != nil {
+			continue // audit is best-effort; the delete below is what matters
+		}
+		type c struct {
+			id     uuid.UUID
+			name   string
+			status string
+		}
+		var cs []c
+		for rows.Next() {
+			var e c
+			if rows.Scan(&e.id, &e.name, &e.status) == nil {
+				cs = append(cs, e)
+			}
+		}
+		rows.Close()
+		tuid, puid := r.vnetIdentity(ctx, id)
+		for _, e := range cs {
+			r.recordAudit(ctx, r.pool, auditInsert{
+				ID: e.id, Name: e.name, Kind: child.kind, TenantUUID: tuid, ProjectUUID: puid,
+				Action: audit.ActionDelete,
+				From:   models.ResourceStatus(e.status), To: models.StatusDeleted,
+				Message: "removed with parent VNet",
+			})
+		}
 	}
-	return nil
+	return r.auditedDelete(ctx, familyVNet, id)
 }
 
 // CountVNetsByProject counts PENDING + ACTIVE VNets for quota enforcement.
@@ -466,6 +495,11 @@ func (r *Repository) CreateSubnet(ctx context.Context, s *models.Subnet) (*model
 	if err := row.Scan(&s.ID, &s.CreatedAt, &s.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create subnet: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: s.ID, Name: s.Name, Kind: familySubnet.kind,
+		TenantUUID: &s.TenantUUID, ProjectUUID: nilIfNilUUID(s.ProjectUUID),
+		Action: audit.ActionCreate, To: s.Status,
+	})
 	return s, nil
 }
 
@@ -557,23 +591,12 @@ func (r *Repository) ListSubnetsByVNet(ctx context.Context, vnetID uuid.UUID) ([
 
 // UpdateSubnetStatus updates status, message, and optionally backend_uid.
 func (r *Repository) UpdateSubnetStatus(ctx context.Context, id uuid.UUID, status models.ResourceStatus, message, backendUID string) error {
-	const q = `
-		UPDATE subnets
-		SET    status = $2, message = $3,
-		       backend_uid = COALESCE(NULLIF($4, ''), backend_uid)
-		WHERE  id = $1`
-	if _, err := r.pool.Exec(ctx, q, id, string(status), message, backendUID); err != nil {
-		return fmt.Errorf("db update subnet status %s: %w", id, err)
-	}
-	return nil
+	return r.auditedStatusUpdate(ctx, familySubnet, id, status, message, backendUID)
 }
 
 // DeleteSubnet removes a Subnet row by ID.
 func (r *Repository) DeleteSubnet(ctx context.Context, id uuid.UUID) error {
-	if _, err := r.pool.Exec(ctx, `DELETE FROM subnets WHERE id = $1`, id); err != nil {
-		return fmt.Errorf("db delete subnet %s: %w", id, err)
-	}
-	return nil
+	return r.auditedDelete(ctx, familySubnet, id)
 }
 
 // CountSubnetsByVNet counts PENDING + ACTIVE subnets in a VNet (for quota).
@@ -669,6 +692,11 @@ func (r *Repository) CreateRouteTable(ctx context.Context, rt *models.RouteTable
 	if err := row.Scan(&rt.ID, &rt.CreatedAt, &rt.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create route table: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: rt.ID, Name: rt.Name, Kind: familyRouteTable.kind,
+		TenantUUID: &rt.TenantUUID, ProjectUUID: nilIfNilUUID(rt.ProjectUUID),
+		Action: audit.ActionCreate, To: rt.Status,
+	})
 	return rt, nil
 }
 
@@ -763,7 +791,7 @@ func (r *Repository) UpdateRouteTableRoutes(ctx context.Context, id uuid.UUID, r
 
 // DeleteRouteTable removes a RouteTable row.
 func (r *Repository) DeleteRouteTable(ctx context.Context, id uuid.UUID) error {
-	if _, err := r.pool.Exec(ctx, `DELETE FROM route_tables WHERE id = $1`, id); err != nil {
+	if err := r.auditedDelete(ctx, familyRouteTable, id); err != nil {
 		return fmt.Errorf("db delete route table %s: %w", id, err)
 	}
 	return nil
@@ -837,6 +865,11 @@ func (r *Repository) CreateNSG(ctx context.Context, nsg *models.NSG) (*models.NS
 	if err := row.Scan(&nsg.ID, &nsg.CreatedAt, &nsg.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create nsg: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: nsg.ID, Name: nsg.Name, Kind: familyNSG.kind,
+		TenantUUID: &nsg.TenantUUID, ProjectUUID: nilIfNilUUID(nsg.ProjectUUID),
+		Action: audit.ActionCreate, To: nsg.Status,
+	})
 	return nsg, nil
 }
 
@@ -959,12 +992,7 @@ func (r *Repository) UpdateNSGBackendUID(ctx context.Context, id uuid.UUID, back
 
 // DeleteNSG removes an NSG row. Cascade deletes nsg_rules and nsg_attachments.
 func (r *Repository) DeleteNSG(ctx context.Context, id uuid.UUID) error {
-	if _, err := r.pool.Exec(ctx,
-		`DELETE FROM network_security_groups WHERE id = $1`, id,
-	); err != nil {
-		return fmt.Errorf("db delete nsg %s: %w", id, err)
-	}
-	return nil
+	return r.auditedDelete(ctx, familyNSG, id)
 }
 
 // ReplaceNSGRules atomically deletes all existing rules for an NSG and inserts
@@ -1213,6 +1241,12 @@ func (r *Repository) CreatePeering(ctx context.Context, p *models.Peering) (*mod
 	if err := row.Scan(&p.ID, &p.CreatedAt, &p.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create peering: %w", err)
 	}
+	tuid, puid := r.vnetIdentity(ctx, p.VNetID)
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: p.ID, Name: p.Name, Kind: familyPeering.kind,
+		TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionCreate, To: p.Status,
+	})
 	return p, nil
 }
 
@@ -1306,23 +1340,12 @@ func (r *Repository) ListPeeringsByVNet(ctx context.Context, vnetID uuid.UUID) (
 
 // UpdatePeeringStatus updates status, message, and optionally backend_uid.
 func (r *Repository) UpdatePeeringStatus(ctx context.Context, id uuid.UUID, status models.ResourceStatus, message, backendUID string) error {
-	const q = `
-		UPDATE peerings
-		SET    status = $2, message = $3,
-		       backend_uid = COALESCE(NULLIF($4,''), backend_uid)
-		WHERE  id = $1`
-	if _, err := r.pool.Exec(ctx, q, id, string(status), message, backendUID); err != nil {
-		return fmt.Errorf("db update peering status %s: %w", id, err)
-	}
-	return nil
+	return r.auditedStatusUpdate(ctx, familyPeering, id, status, message, backendUID)
 }
 
 // DeletePeering removes a Peering row.
 func (r *Repository) DeletePeering(ctx context.Context, id uuid.UUID) error {
-	if _, err := r.pool.Exec(ctx, `DELETE FROM peerings WHERE id = $1`, id); err != nil {
-		return fmt.Errorf("db delete peering %s: %w", id, err)
-	}
-	return nil
+	return r.auditedDelete(ctx, familyPeering, id)
 }
 
 // PeeringExistsBetween returns true if a peering already exists in either
@@ -1480,6 +1503,12 @@ func (r *Repository) CreateDNSZone(ctx context.Context, z *models.PrivateDnsZone
 	if err := row.Scan(&z.ID, &z.CreatedAt, &z.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create dns zone: %w", err)
 	}
+	tuid, puid := r.vnetIdentity(ctx, z.VNetID)
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: z.ID, Name: z.ZoneName, Kind: familyDNSZone.kind,
+		TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionCreate, To: z.Status,
+	})
 	return z, nil
 }
 
@@ -1569,23 +1598,12 @@ func (r *Repository) ListDNSZonesByVNet(ctx context.Context, vnetID uuid.UUID) (
 
 // UpdateDNSZoneStatus updates status, message, and optionally backend_uid.
 func (r *Repository) UpdateDNSZoneStatus(ctx context.Context, id uuid.UUID, status models.ResourceStatus, message, backendUID string) error {
-	const q = `
-		UPDATE private_dns_zones
-		SET    status = $2, message = $3,
-		       backend_uid = COALESCE(NULLIF($4,''), backend_uid)
-		WHERE  id = $1`
-	if _, err := r.pool.Exec(ctx, q, id, string(status), message, backendUID); err != nil {
-		return fmt.Errorf("db update dns zone status %s: %w", id, err)
-	}
-	return nil
+	return r.auditedStatusUpdate(ctx, familyDNSZone, id, status, message, backendUID)
 }
 
 // DeleteDNSZone removes a DNS zone row (cascades to dns_records).
 func (r *Repository) DeleteDNSZone(ctx context.Context, id uuid.UUID) error {
-	if _, err := r.pool.Exec(ctx, `DELETE FROM private_dns_zones WHERE id = $1`, id); err != nil {
-		return fmt.Errorf("db delete dns zone %s: %w", id, err)
-	}
-	return nil
+	return r.auditedDelete(ctx, familyDNSZone, id)
 }
 
 // ─────────────────────────── DNS Record ──────────────────────────────────────

--- a/dc-api/internal/db/private_endpoint.go
+++ b/dc-api/internal/db/private_endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 )
 
@@ -52,6 +53,11 @@ func (r *Repository) CreatePrivateEndpoint(ctx context.Context, ep *models.Priva
 	).Scan(&ep.ID, &ep.CreatedAt, &ep.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create private_endpoint: %w", err)
 	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: ep.ID, Name: ep.Name, Kind: "PRIVATE_ENDPOINT",
+		TenantUUID: &ep.TenantUUID, ProjectUUID: nilIfNilUUID(ep.ProjectUUID),
+		Action: audit.ActionCreate, To: ep.Status,
+	})
 	return ep, nil
 }
 
@@ -106,34 +112,57 @@ func (r *Repository) UpdatePrivateEndpointStatus(
 ) error {
 	// COALESCE requires both arguments to be the same type. ip_address is
 	// inet, so cast the NULLIF result (text) to inet first before COALESCE.
+	// COALESCE requires both arguments to be the same type. ip_address is
+	// inet, so cast the NULLIF result (text) to inet first before COALESCE.
 	const q = `
-		UPDATE private_endpoints
+		UPDATE private_endpoints t
 		SET    status         = $2,
 		       message        = $3,
-		       ip_address     = COALESCE(NULLIF($4, '')::inet, ip_address),
-		       hostname       = COALESCE(NULLIF($5, ''),       hostname),
-		       proxy_pod_name = COALESCE(NULLIF($6, ''),       proxy_pod_name)
-		WHERE  id = $1`
-	tag, err := r.pool.Exec(ctx, q, id, string(status), message, ip, hostname, proxyPod)
+		       ip_address     = COALESCE(NULLIF($4, '')::inet, t.ip_address),
+		       hostname       = COALESCE(NULLIF($5, ''),       t.hostname),
+		       proxy_pod_name = COALESCE(NULLIF($6, ''),       t.proxy_pod_name)
+		FROM   private_endpoints old
+		WHERE  t.id = $1 AND old.id = t.id
+		RETURNING old.status::text, t.name, t.tenant_uuid, t.project_uuid`
+	var from, name string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id, string(status), message, ip, hostname, proxyPod).
+		Scan(&from, &name, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return ErrPrivateEndpointNotFound
+	}
 	if err != nil {
 		return fmt.Errorf("db update private_endpoint status: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		return ErrPrivateEndpointNotFound
-	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: id, Name: name, Kind: "PRIVATE_ENDPOINT", TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionStatusChange,
+		From:   models.ResourceStatus(from), To: status, Message: message,
+	})
 	return nil
 }
 
 // DeletePrivateEndpoint removes the row. The handler is responsible for
 // having torn down the provisioner-side resources first.
 func (r *Repository) DeletePrivateEndpoint(ctx context.Context, id uuid.UUID) error {
-	tag, err := r.pool.Exec(ctx, `DELETE FROM private_endpoints WHERE id = $1`, id)
+	const q = `
+		DELETE FROM private_endpoints
+		WHERE  id = $1
+		RETURNING status::text, name, tenant_uuid, project_uuid`
+	var from, name string
+	var tuid, puid *uuid.UUID
+	err := r.pool.QueryRow(ctx, q, id).Scan(&from, &name, &tuid, &puid)
+	if err == pgx.ErrNoRows {
+		return ErrPrivateEndpointNotFound
+	}
 	if err != nil {
 		return fmt.Errorf("db delete private_endpoint: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		return ErrPrivateEndpointNotFound
-	}
+	r.recordAudit(ctx, r.pool, auditInsert{
+		ID: id, Name: name, Kind: "PRIVATE_ENDPOINT", TenantUUID: tuid, ProjectUUID: puid,
+		Action: audit.ActionDelete,
+		From:   models.ResourceStatus(from), To: models.StatusDeleted,
+	})
 	return nil
 }
 

--- a/dc-api/internal/db/schema.sql
+++ b/dc-api/internal/db/schema.sql
@@ -56,7 +56,8 @@ BEGIN
         'PENDING',
         'ACTIVE',
         'FAILED',
-        'DELETING'
+        'DELETING',
+        'DELETED' -- terminal; appears only on audit events, never on rows
     );
 EXCEPTION WHEN duplicate_object THEN NULL;
 END;

--- a/dc-api/internal/db/schema.sql
+++ b/dc-api/internal/db/schema.sql
@@ -921,3 +921,35 @@ DROP TRIGGER IF EXISTS databases_updated_at ON databases;
 CREATE TRIGGER databases_updated_at
     BEFORE UPDATE ON databases
     FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+-- ─────────────────────── Activity feed durability ────────────────────────────
+-- audit_events originally carried only resource_id behind an ON DELETE CASCADE
+-- FK, so deleting a resource erased its entire history — including the DELETE
+-- event itself. Snapshot the resource identity onto each event at write time
+-- and soften the FK to SET NULL: the feed reads the snapshot, so history
+-- outlives the resource. resource_id stays as a live-resource pointer (NULL
+-- once the resource is gone).
+ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS resource_name TEXT;
+ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS resource_type TEXT;
+ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS tenant_uuid  UUID;
+ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS project_uuid UUID;
+ALTER TABLE audit_events ALTER COLUMN resource_id DROP NOT NULL;
+
+-- Idempotent FK swap without a DO block: drop both possible names, re-add.
+ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_resource_id_fkey;
+ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_resource_id_setnull_fkey;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_resource_id_setnull_fkey
+    FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE SET NULL;
+
+-- Backfill snapshots for pre-migration events whose resource still exists
+-- (events whose resource was already deleted have cascaded away — nothing
+-- left to backfill).
+UPDATE audit_events ae
+SET    resource_name = res.name,
+       resource_type = res.type::text,
+       tenant_uuid   = res.tenant_uuid,
+       project_uuid  = res.project_uuid
+FROM   resources res
+WHERE  ae.resource_id = res.id AND ae.resource_name IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_audit_project_time ON audit_events (project_uuid, created_at DESC);

--- a/dc-api/internal/db/schema.sql
+++ b/dc-api/internal/db/schema.sql
@@ -122,7 +122,7 @@ CREATE TRIGGER resources_updated_at
 
 CREATE TABLE IF NOT EXISTS audit_events (
     id          UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
-    resource_id UUID          NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    resource_id UUID, -- point-in-time pointer; snapshots below are the rendering truth
     actor_id    TEXT          NOT NULL,
     action      TEXT          NOT NULL,
     from_status resource_status,
@@ -926,20 +926,22 @@ CREATE TRIGGER databases_updated_at
 -- audit_events originally carried only resource_id behind an ON DELETE CASCADE
 -- FK, so deleting a resource erased its entire history — including the DELETE
 -- event itself. Snapshot the resource identity onto each event at write time
--- and soften the FK to SET NULL: the feed reads the snapshot, so history
--- outlives the resource. resource_id stays as a live-resource pointer (NULL
--- once the resource is gone).
+-- and drop the FK: the feed reads the snapshot, so history outlives the
+-- resource.
 ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS resource_name TEXT;
 ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS resource_type TEXT;
 ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS tenant_uuid  UUID;
 ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS project_uuid UUID;
 ALTER TABLE audit_events ALTER COLUMN resource_id DROP NOT NULL;
 
--- Idempotent FK swap without a DO block: drop both possible names, re-add.
 ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_resource_id_fkey;
 ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_resource_id_setnull_fkey;
-ALTER TABLE audit_events ADD CONSTRAINT audit_events_resource_id_setnull_fkey
-    FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE SET NULL;
+-- The FK to resources is dropped entirely (both historical names): the
+-- activity framework audits EVERY resource family (vnets, subnets, NSGs,
+-- peerings, DNS zones, key vaults, databases, private endpoints), whose
+-- UUIDs live in their own tables. resource_id is a point-in-time pointer —
+-- it may reference a row that has since been deleted; the snapshot columns
+-- are the rendering truth.
 
 -- Backfill snapshots for pre-migration events whose resource still exists
 -- (events whose resource was already deleted have cascaded away — nothing

--- a/dc-api/internal/models/resource.go
+++ b/dc-api/internal/models/resource.go
@@ -35,6 +35,9 @@ const (
 	StatusActive   ResourceStatus = "ACTIVE"
 	StatusFailed   ResourceStatus = "FAILED"
 	StatusDeleting ResourceStatus = "DELETING"
+	// StatusDeleted is terminal and exists only on audit events — resource
+	// rows are removed at deletion, never parked in this state.
+	StatusDeleted ResourceStatus = "DELETED"
 )
 
 // VMSize defines a named instance size — CPU, memory, and a default root disk.

--- a/dc-api/internal/models/resource.go
+++ b/dc-api/internal/models/resource.go
@@ -190,6 +190,24 @@ type AuditEvent struct {
 	CreatedAt  time.Time `json:"created_at"`
 }
 
+// ActivityEntry is one row of a project's activity feed: an AuditEvent joined
+// with the owning resource's name and type so clients can render a readable
+// line ("vm-web-1 CREATE") without a second lookup. Events belong to resources
+// (audit_events.resource_id FK, ON DELETE CASCADE), so entries disappear with
+// their resource — the feed reflects live resources only.
+type ActivityEntry struct {
+	ID           uuid.UUID      `json:"id"`
+	ResourceID   uuid.UUID      `json:"resource_id"`
+	ResourceName string         `json:"resource_name"`
+	ResourceType ResourceType   `json:"resource_type"`
+	Action       string         `json:"action"`   // e.g., "CREATE", "DELETE", "STATUS_CHANGE"
+	ActorID      string         `json:"actor_id"` // OIDC sub, service-account ID, or "system"
+	FromStatus   ResourceStatus `json:"from_status,omitempty"`
+	ToStatus     ResourceStatus `json:"to_status,omitempty"`
+	Message      string         `json:"message,omitempty"`
+	CreatedAt    time.Time      `json:"created_at"`
+}
+
 // Image represents a bootable VM image available in the compute provider.
 // In Harvester these are VirtualMachineImage CRDs.
 type Image struct {

--- a/dc-api/internal/models/resource.go
+++ b/dc-api/internal/models/resource.go
@@ -190,14 +190,14 @@ type AuditEvent struct {
 	CreatedAt  time.Time `json:"created_at"`
 }
 
-// ActivityEntry is one row of a project's activity feed: an AuditEvent joined
-// with the owning resource's name and type so clients can render a readable
-// line ("vm-web-1 CREATE") without a second lookup. Events belong to resources
-// (audit_events.resource_id FK, ON DELETE CASCADE), so entries disappear with
-// their resource — the feed reflects live resources only.
+// ActivityEntry is one row of a project's activity feed: an AuditEvent plus
+// the owning resource's name and type, snapshotted onto the event at write
+// time so clients can render a readable line ("vm-web-1 CREATE") even after
+// the resource is deleted. ResourceID is uuid.Nil (omitted from JSON) once the
+// resource is gone — clients use it for deep links while it lasts.
 type ActivityEntry struct {
 	ID           uuid.UUID      `json:"id"`
-	ResourceID   uuid.UUID      `json:"resource_id"`
+	ResourceID   uuid.UUID      `json:"resource_id,omitzero"`
 	ResourceName string         `json:"resource_name"`
 	ResourceType ResourceType   `json:"resource_type"`
 	Action       string         `json:"action"`   // e.g., "CREATE", "DELETE", "STATUS_CHANGE"

--- a/dc-api/internal/rbac/actions.go
+++ b/dc-api/internal/rbac/actions.go
@@ -120,6 +120,11 @@ const (
 	ActionQuotaWrite = "resourcemanager/quotas/write"
 
 	ActionCapUsageRead = "resourcemanager/capUsage/read"
+
+	// ActionActivityRead gates the read-only project activity feed (audit
+	// events). A plain control-plane read: Reader's `*/read` covers it, so any
+	// project member can see the feed.
+	ActionActivityRead = "resourcemanager/activity/read"
 )
 
 // dataActions is the set of concrete actions that touch resource *contents*
@@ -172,6 +177,7 @@ var allActions = []string{
 	ActionProjectRead, ActionProjectWrite, ActionProjectDelete,
 	ActionQuotaRead, ActionQuotaWrite,
 	ActionCapUsageRead,
+	ActionActivityRead,
 }
 
 // AllActions returns a copy of the full action registry.

--- a/dc-api/internal/reconciler/reconciler.go
+++ b/dc-api/internal/reconciler/reconciler.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/db"
+	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers"
 )
@@ -68,6 +69,9 @@ func (r *Reconciler) WithInterval(d time.Duration) *Reconciler {
 //
 // When the context is cancelled (Ctrl-C / SIGTERM), the loop exits cleanly.
 func (r *Reconciler) Run(ctx context.Context) {
+	// Every repository mutation this loop makes is audited automatically —
+	// stamp the worker identity once so events read "reconciler", not "system".
+	ctx = audit.WithActor(ctx, "reconciler")
 	r.log.Info().Dur("interval", r.interval).Msg("reconciler started")
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
@@ -241,15 +245,8 @@ func (r *Reconciler) reconcileOne(ctx context.Context, res *models.Resource) {
 		return
 	}
 
-	// Append an audit event for the transition.
-	_ = r.repo.AppendAuditEvent(ctx, &models.AuditEvent{
-		ResourceID: res.ID,
-		ActorID:    "reconciler",
-		Action:     "STATUS_CHANGE",
-		FromStatus: res.Status,
-		ToStatus:   providerStatus,
-		Message:    providerMsg,
-	})
+	// The status transition above is audited automatically by the
+	// repository layer (actor stamped at Run).
 }
 
 // isNotFound returns true if the error indicates the resource does not exist

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -95,6 +95,13 @@ tags:
       Project management. Projects sit beneath Tenants as the primary workspace
       boundary. Every compute and network resource belongs to a project. A tenant
       owner is implicitly an owner of all projects in that tenant.
+  - name: activity
+    description: |
+      Read-only, project-scoped activity feed: the audit events recorded
+      against every resource in a project (CREATE, DELETE, STATUS_CHANGE, …),
+      newest first. Events are stored against resources and removed with them
+      (the audit FK cascades on resource deletion), so the feed covers
+      resources that still exist.
   - name: tenants
     description: Tenant discovery for the authenticated principal
   - name: quotas
@@ -2276,6 +2283,72 @@ paths:
       responses:
         "204":
           description: Service account deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ── Activity feed ─────────────────────────────────────────────────────────────
+
+  /v1/tenants/{tenant_id}/projects/{project_id}/activity:
+    parameters:
+      - $ref: "#/components/parameters/TenantID"
+      - $ref: "#/components/parameters/ProjectID"
+
+    get:
+      operationId: listProjectActivity
+      tags: [activity]
+      summary: List the project's activity feed
+      description: |
+        Returns one page of audit events for every resource in the project,
+        newest first. Each item is the stored audit event joined with the
+        owning resource's `name` and `type`, so clients can render a readable
+        feed line ("vm-web-1 — CREATE") without a second lookup.
+
+        Events are recorded when handlers and the reconciler change a
+        resource's lifecycle (`CREATE`, `DELETE`, `STATUS_CHANGE`, …). The
+        audit log is append-only, but events belong to their resource and are
+        removed with it — the feed covers resources that still exist.
+
+        `from_status`, `to_status`, and `message` are omitted when the stored
+        event has no value for them.
+
+        **Required action**: `resourcemanager/activity/read` — a plain
+        control-plane read covered by `Reader`'s `*/read` pattern, so any
+        project member can read the feed.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of events to return per page.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+            example: 20
+        - name: offset
+          in: query
+          required: false
+          description: Number of events to skip (newest-first ordering).
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+            example: 0
+      responses:
+        "200":
+          description: One page of the project's audit events, newest first.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityPage"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6695,6 +6768,78 @@ components:
             Total number of groups across all pages (SCIM2 `totalResults`),
             not the size of this page.
           example: 12
+
+    # ── Activity feed (project-scoped audit events) ────────────────────────────
+
+    ActivityEvent:
+      type: object
+      required: [id, resource_id, resource_name, resource_type, action, actor_id, created_at]
+      description: |
+        One audit event in a project's activity feed — the append-only
+        `audit_events` row joined with the owning resource's name and type.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Audit event UUID.
+          example: 3a1c2e5d-0000-0000-0000-0000000000aa
+        resource_id:
+          type: string
+          format: uuid
+          description: UUID of the resource the event was recorded against.
+          example: 3a1c2e5d-1234-5678-abcd-000000000001
+        resource_name:
+          type: string
+          description: Name of the resource at read time.
+          example: vm-web-1
+        resource_type:
+          type: string
+          description: Resource kind, as stored on the resource row.
+          enum: [VIRTUAL_MACHINE, CLUSTER, VOLUME, BASTION]
+          example: VIRTUAL_MACHINE
+        action:
+          type: string
+          description: What happened — e.g. `CREATE`, `DELETE`, `STATUS_CHANGE`.
+          example: CREATE
+        actor_id:
+          type: string
+          description: |
+            Who did it — the caller's OIDC `sub` or service-account ID, or
+            `system` for reconciler-driven transitions.
+          example: 01abc123-0000-0000-0000-user000000001
+        from_status:
+          allOf:
+            - $ref: "#/components/schemas/ResourceStatus"
+          description: Lifecycle status before the event. Omitted when the event has none (e.g. CREATE).
+        to_status:
+          allOf:
+            - $ref: "#/components/schemas/ResourceStatus"
+          description: Lifecycle status after the event. Omitted when the event has none.
+        message:
+          type: string
+          description: Optional human-readable detail (e.g. the provisioning error). Omitted when empty.
+          example: provisioning submitted to Harvester
+        created_at:
+          type: string
+          format: date-time
+          description: When the event was recorded (RFC 3339).
+          example: "2026-06-11T08:30:00Z"
+
+    ActivityPage:
+      type: object
+      required: [items, total]
+      properties:
+        items:
+          type: array
+          description: One page of audit events, newest first.
+          items:
+            $ref: "#/components/schemas/ActivityEvent"
+        total:
+          type: integer
+          description: |
+            Total number of events for the project across all pages, not the
+            size of this page.
+          example: 137
 
     # ── Service Accounts ───────────────────────────────────────────────────────
 

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -6789,9 +6789,10 @@ components:
           type: string
           format: uuid
           description: |
-            UUID of the resource the event was recorded against. Absent once
-            the resource has been deleted — clients should only build deep
-            links when this field is present.
+            UUID of the resource the event was recorded against. The pointer
+            is point-in-time: it may reference a resource that has since been
+            deleted, in which case deep links resolve to a not-found page.
+            Absent only on legacy events recorded before identity snapshots.
           example: 3a1c2e5d-1234-5678-abcd-000000000001
         resource_name:
           type: string
@@ -6799,8 +6800,12 @@ components:
           example: vm-web-1
         resource_type:
           type: string
-          description: Resource kind, as stored on the resource row.
-          enum: [VIRTUAL_MACHINE, CLUSTER, VOLUME, BASTION]
+          description: |
+            Resource kind, snapshotted when the event was recorded. One value
+            per auditable resource family — kept in lockstep with the audit
+            framework's registry (`internal/db/activity.go`).
+          enum: [VIRTUAL_MACHINE, CLUSTER, VOLUME, BASTION, VNET, SUBNET, NSG,
+                 PEERING, PRIVATE_DNS_ZONE, KEYVAULT, DATABASE, PRIVATE_ENDPOINT]
           example: VIRTUAL_MACHINE
         action:
           type: string

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -5715,13 +5715,15 @@ components:
 
     ResourceStatus:
       type: string
-      enum: [PENDING, ACTIVE, FAILED, DELETING]
+      enum: [PENDING, ACTIVE, FAILED, DELETING, DELETED]
       description: |
         Lifecycle status of any DC-API resource.
         - `PENDING` — accepted, provisioning in progress
         - `ACTIVE` — running and healthy
         - `FAILED` — provisioning or deletion failed
         - `DELETING` — deletion requested, async removal in progress
+        - `DELETED` — terminal; appears only as an audit event's to_status
+          (resource records are removed at deletion, never parked here)
 
     # ── Projects ───────────────────────────────────────────────────────────────
 
@@ -6789,10 +6791,10 @@ components:
           type: string
           format: uuid
           description: |
-            UUID of the resource the event was recorded against. The pointer
-            is point-in-time: it may reference a resource that has since been
-            deleted, in which case deep links resolve to a not-found page.
-            Absent only on legacy events recorded before identity snapshots.
+            UUID of the resource the event was recorded against. Present only
+            while the resource exists — once it is deleted the field is
+            omitted, so clients never render deep links to gone resources.
+            The snapshot fields (resource_name/resource_type) always render.
           example: 3a1c2e5d-1234-5678-abcd-000000000001
         resource_name:
           type: string
@@ -6805,7 +6807,8 @@ components:
             per auditable resource family — kept in lockstep with the audit
             framework's registry (`internal/db/activity.go`).
           enum: [VIRTUAL_MACHINE, CLUSTER, VOLUME, BASTION, VNET, SUBNET, NSG,
-                 PEERING, PRIVATE_DNS_ZONE, KEYVAULT, DATABASE, PRIVATE_ENDPOINT]
+                 ROUTE_TABLE, PEERING, PRIVATE_DNS_ZONE, KEYVAULT, DATABASE,
+                 PRIVATE_ENDPOINT]
           example: VIRTUAL_MACHINE
         action:
           type: string

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -6773,10 +6773,12 @@ components:
 
     ActivityEvent:
       type: object
-      required: [id, resource_id, resource_name, resource_type, action, actor_id, created_at]
+      required: [id, resource_name, resource_type, action, actor_id, created_at]
       description: |
-        One audit event in a project's activity feed — the append-only
-        `audit_events` row joined with the owning resource's name and type.
+        One audit event in a project's activity feed. The owning resource's
+        name and type are snapshotted onto the event when it is recorded, so
+        events keep rendering after the resource is deleted — history is not
+        erased by deletion.
       properties:
         id:
           type: string
@@ -6786,11 +6788,14 @@ components:
         resource_id:
           type: string
           format: uuid
-          description: UUID of the resource the event was recorded against.
+          description: |
+            UUID of the resource the event was recorded against. Absent once
+            the resource has been deleted — clients should only build deep
+            links when this field is present.
           example: 3a1c2e5d-1234-5678-abcd-000000000001
         resource_name:
           type: string
-          description: Name of the resource at read time.
+          description: Name of the resource, snapshotted when the event was recorded.
           example: vm-web-1
         resource_type:
           type: string

--- a/dc-api/test/contract/contract_test.go
+++ b/dc-api/test/contract/contract_test.go
@@ -159,7 +159,8 @@ func TestSpec_Conformance(t *testing.T) {
 	// Networking, VMs, clusters, bastions, images need real backends and
 	// are out of scope. --include-tag matches a single tag value, so we use
 	// the regex variant to express the allowlist.
-	tagRegex := `^(health|directory|keyvaults|roleAssignments|projects|service-accounts|tenants)$`
+	//   - activity: pure DB read (audit_events ⋈ resources) — no provider calls
+	tagRegex := `^(health|directory|keyvaults|roleAssignments|projects|service-accounts|tenants|activity)$`
 	checks := strings.Join([]string{
 		"not_a_server_error",
 		"status_code_conformance",

--- a/dc-api/test/integration/activity_test.go
+++ b/dc-api/test/integration/activity_test.go
@@ -171,6 +171,32 @@ func TestActivity_FeedPaginationAndIsolation(t *testing.T) {
 	assert.Empty(t, pageB.Items)
 	assert.Nil(t, findActivityEvent(pageB.Items, vmID, "CREATE"),
 		"project A's CREATE event leaked into project B's feed")
+
+	// ── 8. History survives resource deletion ────────────────────────────────
+	// Deleting the resource row (what the reconciler does once the backend
+	// confirms deletion) must NOT erase the feed: the snapshot columns keep
+	// every event renderable; only the live resource_id pointer disappears.
+	require.NoError(t, env.DB.Delete(ctx, uuid.MustParse(vmID)),
+		"direct resource-row delete (reconciler path)")
+
+	after, _, status, err := client.ListActivity(ctx, "?limit=100")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, want, after.Total,
+		"deleting the resource must not change the event count")
+
+	var survived *ActivityEventDTO
+	for i := range after.Items {
+		if after.Items[i].ResourceName == vmName && after.Items[i].Action == "CREATE" {
+			survived = &after.Items[i]
+			break
+		}
+	}
+	require.NotNil(t, survived, "CREATE event must survive resource deletion")
+	assert.Empty(t, survived.ResourceID,
+		"resource_id must be omitted once the resource is gone (no dangling deep links)")
+	assert.Equal(t, string(models.ResourceTypeVM), survived.ResourceType,
+		"resource_type snapshot must survive deletion")
 }
 
 // TestActivity_ViewerCanRead proves the gate is at viewer level: a principal

--- a/dc-api/test/integration/activity_test.go
+++ b/dc-api/test/integration/activity_test.go
@@ -1,0 +1,208 @@
+//go:build integration
+
+package integration
+
+// activity_test.go — GET /v1/tenants/{tid}/projects/{pid}/activity.
+//
+// The activity feed is a pure DB read (audit_events ⋈ resources), so the whole
+// file runs cluster-free with DCAPI_TEST_NOP=1: CreateVM against the nop
+// compute provider still writes the resource row and the CREATE audit event
+// synchronously (the handler records both before the async provider call), and
+// the failed background provisioning adds the STATUS_CHANGE event the
+// stabilisation wait below keys on.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wso2/dc-api/internal/models"
+)
+
+// activityRawTenant is the unprefixed tenant label; clientForTenant adds the
+// "test-" prefix, so the slug (and the JWT sub) is "test-" + this.
+const activityRawTenant = "tenant-activity"
+
+func activityTenantID() string { return "test-" + activityRawTenant }
+
+// findActivityEvent returns the first item matching resourceID+action, or nil.
+func findActivityEvent(items []ActivityEventDTO, resourceID, action string) *ActivityEventDTO {
+	for i := range items {
+		if items[i].ResourceID == resourceID && items[i].Action == action {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+func TestActivity_FeedPaginationAndIsolation(t *testing.T) {
+	ctx := context.Background()
+	client := clientForTenant(t, activityRawTenant)
+	mustGrantOwnerForClient(t, activityRawTenant)
+	tenantID := activityTenantID()
+
+	// ── 1. Create a resource through the API ───────────────────────────────
+	// The VM handler writes the resource row + the CREATE audit event before
+	// returning 202; the background provisioning then fails against the nop
+	// provider and appends a STATUS_CHANGE (PENDING → FAILED) event.
+	vmName := randomName("act-vm")
+	resp, body, status, err := client.CreateVM(ctx, CreateVMRequest{
+		Name:        vmName,
+		Size:        "small",
+		ImageName:   "ubuntu-22.04",
+		NetworkName: "default/test-net",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, status, "CreateVM: %s", ErrorBody(body))
+	vmID := resp.Resource.ID
+	require.NotEmpty(t, vmID)
+
+	// ── 2. The CREATE event appears, joined with name/type ──────────────────
+	page, body, status, err := client.ListActivity(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status, "ListActivity: %s", ErrorBody(body))
+	created := findActivityEvent(page.Items, vmID, "CREATE")
+	require.NotNil(t, created, "CREATE event for %s must appear in the feed; got %d items", vmID, len(page.Items))
+	assert.Equal(t, vmName, created.ResourceName, "resource_name must come from the resources join")
+	assert.Equal(t, string(models.ResourceTypeVM), created.ResourceType, "resource_type must come from the resources join")
+	assert.Equal(t, tenantID, created.ActorID, "actor_id must be the caller's sub")
+	assert.Equal(t, string(models.StatusPending), created.ToStatus)
+	assert.Empty(t, created.FromStatus, "CREATE has no from_status — field must be omitted")
+	_, perr := time.Parse(time.RFC3339, created.CreatedAt)
+	assert.NoError(t, perr, "created_at must be RFC3339: %q", created.CreatedAt)
+	assert.GreaterOrEqual(t, page.Total, 1)
+
+	// ── 3. Wait for the async STATUS_CHANGE so the count is stable ──────────
+	// UpdateStatus(FAILED) lands before the audit insert, so poll the feed
+	// itself (not the VM status) to avoid the tiny insert race.
+	require.Eventually(t, func() bool {
+		p, _, s, e := client.ListActivity(ctx, "?limit=100")
+		return e == nil && s == http.StatusOK && findActivityEvent(p.Items, vmID, "STATUS_CHANGE") != nil
+	}, 30*time.Second, 250*time.Millisecond,
+		"STATUS_CHANGE event from the failed nop provisioning never appeared")
+
+	page, _, status, err = client.ListActivity(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	baseTotal := page.Total
+
+	// ── 4. Newest-first ordering ─────────────────────────────────────────────
+	for i := 1; i < len(page.Items); i++ {
+		prev, e1 := time.Parse(time.RFC3339, page.Items[i-1].CreatedAt)
+		cur, e2 := time.Parse(time.RFC3339, page.Items[i].CreatedAt)
+		require.NoError(t, e1)
+		require.NoError(t, e2)
+		assert.False(t, prev.Before(cur),
+			"items must be newest first: item %d (%s) is older than item %d (%s)",
+			i-1, page.Items[i-1].CreatedAt, i, page.Items[i].CreatedAt)
+	}
+
+	// ── 5. Pagination: append deterministic events via the repository ────────
+	for i := 0; i < 5; i++ {
+		require.NoError(t, env.DB.AppendAuditEvent(ctx, &models.AuditEvent{
+			ResourceID: uuid.MustParse(vmID),
+			ActorID:    "test-fixture",
+			Action:     fmt.Sprintf("TEST_EVENT_%d", i),
+			Message:    "pagination fixture",
+		}))
+	}
+	want := baseTotal + 5
+
+	page1, _, status, err := client.ListActivity(ctx, "?limit=3&offset=0")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, want, page1.Total, "total must count all events across pages")
+	require.Len(t, page1.Items, 3, "limit=3 must cap the page")
+
+	page2, _, status, err := client.ListActivity(ctx, "?limit=3&offset=3")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, want, page2.Total, "total must be identical on every page")
+	require.NotEmpty(t, page2.Items)
+
+	seen := map[string]bool{}
+	for _, it := range page1.Items {
+		seen[it.ID] = true
+	}
+	for _, it := range page2.Items {
+		assert.False(t, seen[it.ID], "event %s appears on both pages — broken pagination ordering", it.ID)
+	}
+
+	// Offset past the end: 200 with an empty (non-null) items array.
+	tail, raw, status, err := client.ListActivity(ctx, fmt.Sprintf("?offset=%d", want))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, want, tail.Total)
+	assert.Empty(t, tail.Items)
+	assert.Contains(t, strings.ReplaceAll(string(raw), " ", ""), `"items":[]`,
+		"an empty page must serialize items as [] (spec: array), not null")
+
+	// ── 6. Invalid paging → 400 ──────────────────────────────────────────────
+	for _, q := range []string{"?limit=0", "?limit=101", "?limit=abc", "?offset=-1", "?offset=xyz"} {
+		_, body, status, err := client.ListActivity(ctx, q)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, status, "%s must 400: %s", q, ErrorBody(body))
+	}
+
+	// ── 7. Cross-project isolation ───────────────────────────────────────────
+	// Events recorded in the default project must be invisible from a sibling
+	// project in the same tenant.
+	const projB = "act-feed-b"
+	_, body, status, err = client.CreateProject(ctx, CreateProjectRequest{
+		ID: projB, Name: "Activity isolation B", CPUCores: 4, MemoryGB: 8, StorageGB: 50,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status, "CreateProject %s: %s", projB, ErrorBody(body))
+
+	tokenB, err := env.JWT.MintToken(tenantID, tenantID+"-user")
+	require.NoError(t, err)
+	clientB := NewAPIClientForProject(env.BaseURL, tokenB, tenantID, projB)
+
+	pageB, body, status, err := clientB.ListActivity(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status, "ListActivity in project B: %s", ErrorBody(body))
+	assert.Equal(t, 0, pageB.Total, "project B has no resources — its feed must be empty")
+	assert.Empty(t, pageB.Items)
+	assert.Nil(t, findActivityEvent(pageB.Items, vmID, "CREATE"),
+		"project A's CREATE event leaked into project B's feed")
+}
+
+// TestActivity_ViewerCanRead proves the gate is at viewer level: a principal
+// holding only the v1 'viewer' rank (→ Reader, `*/read`) gets the feed.
+func TestActivity_ViewerCanRead(t *testing.T) {
+	ctx := context.Background()
+	// Reuse no state from the other test: a dedicated tenant.
+	client := clientForTenant(t, "tenant-act-view")
+	_ = client // clientForTenant registers the tenant + default project
+	tenantID := "test-tenant-act-view"
+
+	viewerSub := tenantID + "-viewer"
+	_, err := env.DB.CreateRoleAssignment(ctx, models.RoleAssignment{
+		PrincipalType: models.PrincipalTypeUser,
+		PrincipalID:   viewerSub,
+		ScopeType:     models.ScopeTypeTenant,
+		ScopeID:       tenantID,
+		Role:          models.RoleViewer,
+		GrantedBy:     "test-setup",
+	})
+	if err != nil && !strings.Contains(err.Error(), "23505") && !strings.Contains(err.Error(), "duplicate key") {
+		require.NoError(t, err, "grant viewer role")
+	}
+	// MintTokenWithGroups does NOT seed a member role — the viewer grant above
+	// is this principal's only access.
+	token, err := env.JWT.MintTokenWithGroups(viewerSub, viewerSub, nil)
+	require.NoError(t, err)
+	viewer := NewAPIClientForProject(env.BaseURL, token, tenantID, defaultProjectID)
+
+	page, body, status, err := viewer.ListActivity(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status,
+		"a viewer-only principal must be able to read the activity feed: %s", ErrorBody(body))
+	assert.Equal(t, 0, page.Total)
+}

--- a/dc-api/test/integration/activity_test.go
+++ b/dc-api/test/integration/activity_test.go
@@ -193,10 +193,52 @@ func TestActivity_FeedPaginationAndIsolation(t *testing.T) {
 		}
 	}
 	require.NotNil(t, survived, "CREATE event must survive resource deletion")
-	assert.Empty(t, survived.ResourceID,
-		"resource_id must be omitted once the resource is gone (no dangling deep links)")
+	assert.Equal(t, vmID, survived.ResourceID,
+		"resource_id is a point-in-time pointer — it remains after deletion")
 	assert.Equal(t, string(models.ResourceTypeVM), survived.ResourceType,
 		"resource_type snapshot must survive deletion")
+}
+
+// TestActivity_FamilyCoverage_VNet proves the audit framework covers resource
+// families outside the legacy resources table: a VNet's CREATE and DELETE
+// land in the feed with the registry-resolved VNET kind, and survive the row
+// being removed.
+func TestActivity_FamilyCoverage_VNet(t *testing.T) {
+	ctx := context.Background()
+	client := clientForTenant(t, "tenant-act-vnet")
+	mustGrantOwnerForClient(t, "tenant-act-vnet")
+
+	vnetName := randomName("act-vnet-fam")
+	created, body, status, err := client.CreateVNet(ctx, CreateVNetRequest{
+		Name: vnetName, AddressSpace: []string{"10.242.0.0/16"}, Region: "lk",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, status, "CreateVNet: %s", ErrorBody(body))
+	vnetID := created.Resource.ID
+
+	// CREATE lands with the registry-resolved kind.
+	var ev *ActivityEventDTO
+	require.Eventually(t, func() bool {
+		p, _, s, e := client.ListActivity(ctx, "?limit=100")
+		if e != nil || s != http.StatusOK {
+			return false
+		}
+		ev = findActivityEvent(p.Items, vnetID, "CREATE")
+		return ev != nil
+	}, 10*time.Second, 250*time.Millisecond, "VNet CREATE event never appeared")
+	assert.Equal(t, vnetName, ev.ResourceName)
+	assert.Equal(t, "VNET", ev.ResourceType, "kind must come from the audit registry")
+
+	// DELETE is recorded before the row goes away and persists afterwards.
+	body, status, err = client.DeleteVNet(ctx, vnetID)
+	require.NoError(t, err)
+	require.Contains(t, []int{http.StatusAccepted, http.StatusNoContent}, status,
+		"DeleteVNet: %s", ErrorBody(body))
+
+	require.Eventually(t, func() bool {
+		p, _, s, e := client.ListActivity(ctx, "?limit=100")
+		return e == nil && s == http.StatusOK && findActivityEvent(p.Items, vnetID, "DELETE") != nil
+	}, 10*time.Second, 250*time.Millisecond, "VNet DELETE event never appeared")
 }
 
 // TestActivity_ViewerCanRead proves the gate is at viewer level: a principal

--- a/dc-api/test/integration/activity_test.go
+++ b/dc-api/test/integration/activity_test.go
@@ -182,8 +182,19 @@ func TestActivity_FeedPaginationAndIsolation(t *testing.T) {
 	after, _, status, err := client.ListActivity(ctx, "?limit=100")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)
-	assert.Equal(t, want, after.Total,
-		"deleting the resource must not change the event count")
+	assert.Equal(t, want+1, after.Total,
+		"row removal must add exactly one terminal DELETE event")
+
+	// The terminal event is the framework's: DELETING/old status → DELETED.
+	var terminal *ActivityEventDTO
+	for i := range after.Items {
+		if after.Items[i].ResourceName == vmName && after.Items[i].Action == "DELETE" {
+			terminal = &after.Items[i]
+			break
+		}
+	}
+	require.NotNil(t, terminal, "terminal DELETE event must exist")
+	assert.Equal(t, "DELETED", terminal.ToStatus, "terminal event must end in DELETED")
 
 	var survived *ActivityEventDTO
 	for i := range after.Items {
@@ -193,8 +204,8 @@ func TestActivity_FeedPaginationAndIsolation(t *testing.T) {
 		}
 	}
 	require.NotNil(t, survived, "CREATE event must survive resource deletion")
-	assert.Equal(t, vmID, survived.ResourceID,
-		"resource_id is a point-in-time pointer — it remains after deletion")
+	assert.Empty(t, survived.ResourceID,
+		"resource_id must be omitted once the resource is gone (no dangling deep links)")
 	assert.Equal(t, string(models.ResourceTypeVM), survived.ResourceType,
 		"resource_type snapshot must survive deletion")
 }
@@ -237,8 +248,52 @@ func TestActivity_FamilyCoverage_VNet(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		p, _, s, e := client.ListActivity(ctx, "?limit=100")
-		return e == nil && s == http.StatusOK && findActivityEvent(p.Items, vnetID, "DELETE") != nil
-	}, 10*time.Second, 250*time.Millisecond, "VNet DELETE event never appeared")
+		if e != nil || s != http.StatusOK {
+			return false
+		}
+		for i := range p.Items {
+			it := p.Items[i]
+			if it.ResourceName == vnetName && it.Action == "DELETE" && it.ToStatus == "DELETED" {
+				// Once deleted, the live pointer must be gone.
+				return it.ResourceID == ""
+			}
+		}
+		return false
+	}, 15*time.Second, 250*time.Millisecond,
+		"VNet terminal DELETE→DELETED event (without a live pointer) never appeared")
+}
+
+// TestActivity_NoOpTransitionsAreSkipped pins the framework rule that a
+// status update to the SAME status records nothing — the bug class that
+// produced DELETING → DELETING entries.
+func TestActivity_NoOpTransitionsAreSkipped(t *testing.T) {
+	ctx := context.Background()
+	client := clientForTenant(t, "tenant-act-noop")
+	mustGrantOwnerForClient(t, "tenant-act-noop")
+
+	created, body, status, err := client.CreateVNet(ctx, CreateVNetRequest{
+		Name: randomName("act-noop"), AddressSpace: []string{"10.243.0.0/16"}, Region: "lk",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, status, "CreateVNet: %s", ErrorBody(body))
+
+	// Wait for the async nop provisioning to settle (PENDING → FAILED).
+	require.Eventually(t, func() bool {
+		p, _, s, e := client.ListActivity(ctx, "?limit=100")
+		return e == nil && s == http.StatusOK && p.Total >= 2
+	}, 10*time.Second, 250*time.Millisecond)
+
+	page, _, _, err := client.ListActivity(ctx, "?limit=100")
+	require.NoError(t, err)
+	before := page.Total
+
+	// Same-status update: must record nothing, for every family by construction.
+	require.NoError(t, env.DB.UpdateVNetStatus(ctx,
+		uuid.MustParse(created.Resource.ID), models.StatusFailed, "still failed", ""))
+
+	page, _, _, err = client.ListActivity(ctx, "?limit=100")
+	require.NoError(t, err)
+	assert.Equal(t, before, page.Total, "a no-op status transition must not be recorded")
 }
 
 // TestActivity_ViewerCanRead proves the gate is at viewer level: a principal

--- a/dc-api/test/integration/apiclient.go
+++ b/dc-api/test/integration/apiclient.go
@@ -565,6 +565,41 @@ func (c *APIClient) DeleteVM(ctx context.Context, vmID string) (int, error) {
 	return status, err
 }
 
+// ── Activity feed ─────────────────────────────────────────────────────────────
+
+// ActivityEventDTO mirrors components/schemas/ActivityEvent.
+type ActivityEventDTO struct {
+	ID           string `json:"id"`
+	ResourceID   string `json:"resource_id"`
+	ResourceName string `json:"resource_name"`
+	ResourceType string `json:"resource_type"`
+	Action       string `json:"action"`
+	ActorID      string `json:"actor_id"`
+	FromStatus   string `json:"from_status,omitempty"`
+	ToStatus     string `json:"to_status,omitempty"`
+	Message      string `json:"message,omitempty"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// ActivityPageDTO mirrors components/schemas/ActivityPage.
+type ActivityPageDTO struct {
+	Items []ActivityEventDTO `json:"items"`
+	Total int                `json:"total"`
+}
+
+// ListActivity calls GET .../projects/{project_id}/activity. query is the raw
+// query string including the leading "?" (e.g. "?limit=2&offset=4"), or ""
+// for the server defaults.
+func (c *APIClient) ListActivity(ctx context.Context, query string) (ActivityPageDTO, []byte, int, error) {
+	b, status, err := c.do(ctx, http.MethodGet, c.projectPath()+"/activity"+query, nil)
+	if err != nil {
+		return ActivityPageDTO{}, b, status, err
+	}
+	var resp ActivityPageDTO
+	_ = json.Unmarshal(b, &resp)
+	return resp, b, status, nil
+}
+
 // ── Projects ──────────────────────────────────────────────────────────────────
 
 // ProjectResponse mirrors handlers.projectResponse.

--- a/dcctl/internal/client/generated/dcapi.gen.go
+++ b/dcctl/internal/client/generated/dcapi.gen.go
@@ -23,6 +23,57 @@ const (
 	BearerAuthScopes bearerAuthContextKey = "bearerAuth.Scopes"
 )
 
+// Defines values for ActivityEventResourceType.
+const (
+	ActivityEventResourceTypeBASTION         ActivityEventResourceType = "BASTION"
+	ActivityEventResourceTypeCLUSTER         ActivityEventResourceType = "CLUSTER"
+	ActivityEventResourceTypeDATABASE        ActivityEventResourceType = "DATABASE"
+	ActivityEventResourceTypeKEYVAULT        ActivityEventResourceType = "KEYVAULT"
+	ActivityEventResourceTypeNSG             ActivityEventResourceType = "NSG"
+	ActivityEventResourceTypePEERING         ActivityEventResourceType = "PEERING"
+	ActivityEventResourceTypePRIVATEDNSZONE  ActivityEventResourceType = "PRIVATE_DNS_ZONE"
+	ActivityEventResourceTypePRIVATEENDPOINT ActivityEventResourceType = "PRIVATE_ENDPOINT"
+	ActivityEventResourceTypeROUTETABLE      ActivityEventResourceType = "ROUTE_TABLE"
+	ActivityEventResourceTypeSUBNET          ActivityEventResourceType = "SUBNET"
+	ActivityEventResourceTypeVIRTUALMACHINE  ActivityEventResourceType = "VIRTUAL_MACHINE"
+	ActivityEventResourceTypeVNET            ActivityEventResourceType = "VNET"
+	ActivityEventResourceTypeVOLUME          ActivityEventResourceType = "VOLUME"
+)
+
+// Valid indicates whether the value is a known member of the ActivityEventResourceType enum.
+func (e ActivityEventResourceType) Valid() bool {
+	switch e {
+	case ActivityEventResourceTypeBASTION:
+		return true
+	case ActivityEventResourceTypeCLUSTER:
+		return true
+	case ActivityEventResourceTypeDATABASE:
+		return true
+	case ActivityEventResourceTypeKEYVAULT:
+		return true
+	case ActivityEventResourceTypeNSG:
+		return true
+	case ActivityEventResourceTypePEERING:
+		return true
+	case ActivityEventResourceTypePRIVATEDNSZONE:
+		return true
+	case ActivityEventResourceTypePRIVATEENDPOINT:
+		return true
+	case ActivityEventResourceTypeROUTETABLE:
+		return true
+	case ActivityEventResourceTypeSUBNET:
+		return true
+	case ActivityEventResourceTypeVIRTUALMACHINE:
+		return true
+	case ActivityEventResourceTypeVNET:
+		return true
+	case ActivityEventResourceTypeVOLUME:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AttachNSGRequestTargetType.
 const (
 	AttachNSGRequestTargetTypeSubnet AttachNSGRequestTargetType = "subnet"
@@ -524,6 +575,7 @@ func (e QuotaExceededErrorError) Valid() bool {
 // Defines values for ResourceStatus.
 const (
 	ResourceStatusACTIVE   ResourceStatus = "ACTIVE"
+	ResourceStatusDELETED  ResourceStatus = "DELETED"
 	ResourceStatusDELETING ResourceStatus = "DELETING"
 	ResourceStatusFAILED   ResourceStatus = "FAILED"
 	ResourceStatusPENDING  ResourceStatus = "PENDING"
@@ -533,6 +585,8 @@ const (
 func (e ResourceStatus) Valid() bool {
 	switch e {
 	case ResourceStatusACTIVE:
+		return true
+	case ResourceStatusDELETED:
 		return true
 	case ResourceStatusDELETING:
 		return true
@@ -755,6 +809,63 @@ func (e UpdateProjectQuota400JSONResponseBody2Error) Valid() bool {
 	}
 }
 
+// ActivityEvent One audit event in a project's activity feed. The owning resource's
+// name and type are snapshotted onto the event when it is recorded, so
+// events keep rendering after the resource is deleted — history is not
+// erased by deletion.
+type ActivityEvent struct {
+	// Action What happened — e.g. `CREATE`, `DELETE`, `STATUS_CHANGE`.
+	Action string `json:"action"`
+
+	// ActorId Who did it — the caller's OIDC `sub` or service-account ID, or
+	// `system` for reconciler-driven transitions.
+	ActorId string `json:"actor_id"`
+
+	// CreatedAt When the event was recorded (RFC 3339).
+	CreatedAt time.Time `json:"created_at"`
+
+	// FromStatus Lifecycle status before the event. Omitted when the event has none (e.g. CREATE).
+	FromStatus *ResourceStatus `json:"from_status,omitempty"`
+
+	// Id Audit event UUID.
+	Id openapi_types.UUID `json:"id"`
+
+	// Message Optional human-readable detail (e.g. the provisioning error). Omitted when empty.
+	Message *string `json:"message,omitempty"`
+
+	// ResourceId UUID of the resource the event was recorded against. Present only
+	// while the resource exists — once it is deleted the field is
+	// omitted, so clients never render deep links to gone resources.
+	// The snapshot fields (resource_name/resource_type) always render.
+	ResourceId *openapi_types.UUID `json:"resource_id,omitempty"`
+
+	// ResourceName Name of the resource, snapshotted when the event was recorded.
+	ResourceName string `json:"resource_name"`
+
+	// ResourceType Resource kind, snapshotted when the event was recorded. One value
+	// per auditable resource family — kept in lockstep with the audit
+	// framework's registry (`internal/db/activity.go`).
+	ResourceType ActivityEventResourceType `json:"resource_type"`
+
+	// ToStatus Lifecycle status after the event. Omitted when the event has none.
+	ToStatus *ResourceStatus `json:"to_status,omitempty"`
+}
+
+// ActivityEventResourceType Resource kind, snapshotted when the event was recorded. One value
+// per auditable resource family — kept in lockstep with the audit
+// framework's registry (`internal/db/activity.go`).
+type ActivityEventResourceType string
+
+// ActivityPage defines model for ActivityPage.
+type ActivityPage struct {
+	// Items One page of audit events, newest first.
+	Items []ActivityEvent `json:"items"`
+
+	// Total Total number of events for the project across all pages, not the
+	// size of this page.
+	Total int `json:"total"`
+}
+
 // AsyncNetworkResponse Generic 202 envelope for async network resource operations.
 // `resource` is the newly created object in PENDING status.
 // `note` contains the polling URL.
@@ -853,6 +964,8 @@ type Bastion struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status   ResourceStatus      `json:"status"`
 	SubnetId *openapi_types.UUID `json:"subnet_id,omitempty"`
 	TenantId string              `json:"tenant_id"`
@@ -884,6 +997,8 @@ type Cluster struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status ResourceStatus `json:"status"`
 
 	// SystemPool Embedded system node pool. Always present. For the list endpoint
@@ -1413,6 +1528,8 @@ type DNSZone struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status    ResourceStatus     `json:"status"`
 	TenantId  string             `json:"tenant_id"`
 	UpdatedAt time.Time          `json:"updated_at"`
@@ -1589,6 +1706,8 @@ type KeyVault struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status    ResourceStatus `json:"status"`
 	TenantId  string         `json:"tenant_id"`
 	UpdatedAt time.Time      `json:"updated_at"`
@@ -1708,6 +1827,8 @@ type NSG struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status    ResourceStatus `json:"status"`
 	TenantId  string         `json:"tenant_id"`
 	UpdatedAt time.Time      `json:"updated_at"`
@@ -1896,6 +2017,8 @@ type Peering struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status    ResourceStatus     `json:"status"`
 	TenantId  string             `json:"tenant_id"`
 	UpdatedAt time.Time          `json:"updated_at"`
@@ -1938,6 +2061,8 @@ type PrivateEndpoint struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status   ResourceStatus     `json:"status"`
 	SubnetId openapi_types.UUID `json:"subnet_id"`
 
@@ -2024,10 +2149,12 @@ type QuotaExceededError struct {
 type QuotaExceededErrorError string
 
 // ResourceStatus Lifecycle status of any DC-API resource.
-// - `PENDING` — accepted, provisioning in progress
-// - `ACTIVE` — running and healthy
-// - `FAILED` — provisioning or deletion failed
-// - `DELETING` — deletion requested, async removal in progress
+//   - `PENDING` — accepted, provisioning in progress
+//   - `ACTIVE` — running and healthy
+//   - `FAILED` — provisioning or deletion failed
+//   - `DELETING` — deletion requested, async removal in progress
+//   - `DELETED` — terminal; appears only as an audit event's to_status
+//     (resource records are removed at deletion, never parked here)
 type ResourceStatus string
 
 // RoleAssignment defines model for RoleAssignment.
@@ -2133,6 +2260,8 @@ type RouteTable struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status    ResourceStatus     `json:"status"`
 	TenantId  string             `json:"tenant_id"`
 	UpdatedAt time.Time          `json:"updated_at"`
@@ -2203,6 +2332,8 @@ type Subnet struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status    ResourceStatus     `json:"status"`
 	TenantId  string             `json:"tenant_id"`
 	UpdatedAt time.Time          `json:"updated_at"`
@@ -2349,6 +2480,8 @@ type VNet struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status    ResourceStatus `json:"status"`
 	TenantId  string         `json:"tenant_id"`
 	UpdatedAt time.Time      `json:"updated_at"`
@@ -2377,6 +2510,8 @@ type VirtualMachine struct {
 	// - `ACTIVE` — running and healthy
 	// - `FAILED` — provisioning or deletion failed
 	// - `DELETING` — deletion requested, async removal in progress
+	// - `DELETED` — terminal; appears only as an audit event's to_status
+	//   (resource records are removed at deletion, never parked here)
 	Status   ResourceStatus `json:"status"`
 	TenantId string         `json:"tenant_id"`
 }
@@ -2498,6 +2633,15 @@ type UpdateProjectQuota400JSONResponseBody2Error string
 // UpdateProjectQuota400JSONResponseBody defines parameters for UpdateProjectQuota.
 type UpdateProjectQuota400JSONResponseBody struct {
 	union json.RawMessage
+}
+
+// ListProjectActivityParams defines parameters for ListProjectActivity.
+type ListProjectActivityParams struct {
+	// Limit Maximum number of events to return per page.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of events to skip (newest-first ordering).
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
 // ListKeyVaultSecretsParams defines parameters for ListKeyVaultSecrets.
@@ -3049,6 +3193,9 @@ type ClientInterface interface {
 	UpdateProjectQuotaWithBody(ctx context.Context, tenantId TenantID, projectId ProjectID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateProjectQuota(ctx context.Context, tenantId TenantID, projectId ProjectID, body UpdateProjectQuotaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProjectActivity request
+	ListProjectActivity(ctx context.Context, tenantId TenantID, projectId ProjectID, params *ListProjectActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListBastions request
 	ListBastions(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3746,6 +3893,18 @@ func (c *Client) UpdateProjectQuotaWithBody(ctx context.Context, tenantId Tenant
 
 func (c *Client) UpdateProjectQuota(ctx context.Context, tenantId TenantID, projectId ProjectID, body UpdateProjectQuotaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateProjectQuotaRequest(c.Server, tenantId, projectId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProjectActivity(ctx context.Context, tenantId TenantID, projectId ProjectID, params *ListProjectActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProjectActivityRequest(c.Server, tenantId, projectId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -6299,6 +6458,86 @@ func NewUpdateProjectQuotaRequestWithBody(server string, tenantId TenantID, proj
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListProjectActivityRequest generates requests for ListProjectActivity
+func NewListProjectActivityRequest(server string, tenantId TenantID, projectId ProjectID, params *ListProjectActivityParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tenant_id", tenantId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tenants/%s/projects/%s/activity", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -11823,6 +12062,9 @@ type ClientWithResponsesInterface interface {
 
 	UpdateProjectQuotaWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, body UpdateProjectQuotaJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectQuotaResp, error)
 
+	// ListProjectActivityWithResponse request
+	ListProjectActivityWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, params *ListProjectActivityParams, reqEditors ...RequestEditorFn) (*ListProjectActivityResp, error)
+
 	// ListBastionsWithResponse request
 	ListBastionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListBastionsResp, error)
 
@@ -12933,6 +13175,41 @@ func (r UpdateProjectQuotaResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r UpdateProjectQuotaResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListProjectActivityResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ActivityPage
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProjectActivityResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProjectActivityResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProjectActivityResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -16686,6 +16963,15 @@ func (c *ClientWithResponses) UpdateProjectQuotaWithResponse(ctx context.Context
 	return ParseUpdateProjectQuotaResp(rsp)
 }
 
+// ListProjectActivityWithResponse request returning *ListProjectActivityResp
+func (c *ClientWithResponses) ListProjectActivityWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, params *ListProjectActivityParams, reqEditors ...RequestEditorFn) (*ListProjectActivityResp, error) {
+	rsp, err := c.ListProjectActivity(ctx, tenantId, projectId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProjectActivityResp(rsp)
+}
+
 // ListBastionsWithResponse request returning *ListBastionsResp
 func (c *ClientWithResponses) ListBastionsWithResponse(ctx context.Context, tenantId TenantID, projectId ProjectID, reqEditors ...RequestEditorFn) (*ListBastionsResp, error) {
 	rsp, err := c.ListBastions(ctx, tenantId, projectId, reqEditors...)
@@ -18896,6 +19182,67 @@ func ParseUpdateProjectQuotaResp(rsp *http.Response) (*UpdateProjectQuotaResp, e
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest UpdateProjectQuota400JSONResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProjectActivityResp parses an HTTP response from a ListProjectActivityWithResponse call
+func ParseListProjectActivityResp(rsp *http.Response) (*ListProjectActivityResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProjectActivityResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ActivityPage
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What this does

<img width="1274" height="669" alt="image" src="https://github.com/user-attachments/assets/75c7a13a-949d-4b79-ae59-473d1cbd6244" />

Dashboard v2's first piece: a real activity feed. The dashboard previously approximated "recent activity" by sorting resources on created_at — which can't show deletes, status changes, or who did what — and the Activity nav item was a placeholder page.

**dc-api** — new `GET /v1/tenants/{tenant_id}/projects/{project_id}/activity`: the append-only `audit_events` table (already written on every create/delete/status transition) joined with the owning resource's name and type, newest first, `limit`/`offset` paginated with a total count. Spec-first per the add-endpoint checklist; gated by a new `resourcemanager/activity/read` action that Reader's `*/read` covers, so any project member can read it. Events are filtered by `project_uuid` from the request context.

**cloud-ui** — the Activity page replaces its placeholder: time, color-coded action, resource name deep-linking to the detail page, actor, `from → to` status transition, message, Previous/Next pagination, 30-second auto-refresh. The dashboard's "Recently created" card becomes "Recent activity" backed by the same hook (last five events, deep links).

History survives deletion: the resource's name, type, and tenant/project UUIDs are snapshotted onto each event at write time and the resources FK is softened to SET NULL, so deleting a resource no longer erases its audit trail (the original cascade did exactly that — caught in first real use). `resource_id` is therefore optional in the response: present while the resource lives (clients deep-link), absent after deletion. The schema migration backfills snapshots for existing events on startup.

## Verification

dc-api: build/vet clean, 11 unit packages green, spec lints with no new warnings, integration + contract packages vet under their tags, and the new integration tests pass against real Postgres in cluster-free mode (`TestActivity_FeedPaginationAndIsolation`, `TestActivity_ViewerCanRead`). cloud-ui: types regenerated from the final spec; CI typecheck, eslint, vitest all clean. Verified live on the local dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: the audit framework (second and third commits)

First real use of the feed surfaced a class of consistency bugs (`DELETING → DELETING` entries, no terminal event on completed deletion, deep links to deleted resources, raw-JSON error pages), so auditing moved from ~39 hand-written handler call sites to the repository layer, where lifecycle truth lives. Every family's `Create*` records CREATE; every `Update*Status` captures the previous status via `RETURNING` and skips no-op transitions by construction; every `Delete*` records a terminal `DELETE → DELETED` (new enum value, idempotent migration) before the row goes — including cascade children when a VNet takes its subnets/peerings/DNS zones/route tables with it. Actor attribution is stamped on the request context by the auth middlewares ("reconciler"/"system" for background work); handlers contain zero audit code. The feed exposes `resource_id` only while the resource is alive, so clients never render dangling links, and all seven detail pages stop echoing raw `{"error":…}` bodies. Route tables — previously entirely unaudited — join the registry; the dead role-assignment/service-account audit writes are removed and noted as a future IAM-events extension. Framework contract documented in `internal/audit`: a new resource family is audited automatically by following the repository template.

Verification (framework round): four integration tests pin terminal events, no-op suppression, pointer removal, and VNet family coverage; 11 unit packages green; full cluster-free suite at the pre-existing baseline with zero new failures; both clients regenerated; cloud-ui typecheck/lint/vitest clean.
