### PR TITLE
Add dc-agent token minting, CLI, and connect ingress

### DIFF
--- a/dc-agent/README.md
+++ b/dc-agent/README.md
@@ -44,8 +44,8 @@ reporting every problem at once.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `DCAGENT_ENDPOINT` | yes | — | Control-plane WebSocket URL, e.g. `wss://controlplane.example.com/v1/agent/ws`. Scheme must be `wss` (`ws` allowed for local dev). |
-| `DCAGENT_TOKEN` | yes | — | Agent bearer token minted by the control plane (`POST /v1/admin/regions`). Must start with `dcagent_`. |
+| `DCAGENT_ENDPOINT` | yes | — | Control-plane agent-channel URL, e.g. `wss://connect.<domain>/v1/agent/ws`. This is the dedicated **connect** host (not the human/API host), which must not sit behind a bot/JS challenge. Scheme must be `wss` (`ws` allowed for local dev). |
+| `DCAGENT_TOKEN` | yes | — | Agent bearer token minted by the control plane — `dcctl admin agent-token create --region <r> --zone <z>` (or the cloud-ui admin page). Must start with `dcagent_`. |
 | `DCAGENT_REGION` | yes | — | Region this agent serves, e.g. `lk`. Sent in the `hello` frame. |
 | `DCAGENT_ZONE` | yes | — | Zone within the region, e.g. `zone-1`. Required even while regions have one zone — the region → zone model is first-class from day one. |
 | `DCAGENT_LOG_LEVEL` | no | `info` | `trace`, `debug`, `info`, `warn`, or `error`. |

--- a/dc-api/internal/api/handlers/regions.go
+++ b/dc-api/internal/api/handlers/regions.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -37,6 +38,11 @@ const (
 	agentUpWindow       = 90 * time.Second
 	agentDegradedWindow = 10 * time.Minute
 )
+
+// regionZonePattern is the slug rule for region and zone names — lowercase
+// ASCII, starts with a letter, ends alphanumeric, 2-32 chars. Mirrors the
+// tenant slug convention so the names stay DNS/label-safe.
+var regionZonePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}[a-z0-9]$`)
 
 // RegionsHandler handles the regions read endpoint and the admin token mint.
 type RegionsHandler struct {
@@ -125,15 +131,23 @@ func (h *RegionsHandler) MintAgentToken(w http.ResponseWriter, r *http.Request) 
 
 	region := chi.URLParam(r, "region")
 	zone := chi.URLParam(r, "zone")
-
-	exists, err := h.repo.ZoneExists(r.Context(), region, zone)
-	if err != nil {
-		h.log.Error().Err(err).Msg("zone exists check failed")
-		writeError(w, http.StatusInternalServerError, "failed to mint agent token")
+	if !regionZonePattern.MatchString(region) {
+		writeError(w, http.StatusBadRequest, "region must match ^[a-z][a-z0-9-]{0,30}[a-z0-9]$")
 		return
 	}
-	if !exists {
-		writeError(w, http.StatusNotFound, "region/zone not found")
+	if !regionZonePattern.MatchString(zone) {
+		writeError(w, http.StatusBadRequest, "zone must match ^[a-z][a-z0-9-]{0,30}[a-z0-9]$")
+		return
+	}
+
+	// Register the region/zone if this is the first token for a freshly
+	// bootstrapped cluster. This records metadata only — provisioning the
+	// underlying Harvester/Rancher infrastructure remains Terraform's job, so
+	// there is no "create region" API; the region/zone simply comes into being
+	// when an admin mints the first agent token for it.
+	if err := h.repo.EnsureRegionZone(r.Context(), region, zone); err != nil {
+		h.log.Error().Err(err).Msg("ensure region/zone failed")
+		writeError(w, http.StatusInternalServerError, "failed to mint agent token")
 		return
 	}
 

--- a/dc-api/internal/db/regions.go
+++ b/dc-api/internal/db/regions.go
@@ -110,16 +110,22 @@ func (r *Repository) ListRegionsWithZones(ctx context.Context) ([]RegionRow, err
 	return regions, nil
 }
 
-// ZoneExists reports whether (region, zone) names a row in the zones table.
-// The admin token-mint handler calls this to return 404 for an unknown zone
-// before generating a credential.
-func (r *Repository) ZoneExists(ctx context.Context, region, zone string) (bool, error) {
-	const q = `SELECT EXISTS (SELECT 1 FROM zones WHERE region_name = $1 AND name = $2)`
-	var exists bool
-	if err := r.pool.QueryRow(ctx, q, region, zone).Scan(&exists); err != nil {
-		return false, fmt.Errorf("db zone exists: %w", err)
+// EnsureRegionZone records a region and its zone if they don't already exist,
+// so an admin minting the first token for a freshly bootstrapped cluster
+// implicitly registers it. This is metadata only — provisioning the underlying
+// Harvester/Rancher infrastructure stays with Terraform, so there is no
+// separate "create region" path; a region/zone exists once a token is minted
+// for it (or an agent connects). Both inserts are idempotent.
+func (r *Repository) EnsureRegionZone(ctx context.Context, region, zone string) error {
+	const regionQ = `INSERT INTO regions (name) VALUES ($1) ON CONFLICT (name) DO NOTHING`
+	if _, err := r.pool.Exec(ctx, regionQ, region); err != nil {
+		return fmt.Errorf("db ensure region: %w", err)
 	}
-	return exists, nil
+	const zoneQ = `INSERT INTO zones (region_name, name) VALUES ($1, $2) ON CONFLICT (region_name, name) DO NOTHING`
+	if _, err := r.pool.Exec(ctx, zoneQ, region, zone); err != nil {
+		return fmt.Errorf("db ensure zone: %w", err)
+	}
+	return nil
 }
 
 // CreateAgentToken stores the sha256 hex digest of a freshly minted agent

--- a/dc-api/openapi.yaml
+++ b/dc-api/openapi.yaml
@@ -214,16 +214,18 @@ paths:
       - name: region
         in: path
         required: true
-        description: Region name (must exist in the regions catalog)
+        description: Region name (slug). Registered on first use if new.
         schema:
           type: string
+          pattern: '^[a-z][a-z0-9-]{0,30}[a-z0-9]$'
           example: lk
       - name: zone
         in: path
         required: true
-        description: Zone name within the region
+        description: Zone name within the region (slug). Registered on first use if new.
         schema:
           type: string
+          pattern: '^[a-z][a-z0-9-]{0,30}[a-z0-9]$'
           example: zone-1
     post:
       operationId: mintAgentToken
@@ -231,10 +233,16 @@ paths:
       summary: Mint a dc-agent bearer token for a zone
       description: |
         Generates a `dcagent_`-prefixed bearer token authorising a dc-agent to
-        connect to `GET /v1/agent/ws` for the given (region, zone). The raw token
+        connect to the agent channel for the given (region, zone). The raw token
         is returned ONCE — only its sha256 digest is stored, so it is never
         recoverable afterwards. Platform-admin only; non-admin callers receive
         403 regardless of their tenant/project roles.
+
+        If the region/zone is not yet known, it is registered as a side effect
+        (metadata only — provisioning the underlying Harvester/Rancher
+        infrastructure is owned by Terraform, not this API). There is therefore
+        no separate "create region/zone" call: a region/zone comes into being
+        when an admin mints the first token for it.
       responses:
         "201":
           description: Token minted (raw value returned exactly once)
@@ -242,14 +250,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AgentTokenResponse"
-        "403":
-          description: Caller is not a platform admin
+        "400":
+          description: Region or zone name is not a valid slug
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        "404":
-          description: Region or zone not found
+        "403":
+          description: Caller is not a platform admin
           content:
             application/json:
               schema:

--- a/dc-api/test/integration/regions_test.go
+++ b/dc-api/test/integration/regions_test.go
@@ -164,9 +164,26 @@ func TestAgentTokenMint(t *testing.T) {
 		t.Errorf("non-admin mint: status %d, want 403", status)
 	}
 
-	// Admin, unknown zone → 404.
-	if _, status := rawReq(t, http.MethodPost, env.BaseURL+"/v1/admin/regions/lk/zones/nope/agent-token", adminToken, nil); status != http.StatusNotFound {
-		t.Errorf("unknown-zone mint: status %d, want 404", status)
+	// Admin, invalid zone name → 400 (slug validation).
+	if _, status := rawReq(t, http.MethodPost, env.BaseURL+"/v1/admin/regions/lk/zones/Bad_Zone/agent-token", adminToken, nil); status != http.StatusBadRequest {
+		t.Errorf("invalid-zone mint: status %d, want 400", status)
+	}
+
+	// Admin, brand-new region/zone → 201 AND the region/zone is registered as a
+	// side effect (no separate create-region call), so it shows up in /v1/regions.
+	if _, status := rawReq(t, http.MethodPost, env.BaseURL+"/v1/admin/regions/lk/zones/zone-new/agent-token", adminToken, nil); status != http.StatusCreated {
+		t.Errorf("new-zone mint: status %d, want 201", status)
+	}
+	regBody, regStatus := rawReq(t, http.MethodGet, env.BaseURL+"/v1/regions", adminToken, nil)
+	if regStatus != http.StatusOK {
+		t.Fatalf("GET /v1/regions after new-zone mint: status %d", regStatus)
+	}
+	var regList tRegionList
+	_ = json.Unmarshal(regBody, &regList)
+	if reg, ok := findRegion(regList, "lk"); !ok {
+		t.Errorf("region lk missing after mint")
+	} else if _, ok := findZone(reg, "zone-new"); !ok {
+		t.Errorf("zone-new not registered by mint; /v1/regions = %s", regBody)
 	}
 
 	// Admin, valid zone → 201 + token once.

--- a/dcctl/cmd/admin/admin.go
+++ b/dcctl/cmd/admin/admin.go
@@ -26,6 +26,7 @@ or DCAPI_ADMIN_GROUP membership).
 Non-admin callers receive 403 from every endpoint under this group.`,
 	}
 	cmd.AddCommand(newAdminTenantCmd())
+	cmd.AddCommand(newAdminAgentTokenCmd())
 	return cmd
 }
 

--- a/dcctl/cmd/admin/agent_token.go
+++ b/dcctl/cmd/admin/agent_token.go
@@ -1,0 +1,95 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/dcctl/internal/client"
+	dcconfig "github.com/wso2/dcctl/internal/config"
+)
+
+func newAdminAgentTokenCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent-token",
+		Short: "Manage dc-agent bootstrap tokens",
+	}
+	cmd.AddCommand(newAdminAgentTokenCreateCmd())
+	return cmd
+}
+
+func newAdminAgentTokenCreateCmd() *cobra.Command {
+	var (
+		region     string
+		zone       string
+		outputJSON bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a dc-agent token for a region/zone (platform-admin only)",
+		Long: `Mint a bearer token that a dc-agent uses to connect to the control plane.
+
+The token is for the agent that runs inside a Harvester cluster identified by
+--region / --zone. If that region/zone is not yet known to dc-api it is
+registered as a side effect (metadata only — the Harvester/Rancher bootstrap
+itself stays with Terraform). The raw token is printed ONCE and is never
+recoverable afterwards.
+
+Names must match ^[a-z][a-z0-9-]{0,30}[a-z0-9]$ (lowercase, starts with a
+letter, 2-32 chars).
+
+Examples:
+  dcctl admin agent-token create --region lk --zone zone-1
+  dcctl admin agent-token create --region lk --zone zone-2 --json`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if region == "" || zone == "" {
+				return fmt.Errorf("--region and --zone are required")
+			}
+			return runAdminAgentTokenCreate(cmd.Context(), region, zone, outputJSON)
+		},
+	}
+
+	cmd.Flags().StringVar(&region, "region", "", "Region slug (e.g. lk) — required")
+	cmd.Flags().StringVar(&zone, "zone", "", "Zone slug within the region (e.g. zone-1) — required")
+	cmd.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAdminAgentTokenCreate(ctx context.Context, region, zone string, outputJSON bool) error {
+	creds, err := dcconfig.LoadCredentials()
+	if err != nil {
+		return err
+	}
+	apiClient := client.New(creds.AccessToken)
+
+	resp, err := apiClient.Typed.MintAgentTokenWithResponse(ctx, region, zone)
+	if err != nil {
+		return fmt.Errorf("POST /v1/admin/regions/%s/zones/%s/agent-token: %w", region, zone, err)
+	}
+	if resp.StatusCode() != http.StatusCreated || resp.JSON201 == nil {
+		return apiErrorf(resp.StatusCode(), resp.Body)
+	}
+	tok := resp.JSON201
+
+	if outputJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(tok)
+	}
+
+	fmt.Printf("Agent token created for region=%s zone=%s\n", tok.Region, tok.Zone)
+	fmt.Println("Store it now — it is shown only once and cannot be recovered.")
+	fmt.Println()
+	fmt.Println("Set these on the dc-agent in that cluster:")
+	fmt.Println("  DCAGENT_ENDPOINT=wss://<connect-endpoint>/v1/agent/ws")
+	fmt.Printf("  DCAGENT_TOKEN=%s\n", tok.Token)
+	fmt.Printf("  DCAGENT_REGION=%s\n", tok.Region)
+	fmt.Printf("  DCAGENT_ZONE=%s\n", tok.Zone)
+	return nil
+}

--- a/dcctl/internal/client/generated/dcapi.gen.go
+++ b/dcctl/internal/client/generated/dcapi.gen.go
@@ -12704,8 +12704,8 @@ type MintAgentTokenResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *AgentTokenResponse
+	JSON400      *Error
 	JSON403      *Error
-	JSON404      *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -18547,19 +18547,19 @@ func ParseMintAgentTokenResp(rsp *http.Response) (*MintAgentTokenResp, error) {
 		}
 		response.JSON201 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON403 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
 
 	}
 

--- a/examples/consumer/flux/platform-overlay/kustomization.yaml
+++ b/examples/consumer/flux/platform-overlay/kustomization.yaml
@@ -79,6 +79,18 @@ patches:
         path: /spec/tls/0/hosts/0
         value: "CHANGE-ME-dcapi-hostname"
 
+  # dc-agent connect endpoint. Use a sibling host under the same wildcard cert
+  # as the API (e.g. connect.<domain>). This host must NOT sit behind a bot/JS
+  # challenge — dc-agents are programmatic clients that can't solve one.
+  - target: { kind: Ingress, name: dc-api-connect }
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: "CHANGE-ME-connect-hostname"
+      - op: replace
+        path: /spec/tls/0/hosts/0
+        value: "CHANGE-ME-connect-hostname"
+
   - target: { kind: Ingress, name: cloud-ui }
     patch: |-
       - op: replace

--- a/flux/platform/dc-api/base/connect-ingress.yaml
+++ b/flux/platform/dc-api/base/connect-ingress.yaml
@@ -1,0 +1,40 @@
+# Dedicated dc-agent "connect" Ingress.
+#
+# dc-agents dial THIS host (not the human/API host) over WSS to reach the agent
+# channel (/v1/agent/ws). It is a separate hostname on purpose so the platform
+# can apply different edge policy here: in particular this host must NOT sit
+# behind a bot/JS challenge (e.g. a CDN "managed challenge"), because dc-agents
+# are programmatic clients that can't solve one. Security still holds — the
+# agent authenticates with its dcagent_ bearer token, validated by dc-api.
+#
+# Typically a sibling subdomain under the same wildcard cert as the API host
+# (e.g. connect.<domain> alongside api.<domain>). The per-env overlay patches
+# the host + TLS secret name.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dc-api-connect
+  namespace: dc-system
+  annotations:
+    # WebSocket keepalive: hold the upgraded connection open well past nginx's
+    # 60s default so the agent's 30s-ping / ~120s read-deadline loop survives.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: ["connect.placeholder.example.com"]
+      secretName: dc-api-connect-tls
+  rules:
+    - host: connect.placeholder.example.com
+      http:
+        paths:
+          # Scoped to the agent channel only — widen if other programmatic
+          # (non-browser) clients need this non-challenged host too.
+          - path: /v1/agent/ws
+            pathType: Prefix
+            backend:
+              service:
+                name: dc-api
+                port:
+                  number: 80

--- a/flux/platform/dc-api/base/kustomization.yaml
+++ b/flux/platform/dc-api/base/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - connect-ingress.yaml
   - image-automation.yaml

--- a/scripts/init-flux.sh
+++ b/scripts/init-flux.sh
@@ -691,7 +691,18 @@ cmd_seal() {
   else
     bff_session_secret="$(openssl rand -base64 32)"
   fi
-  oidc_audience="$rancher_oidc_client_id,$bff_client_id,$cloud_ui_client_id"
+  # Audience = every client whose tokens dc-api must accept. Single source of
+  # truth: the asgardeo-auth layer's dc_api_oidc_audiences output, which joins
+  # every TF-managed client (rancher-sso, cloud-ui SPA, cloud-ui BFF, dcctl).
+  # Sourcing it here (instead of hand-assembling) is what keeps a from-scratch
+  # bootstrap and an ad-hoc re-seal byte-identical, and stops a client from
+  # being silently dropped (which is how dcctl fell out of the list before).
+  # Fallback: the legacy trio for consumers whose asgardeo-auth predates the
+  # output (it won't include dcctl — add the output to fix that).
+  oidc_audience="$(tf_get asgardeo-auth dc_api_oidc_audiences)"
+  if [[ -z "$oidc_audience" ]]; then
+    oidc_audience="$rancher_oidc_client_id,$bff_client_id,$cloud_ui_client_id"
+  fi
 
   seal() {
     local name="$1" namespace="$2"; shift 2


### PR DESCRIPTION
## What this does

<img width="1512" height="62" alt="image" src="https://github.com/user-attachments/assets/e4508d8a-c015-47e9-b56d-371a4ea93a6d" />

<img width="413" height="109" alt="image" src="https://github.com/user-attachments/assets/e2c026fe-b2fe-47d5-9d89-5a2e23cd20a0" />

Completes the operator-facing path to bring a per-zone `dc-agent` online against a deployed control plane. The multi-region foundation added the agent WebSocket channel (`/v1/agent/ws`) and the region/zone model; this adds the pieces an operator actually uses to connect an agent.

- **Register region/zone on mint** (`d861bda`) — minting the first agent token for a region/zone now records that region/zone if it doesn't exist yet, so a freshly bootstrapped cluster comes into being by minting its first token rather than needing a separate "create region" call. Provisioning the underlying Harvester/Rancher infra remains Terraform's job; this records metadata only.
- **`dcctl admin agent-token`** (`b573282`) — a platform-admin CLI command to mint an agent token for a region/zone. The raw `dcagent_` token is returned exactly once (only its sha256 digest is stored).
- **Dedicated connect ingress** (`1ece344`) — a separate hostname serving only `/v1/agent/ws`, kept deliberately off any bot/JS challenge because dc-agents are programmatic clients that can't solve one. Security still holds via the `dcagent_` bearer token validated by dc-api. The base uses a placeholder host; the per-env overlay patches the real host and TLS secret name.
- **Single-source the OIDC audience** (`f63c974`) — `init-flux.sh` derives `DCAPI_OIDC_AUDIENCE` from one Terraform output instead of hand-assembling the list, closing the gap where a client's audience could be silently dropped from the sealed secret.

## Verification

dc-api and dcctl build and unit tests pass. End-to-end: minted a token through the admin endpoint with a real `dc-admin` JWT, ran the dc-agent against the deployed dc-api, and watched `zone-1` go from `agent: null` to connected (`status: up`). `openapi.yaml` and the regions integration test are updated in the same change.

## Operational notes

The connect ingress host is a placeholder in the base (`connect.placeholder.example.com`); consumers patch it per environment. No internal hostnames are committed.