### PR TITLE
Add the dc-agent image build and a host-cluster Flux template

### DIFF
--- a/.github/workflows/dc-agent.yaml
+++ b/.github/workflows/dc-agent.yaml
@@ -1,0 +1,92 @@
+name: dc-agent
+
+# Build, test, and publish the dc-agent image. The agent runs IN each region's
+# host (Harvester) cluster, dials the control plane outbound over WSS, and serves
+# operations against the local cluster. Runs on GitHub-hosted runners — no
+# self-hosted infrastructure. Deployment is the consumer's concern: the host
+# cluster's Flux ImageUpdateAutomation watches ghcr.io/wso2/dc-agent and rolls
+# new tags in (see examples/consumer/flux-harvester/).
+
+on:
+  pull_request:
+    paths:
+      - 'dc-agent/**'
+      - '.github/workflows/dc-agent.yaml'
+  push:
+    branches: [controlplane]
+    paths:
+      - 'dc-agent/**'
+      - '.github/workflows/dc-agent.yaml'
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/wso2/dc-agent
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: dc-agent/go.mod
+          cache-dependency-path: dc-agent/go.sum
+
+      - name: Unit tests
+        run: cd dc-agent && go test ./...
+
+  build-and-push:
+    # Only publish on push to controlplane (i.e. after a merge). PRs from
+    # forks couldn't write to ghcr.io/wso2/* anyway — GITHUB_TOKEN's
+    # packages:write permission is denied for fork-triggered runs.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Sortable timestamp tag (UTC) for the consumer Flux ImagePolicy's
+      # numerical sort — bare-SHA tags sort alphabetically, which is
+      # meaningless for hex. Matches the dc-api workflow's tag scheme.
+      - name: Generate build timestamp
+        id: ts
+        run: echo "tag=$(date -u +%Y%m%d-%H%M%S)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push dc-agent
+        uses: docker/build-push-action@v5
+        with:
+          context: ./dc-agent
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ steps.ts.outputs.tag }}-${{ github.sha }}
+          cache-from: type=gha,scope=dc-agent
+          cache-to: type=gha,mode=max,scope=dc-agent
+
+      - name: Summary
+        run: |
+          {
+            echo "### dc-agent published"
+            echo
+            echo "- \`${{ env.IMAGE }}:latest\`"
+            echo "- \`${{ env.IMAGE }}:${{ github.sha }}\`"
+            echo "- \`${{ env.IMAGE }}:${{ steps.ts.outputs.tag }}-${{ github.sha }}\`"
+            echo
+            echo "A host-cluster Flux ImagePolicy auto-bumps the deployed pin."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/examples/consumer/flux-harvester/README.md
+++ b/examples/consumer/flux-harvester/README.md
@@ -1,0 +1,65 @@
+# Consumer Flux overlay (host cluster) — template
+
+The **second** Flux overlay: this one runs on the **Harvester host cluster**,
+the sibling of `../flux/` (which runs on the control-plane / management
+cluster). It reconciles the OCD operators that belong on the host cluster —
+the things that need in-cluster access to the nodes and KubeVirt VMs:
+keyvault-operator today, and dc-agent / a database-operator next.
+
+It is a dedicated Flux instance, **not** Rancher Fleet — the host cluster's
+Fleet is left untouched. Bootstrap it with a `06-flux-bootstrap-harvester`
+Terraform layer (`flux_bootstrap_git` pointed at the host cluster's local
+kubeconfig), the analogue of the control-plane `06-flux-bootstrap`.
+
+Copy this directory into your consumer repo at a per-env path:
+
+```bash
+cp -r examples/consumer/flux-harvester/ \
+  ~/path/to/my-consumer-repo/environments/<env>/flux-harvester/
+```
+
+Then:
+
+1. Replace every `CHANGE-ME` placeholder with your env's values (the env path
+   in `platform.yaml` + `image-update-automation.yaml`, the commit author, and
+   the image-tag pins in `platform-overlay/kustomization.yaml`).
+2. Pin OCD to a release tag in `sources.yaml` + `platform-overlay/` (`?ref=`),
+   in lock-step with `../flux/`.
+3. Apply your `06-flux-bootstrap-harvester` TF layer (kubeconfig = the host
+   cluster, NOT the Rancher proxy) — `flux_bootstrap_git` populates
+   `flux-system/` and installs Flux on the host cluster.
+4. Flux reconciles the operators from GHCR.
+
+## What each file does
+
+- `sources.yaml` — Flux `GitRepository` resources: OCD (the shared operator
+  bases, pinned) and this consumer repo (the overlay + any sealed secrets).
+- `platform.yaml` — Flux `Kustomization` reconciling `./platform-overlay/`.
+- `platform-overlay/kustomization.yaml` — pulls each OCD operator base as a
+  remote Kustomize base (one line per operator) and patches it for the host
+  cluster.
+- `image-update-automation.yaml` — commits operator image-tag bumps back to
+  this repo as CI publishes new tags.
+- `flux-system/` — populated by `flux_bootstrap_git` on apply
+  (gotk-components / gotk-sync / kustomization). Empty until then; don't
+  hand-edit. It **must** stay listed in `kustomization.yaml` or the root
+  prune deletes Flux's own components.
+
+## No infrastructure layer
+
+Unlike `../flux/`, there is no `infrastructure.yaml`. The host cluster runs
+operators, not ingress workloads — no cert-manager / ingress-nginx /
+sealed-secrets needed. The operator images are public GHCR packages, so the
+platform overlay patches out the bases' `ghcr-pull-secret` references rather
+than sealing a pull secret. Add an `infrastructure.yaml` (pulling OCD's
+`flux/infrastructure/sealed-secrets`) only if a future operator needs a sealed
+secret — e.g. dc-agent, whose `dcagent_` channel token is sealed in.
+
+## Adding an operator (e.g. dc-agent)
+
+1. Add the operator's OCD base to `platform-overlay/kustomization.yaml`
+   `resources:` (one line, `?ref=` matching `sources.yaml`).
+2. Add a matching `images:` entry with the `{"$imagepolicy": ...:tag}` setter
+   marker so image-automation bumps it.
+3. If the operator needs a secret (dc-agent's token) or a private image, add an
+   `infrastructure.yaml` for sealed-secrets and seal it into `platform-overlay/`.

--- a/examples/consumer/flux-harvester/flux-system/.gitkeep
+++ b/examples/consumer/flux-harvester/flux-system/.gitkeep
@@ -1,0 +1,4 @@
+# Populated by `flux_bootstrap_git` (the 06-flux-bootstrap-harvester TF layer)
+# on apply: gotk-components.yaml, gotk-sync.yaml, kustomization.yaml. Empty
+# until then — do not hand-edit. Must stay listed in ../kustomization.yaml or
+# the root prune deletes Flux's own components.

--- a/examples/consumer/flux-harvester/image-update-automation.yaml
+++ b/examples/consumer/flux-harvester/image-update-automation.yaml
@@ -1,0 +1,50 @@
+# Flux Image Update Automation — host-cluster operators.
+#
+# Watches the ImagePolicy resources from the OCD operator bases and commits
+# image-tag bumps back to this consumer repo as CI publishes newer tags. It
+# scans the platform-overlay path for `{"$imagepolicy": "..."}` markers (on the
+# kustomize images: newTag fields), mutates them inline, and pushes one commit
+# per round.
+#
+# This is a DIFFERENT object on a DIFFERENT cluster from the control-plane
+# overlay's automation. Both may push to the same branch, but they touch
+# disjoint files (this one only flux-harvester/, the control-plane one only
+# flux/), so their commits don't collide.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: harvester-operators
+  namespace: flux-system
+spec:
+  interval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        # CHANGE-ME: the branch your host-cluster Flux reconciles (commonly an
+        # unprotected `flux-deploy` branch so the bot can push tag bumps).
+        branch: CHANGE-ME-FLUX-BRANCH
+    commit:
+      author:
+        name: Flux Image Automation
+        email: flux@CHANGE-ME.example.com
+      messageTemplate: |
+        Auto-bump host-cluster operator image tags
+
+        Files:
+        {{ range $filename, $_ := .Updated.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Images:
+        {{ range .Updated.Images -}}
+        - {{ . }}
+        {{ end -}}
+    push:
+      branch: CHANGE-ME-FLUX-BRANCH
+  update:
+    # CHANGE-ME: your env's path to platform-overlay/.
+    path: ./environments/CHANGE-ME-ENV/flux-harvester/platform-overlay
+    strategy: Setters

--- a/examples/consumer/flux-harvester/kustomization.yaml
+++ b/examples/consumer/flux-harvester/kustomization.yaml
@@ -1,0 +1,23 @@
+# Root kustomization for the host cluster's Flux overlay. Sibling of
+# ../flux/kustomization.yaml but scoped to host-cluster operators.
+#
+# List each child explicitly so the root reconcile is a one-shot pass and never
+# falls into Flux's recursive fallback (which would drag platform-overlay/'s
+# Deployment into the root reconcile out of order).
+#
+# flux-system/ MUST be listed — it holds gotk-components.yaml, gotk-sync.yaml,
+# and the bootstrap kustomization.yaml that flux_bootstrap_git writes on apply.
+# Without it in the root inventory, the root Kustomization (prune: true) deletes
+# the gotk-* set on the next reconcile and the cluster's Flux silently goes
+# offline.
+#
+# NOTE: no infrastructure.yaml — the host cluster runs operators, not ingress
+# workloads (no cert-manager / ingress-nginx / sealed-secrets). Add one only if
+# a future operator needs a sealed secret (see README).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-system
+  - sources.yaml
+  - platform.yaml
+  - image-update-automation.yaml

--- a/examples/consumer/flux-harvester/platform-overlay/kustomization.yaml
+++ b/examples/consumer/flux-harvester/platform-overlay/kustomization.yaml
@@ -1,0 +1,58 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Host-cluster operator overlay. Each OCD operator base is pulled as a remote
+# Kustomize base — ONE LINE PER OPERATOR. A new operator (dc-agent, a
+# database-operator) slots in by adding its base path here + a matching images:
+# entry below; nothing else in this file changes shape.
+resources:
+  # keyvault-operator (KVI): reconciles per-tenant OpenBao Raft clusters.
+  # Keep the ?ref= in lock-step with ../sources.yaml.
+  - https://github.com/wso2/open-cloud-datacenter//flux/platform/keyvault-operator/base?ref=controlplane
+  #
+  # dc-agent: the per-zone agent. Uncomment once ghcr.io/wso2/dc-agent is
+  # published and flux/platform/dc-agent/base exists. The agent needs its
+  # dcagent_ channel token — seal it via an infrastructure.yaml (sealed-secrets)
+  # and reference it from the base, OR patch a Secret in here.
+  # - https://github.com/wso2/open-cloud-datacenter//flux/platform/dc-agent/base?ref=controlplane
+
+# ── Host-cluster patches ─────────────────────────────────────────────────────
+# The OCD bases assume a sealed ghcr-pull-secret exists. On the host cluster
+# there is no sealed-secrets controller and the images are PUBLIC GHCR
+# packages, so strip the pull-secret references rather than provisioning one.
+patches:
+  - target: {kind: Deployment, name: keyvault-controller-manager}
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/imagePullSecrets
+  - target: {kind: ImageRepository, name: keyvault-operator}
+    patch: |-
+      - op: remove
+        path: /spec/secretRef
+  # ── Controller-only: leave cluster-scoped CRDs to Terraform ────────────────
+  # CRDs hold live CRs with cleanup finalizers; keep them TF-owned so Flux
+  # never prunes them. Delete the base's bundled CRDs from this build output.
+  - patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: keyvaultbackends.keyvault.opencloud.wso2.com
+      $patch: delete
+  - patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: keyvaultinstances.keyvault.opencloud.wso2.com
+      $patch: delete
+
+# ── Image pins + auto-bump markers ───────────────────────────────────────────
+# Swap each base Deployment's placeholder image for this env's pinned tag. The
+# `{"$imagepolicy": "...:tag"}` marker tells the host cluster's
+# ImageUpdateAutomation to bump ONLY this tag field. The initial tag MUST exist
+# in GHCR.
+images:
+  - name: ghcr.io/wso2/keyvault-operator
+    newName: ghcr.io/wso2/keyvault-operator
+    newTag: "CHANGE-ME-TAG" # {"$imagepolicy": "flux-system:keyvault-operator:tag"}
+  # - name: ghcr.io/wso2/dc-agent
+  #   newName: ghcr.io/wso2/dc-agent
+  #   newTag: "CHANGE-ME-TAG" # {"$imagepolicy": "flux-system:dc-agent:tag"}

--- a/examples/consumer/flux-harvester/platform.yaml
+++ b/examples/consumer/flux-harvester/platform.yaml
@@ -1,0 +1,22 @@
+# Reconciles the host-cluster operator overlay in ./platform-overlay/, which
+# pulls OCD operator bases as remote Kustomize bases and patches them for the
+# host cluster.
+#
+# No dependsOn (unlike the control-plane overlay): the operator images are
+# public, so this needs no sealed-secrets controller first. Add a dependsOn on
+# an infrastructure Kustomization only if you introduce sealed secrets.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: platform
+  namespace: flux-system
+spec:
+  interval: 10m
+  # CHANGE-ME: your env's path to this overlay's platform-overlay/ dir.
+  path: ./environments/CHANGE-ME-ENV/flux-harvester/platform-overlay
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  timeout: 10m

--- a/examples/consumer/flux-harvester/sources.yaml
+++ b/examples/consumer/flux-harvester/sources.yaml
@@ -1,0 +1,26 @@
+# Flux Sources for the host-cluster overlay:
+#   1. open-cloud-datacenter — the shared OCD library (operator bases),
+#      pinned to a ref. Bump to upgrade OCD across this env.
+#   2. flux-system — this consumer repo, auto-created by `flux_bootstrap_git`
+#      in the 06-flux-bootstrap-harvester layer (not declared here).
+#
+# This is a SEPARATE GitRepository from the one the control-plane Flux creates
+# — it lives in the host cluster's own flux-system namespace, isolated by
+# cluster, so the shared name does not conflict. Image-automation writes back
+# only to the consumer repo; OCD is read-only from the cluster's POV.
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: open-cloud-datacenter
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: https://github.com/wso2/open-cloud-datacenter
+  ref:
+    # Track `controlplane` for tip-of-trunk; switch to a `controlplane/vX.Y.Z`
+    # tag once OCD cuts one. Keep in lock-step with ../flux/sources.yaml.
+    branch: controlplane
+  ignore: |
+    /*
+    !/flux


### PR DESCRIPTION
## What this does

Makes the **host (Harvester) cluster's** operators deployable the same GitOps way the control-plane cluster already is — so keyvault-operator runs via Flux today, and dc-agent slots in next with nothing new to design.

**dc-agent CI** (`.github/workflows/dc-agent.yaml`): test + build-and-push `ghcr.io/wso2/dc-agent` on merge to `controlplane`, mirroring the dc-api workflow (UTC-timestamped tags so a consumer `ImagePolicy`'s numeric sort works). It builds the `dc-agent/` that's on `controlplane` today and picks up the M-A channel/executor automatically once that lands.

**Host-cluster Flux template** (`examples/consumer/flux-harvester/`): the template for the *second* Flux overlay — the host-cluster sibling of `examples/consumer/flux/`. It's a dedicated Flux instance (deliberately **not** Rancher Fleet — the host cluster's Fleet is left untouched), bootstrapped by a `06-flux-bootstrap-harvester` TF layer against the host cluster's own kubeconfig. It pulls OCD operator bases as remote Kustomize bases (one line per operator) and patches them for a host cluster that has no cert-manager / ingress-nginx / sealed-secrets. The README walks through copy-and-`CHANGE-ME` and the "adding an operator" recipe; the overlay ships keyvault-operator wired and dc-agent commented-in alongside it.

## Why

The host cluster needs in-cluster operators (read its nodes/KubeVirt VMs; later apply CRs) without leaking its credential off-cluster. Running them via a host-local Flux keeps the credential in the zone and gives the same image → ImagePolicy → auto-bump loop the control plane uses. This is the source-side counterpart to the consumer-side `flux-harvester` overlay (wso2-enterprise/wso2-datacenter-project#269), and the on-ramp for shipping dc-agent into Harvester.

## Notes

No `infrastructure.yaml` in the template by design — host clusters don't need ingress/cert add-ons. One is added only when an operator needs a sealed secret, which dc-agent will (its `dcagent_` channel token). The keyvault CRDs stay Terraform-owned (cluster-scoped, hold tenant finalizers); the overlay deletes the bases' bundled CRDs so Flux is controller-only.