### PR TITLE
Add a Flux base for dc-webhook and an in-cluster client path

### DIFF
--- a/dc-api/cmd/webhook/main.go
+++ b/dc-api/cmd/webhook/main.go
@@ -15,8 +15,10 @@
 //	DCWEBHOOK_LISTEN_ADDR   HTTPS listen address (default: :9443)
 //	DCWEBHOOK_CERT_FILE     Path to TLS certificate PEM file (required)
 //	DCWEBHOOK_KEY_FILE      Path to TLS private key PEM file (required)
-//	DCWEBHOOK_KUBECONFIG    Base64-encoded kubeconfig for the Harvester cluster
-//	                        (required; same credential as DCAPI_HARVESTER_KUBECONFIG)
+//	DCWEBHOOK_KUBECONFIG    Optional. Empty → in-cluster config (the production
+//	                        default: runs in the Harvester cluster with a
+//	                        ServiceAccount + RBAC). Set (base64 or raw YAML) only
+//	                        for out-of-cluster/local runs.
 //	DCWEBHOOK_LOG_LEVEL     zerolog level: debug|info|warn|error (default: info)
 //
 // Running locally (for development, not production):
@@ -48,6 +50,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/wso2/dc-api/internal/webhook"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -55,7 +58,10 @@ type config struct {
 	ListenAddr string `envconfig:"LISTEN_ADDR" default:":9443"`
 	CertFile   string `envconfig:"CERT_FILE"   required:"true"`
 	KeyFile    string `envconfig:"KEY_FILE"    required:"true"`
-	Kubeconfig string `envconfig:"KUBECONFIG"  required:"true"`
+	// Kubeconfig is optional. Empty → in-cluster config (the webhook runs in
+	// the Harvester cluster with a ServiceAccount + RBAC, the GitOps default).
+	// Set it (base64 or raw YAML) only for out-of-cluster/local runs.
+	Kubeconfig string `envconfig:"KUBECONFIG"`
 	LogLevel   string `envconfig:"LOG_LEVEL"   default:"info"`
 }
 
@@ -77,15 +83,25 @@ func main() {
 	log.Info().Str("listen", cfg.ListenAddr).Str("log_level", level.String()).Msg("DC-API webhook starting")
 
 	// ── Kubernetes dynamic client ─────────────────────────────────────────────
-	// Decode kubeconfig (accepts base64 or raw YAML, same as the harvester driver).
-	kubeconfigBytes, err := base64.StdEncoding.DecodeString(cfg.Kubeconfig)
-	if err != nil {
-		kubeconfigBytes = []byte(cfg.Kubeconfig)
-	}
-
-	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
-	if err != nil {
-		log.Fatal().Err(err).Msg("webhook: parse kubeconfig failed")
+	// In-cluster by default: the webhook runs in the Harvester cluster and reads
+	// NetworkAttachmentDefinitions through its ServiceAccount (RBAC). A kubeconfig
+	// is only needed for out-of-cluster runs (local dev) — set DCWEBHOOK_KUBECONFIG
+	// then (accepts base64 or raw YAML, same as the harvester driver).
+	var restCfg *rest.Config
+	if cfg.Kubeconfig == "" {
+		restCfg, err = rest.InClusterConfig()
+		if err != nil {
+			log.Fatal().Err(err).Msg("webhook: in-cluster config failed (set DCWEBHOOK_KUBECONFIG for out-of-cluster runs)")
+		}
+	} else {
+		kubeconfigBytes, decErr := base64.StdEncoding.DecodeString(cfg.Kubeconfig)
+		if decErr != nil {
+			kubeconfigBytes = []byte(cfg.Kubeconfig)
+		}
+		restCfg, err = clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+		if err != nil {
+			log.Fatal().Err(err).Msg("webhook: parse kubeconfig failed")
+		}
 	}
 
 	dynClient, err := dynamic.NewForConfig(restCfg)

--- a/flux/platform/dc-webhook/base/certificate.yaml
+++ b/flux/platform/dc-webhook/base/certificate.yaml
@@ -1,0 +1,34 @@
+# TLS for the admission webhook, via cert-manager (replaces the Terraform `tls`
+# provider's self-signed CA). A namespaced self-signed Issuer mints the serving
+# cert; cert-manager writes it to the dc-api-webhook-tls Secret (mounted at /tls)
+# and populates ca.crt. The MutatingWebhookConfiguration's
+# `cert-manager.io/inject-ca-from` annotation then lets cainjector fill its
+# caBundle from this cert — so the cert + the apiserver's trust stay in lock-step
+# and rotate automatically. Requires cert-manager on the cluster (already present
+# on harvester-dev; otherwise the flux-harvester infrastructure layer installs it).
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: dc-api-webhook-selfsigned
+  namespace: dc-webhook-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dc-api-webhook-serving-cert
+  namespace: dc-webhook-system
+spec:
+  secretName: dc-api-webhook-tls
+  duration: 8760h    # 1y
+  renewBefore: 720h  # 30d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - dc-api-webhook.dc-webhook-system.svc
+    - dc-api-webhook.dc-webhook-system.svc.cluster.local
+  issuerRef:
+    name: dc-api-webhook-selfsigned
+    kind: Issuer

--- a/flux/platform/dc-webhook/base/deployment.yaml
+++ b/flux/platform/dc-webhook/base/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dc-api-webhook
+  namespace: dc-webhook-system
+  labels:
+    app: dc-api-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dc-api-webhook
+  template:
+    metadata:
+      labels:
+        app: dc-api-webhook
+    spec:
+      serviceAccountName: dc-api-webhook
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: webhook
+          # Public image; tag pinned + auto-bumped by the consumer overlay.
+          image: ghcr.io/wso2/dc-api-webhook:latest # {"$imagepolicy": "flux-system:dc-api-webhook"}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: https
+              containerPort: 9443
+          env:
+            - name: DCWEBHOOK_LISTEN_ADDR
+              value: ":9443"
+            - name: DCWEBHOOK_CERT_FILE
+              value: /tls/tls.crt
+            - name: DCWEBHOOK_KEY_FILE
+              value: /tls/tls.key
+            - name: DCWEBHOOK_LOG_LEVEL
+              value: info
+            # No DCWEBHOOK_KUBECONFIG — the webhook uses in-cluster config + the
+            # ServiceAccount above. Set it only for out-of-cluster/local runs.
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: tls
+          secret:
+            secretName: dc-api-webhook-tls

--- a/flux/platform/dc-webhook/base/image-automation.yaml
+++ b/flux/platform/dc-webhook/base/image-automation.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: dc-api-webhook
+  namespace: flux-system
+spec:
+  image: ghcr.io/wso2/dc-api-webhook
+  interval: 5m
+  # Public image — no secretRef. (The host overlay would strip one anyway.)
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: dc-api-webhook
+  namespace: flux-system
+spec:
+  imageRepositoryRef: { name: dc-api-webhook }
+  # Same timestamp-prefixed tag scheme as dc-api / keyvault-operator:
+  # <YYYYMMDD>-<HHMMSS>-<git-sha>, sorted numerically to pick the newest build.
+  filterTags:
+    pattern: '^(?P<ts>\d{8})-(?P<tm>\d{6})-[a-f0-9]+$'
+    extract: '$ts$tm'
+  policy:
+    numerical:
+      order: asc

--- a/flux/platform/dc-webhook/base/kustomization.yaml
+++ b/flux/platform/dc-webhook/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - certificate.yaml
+  - service.yaml
+  - deployment.yaml
+  - webhook.yaml
+  - image-automation.yaml

--- a/flux/platform/dc-webhook/base/namespace.yaml
+++ b/flux/platform/dc-webhook/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dc-webhook-system

--- a/flux/platform/dc-webhook/base/rbac.yaml
+++ b/flux/platform/dc-webhook/base/rbac.yaml
@@ -1,0 +1,31 @@
+# The webhook runs in-cluster and resolves NetworkAttachmentDefinitions at
+# admission time via this ServiceAccount — no kubeconfig travels. Tenant
+# namespaces are dc-<id>, not predictable at deploy time, so NAD reads are
+# cluster-scoped (ClusterRole), exactly as the retired Terraform module granted.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dc-api-webhook
+  namespace: dc-webhook-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dc-api-webhook
+rules:
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources: ["network-attachment-definitions"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dc-api-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dc-api-webhook
+subjects:
+  - kind: ServiceAccount
+    name: dc-api-webhook
+    namespace: dc-webhook-system

--- a/flux/platform/dc-webhook/base/service.yaml
+++ b/flux/platform/dc-webhook/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dc-api-webhook
+  namespace: dc-webhook-system
+spec:
+  type: ClusterIP
+  selector:
+    app: dc-api-webhook
+  ports:
+    - name: https
+      port: 443
+      targetPort: 9443

--- a/flux/platform/dc-webhook/base/webhook.yaml
+++ b/flux/platform/dc-webhook/base/webhook.yaml
@@ -1,0 +1,34 @@
+# Mutating admission webhook: injects MAC-pinning + KubeOVN annotations on
+# KubeVirt VMs. failurePolicy: Ignore is intentional — if the webhook is down,
+# non-OVN VMs must not be blocked; OVN VMs just miss the MAC pinning (same as
+# before the webhook existed). The handler filters internally by NAD type and
+# no-ops on non-OVN VMs, so no namespaceSelector is needed.
+#
+# The caBundle is injected by cert-manager's cainjector from the serving
+# Certificate (the inject-ca-from annotation), so it is omitted here and kept in
+# lock-step with cert rotation.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: dc-api-ovn-mac-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: dc-webhook-system/dc-api-webhook-serving-cert
+webhooks:
+  - name: virtualmachines.kubevirt.io.dc-api.opencloud.wso2.com
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: dc-api-webhook
+        namespace: dc-webhook-system
+        path: /mutate
+        port: 443
+    rules:
+      - apiGroups: ["kubevirt.io"]
+        apiVersions: ["v1"]
+        resources: ["virtualmachines"]
+        operations: ["CREATE", "UPDATE"]
+        scope: Namespaced
+    failurePolicy: Ignore
+    sideEffects: None
+    timeoutSeconds: 5
+    reinvocationPolicy: Never


### PR DESCRIPTION
## What this does

Moves the dc-api mutating admission webhook off Terraform onto the host cluster's Flux — the same pattern as keyvault-operator — so the last hand-rolled operator on Harvester becomes GitOps-managed. Two parts:

**1. In-cluster client path** (`cmd/webhook/main.go`): `DCWEBHOOK_KUBECONFIG` becomes optional and the webhook falls back to `rest.InClusterConfig()`. It runs inside the Harvester cluster, so it should resolve NetworkAttachmentDefinitions through a ServiceAccount + RBAC rather than a travelling kubeconfig. A kubeconfig is still honored for out-of-cluster/local runs.

**2. `flux/platform/dc-webhook/base/`**: the full stack as GitOps manifests — ServiceAccount + ClusterRole (NAD reads) + binding, Deployment (in-cluster, **no kubeconfig secret**), Service, and the `MutatingWebhookConfiguration` (kubevirt.io VMs, CREATE/UPDATE, `failurePolicy: Ignore`). TLS moves from the Terraform `tls` provider to a **cert-manager** self-signed Issuer + Certificate, with **cainjector** populating the webhook's `caBundle` — so the serving cert and the apiserver's trust rotate together. Public image; tag auto-bumped via the same timestamp `ImagePolicy` scheme as dc-api.

## Notes for reviewers

The consumer side (separate PR) adds this base to the `flux-harvester` overlay and retires the TF `dc_webhook` module. cert-manager is already present on the host cluster, so the webhook's TLS works without first migrating cert-manager itself. Unlike the keyvault move, nothing stays TF-owned here — there are no CRDs (RBAC + webhook config are safe for Flux to own). `kustomize build` produces the 11 expected objects; webhook unit tests pass.

Sequencing: merge this so CI republishes `ghcr.io/wso2/dc-api-webhook` with the in-cluster path, then the consumer overlay pins that tag and the kubeconfig-free Deployment works.