### PR TITLE
[Fix] Sort the keyvault-operator ImagePolicy by timestamp

### DIFF
--- a/flux/platform/keyvault-operator/base/image-automation.yaml
+++ b/flux/platform/keyvault-operator/base/image-automation.yaml
@@ -17,8 +17,14 @@ metadata:
   namespace: flux-system
 spec:
   imageRepositoryRef: { name: keyvault-operator }
+  # Filter on the timestamp-prefixed tags the operators-branch CI publishes:
+  # <YYYYMMDD>-<HHMMSS>-<git-sha>. The date + time groups concatenate to 14
+  # decimal digits sorted numerically, picking the most recently built image.
+  # Bare-SHA tags are deliberately NOT matched — alphabetical sort of hex SHAs
+  # is meaningless and previously pinned whatever tag began with "ff".
   filterTags:
-    pattern: '^(?P<sha>[a-f0-9]{7,40})$'
-    extract: '$sha'
+    pattern: '^(?P<ts>\d{8})-(?P<tm>\d{6})-[a-f0-9]+$'
+    extract: '$ts$tm'
   policy:
-    alphabetical: { order: asc }
+    numerical:
+      order: asc


### PR DESCRIPTION
The keyvault-operator ImagePolicy filtered on a bare-SHA pattern and sorted alphabetically. Hex SHAs have no meaningful alphabetical order, so image-automation pins whatever tag begins with the highest hex prefix rather than the newest build — the same defect fixed for dc-api in #131. Switch to the timestamp pattern (`YYYYMMDD-HHMMSS-<sha>`) with a numerical sort, matching the tag the operators-branch CI now publishes (see the companion CI PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
