### PR TITLE
Add kube-ovn Flux base for host-cluster SDN

### DIFF
--- a/flux/infrastructure/kube-ovn/README.md
+++ b/flux/infrastructure/kube-ovn/README.md
@@ -1,0 +1,70 @@
+# KubeOVN (host-cluster SDN) — Flux base
+
+Installs **upstream KubeOVN** (`kubeovn/kube-ovn`, pinned `v1.15.4`) as a
+**Multus secondary CNI** on the Harvester host cluster. This is the SDN dc-api
+drives for tenant VPC networking — it creates `Vpc` / `Subnet` /
+`VpcNatGateway` / `NetworkAttachmentDefinition` CRDs against this install at
+runtime.
+
+This base is for a **host cluster** (the one running KubeVirt VMs), not the
+control-plane workload cluster. A host-cluster Flux overlay references it; the
+control-plane cluster's `flux/infrastructure/kustomization.yaml` does **not**.
+
+## Single owner — disable the Harvester bundled add-on first
+
+KubeOVN's CRDs are cluster-scoped and the OVN central DB is a singleton. Two
+installs **fight** regardless of namespace. Harvester ships a bundled
+`kubeovn-operator` **Addon** (plus a Rancher Fleet `managedchart` for its CRDs)
+that renders its own kube-ovn into `kube-system`. Before this chart reconciles,
+that bundled install MUST be removed on the host cluster:
+
+```bash
+# Disable + delete the Harvester Addon (stops its helm-controller reconcile)
+kubectl -n kube-system patch addon kubeovn-operator --type=merge -p '{"spec":{"enabled":false}}'
+kubectl -n kube-system delete addon kubeovn-operator
+# Remove the Fleet-managed CRD chart
+kubectl -n fleet-local delete managedchart kubeovn-operator-crd
+# Uninstall whatever the operator/Fleet left behind, then this chart installs clean
+helm -n kube-system uninstall kubeovn-operator kubeovn-operator-crd 2>/dev/null || true
+```
+
+(If a prior **manual** `helm install kube-ovn` exists, uninstall it too — this
+Flux release replaces it as the single manager.)
+
+## What a consumer overlay MUST set
+
+The base omits two site-specific values; patch the `kube-ovn` HelmRelease in
+your overlay:
+
+| Value | What | Example |
+|---|---|---|
+| `spec.values.MASTER_NODES` | comma-separated control-plane node IP(s) for ovn-central | `"10.0.0.10"` |
+| `spec.values.ipv4.SVC_CIDR` | the cluster's REAL Kubernetes service CIDR | `"10.43.0.0/16"` |
+
+```yaml
+# infrastructure-overlay/kustomization.yaml
+resources:
+  - https://github.com/wso2/open-cloud-datacenter//flux/infrastructure/kube-ovn?ref=controlplane
+patches:
+  - patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: kube-ovn
+        namespace: kube-ovn
+      spec:
+        values:
+          MASTER_NODES: "10.0.0.10"
+          ipv4:
+            SVC_CIDR: "10.43.0.0/16"
+```
+
+## The external (SNAT/EIP) network is NOT here
+
+The `ProviderNetwork` + `Vlan` + `ovn-vpc-external-network` Subnet that VPC
+EIPs are SNAT'd through are created by **dc-api at runtime**
+(`EnsureExternalNetworkBootstrap`), driven by `DCAPI_VPC_EXTERNAL_*` config.
+This chart only installs the kube-ovn control/data plane. After a fresh
+install, restart dc-api so it re-creates the external network. Ensure
+`DCAPI_VPC_EXTERNAL_RESERVED_IPS` lists the host node IPs + any VIPs so
+kube-ovn's IPAM never hands them out.

--- a/flux/infrastructure/kube-ovn/kustomization.yaml
+++ b/flux/infrastructure/kube-ovn/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - source.yaml
+  - release.yaml

--- a/flux/infrastructure/kube-ovn/release.yaml
+++ b/flux/infrastructure/kube-ovn/release.yaml
@@ -1,0 +1,112 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# KubeOVN — self-managed upstream install, Multus SECONDARY CNI
+#
+# This is the SDN dc-api drives for tenant VPC networking (Vpc / Subnet /
+# VpcNatGateway / NAD CRDs created at runtime). It runs as a Multus SECONDARY
+# CNI: the cluster's primary CNI (Canal) keeps cluster pod/service networking;
+# kube-ovn is referenced explicitly via per-subnet NetworkAttachmentDefinitions
+# that dc-api creates. Tenant VMs attach to kube-ovn via those NADs.
+#
+# IMPORTANT — single owner. KubeOVN's CRDs are cluster-scoped and the OVN
+# central DB is a singleton. Two installs (e.g. Harvester's bundled
+# `kubeovn-operator` Addon + this chart) FIGHT regardless of namespace. The
+# host cluster MUST have the bundled add-on disabled before this reconciles —
+# see this directory's README.
+#
+# Workloads land in kube-system (chart-hardcoded, standard for a CNI); the
+# `kube-ovn` namespace below only holds the Helm release metadata.
+#
+# ── Values = the PROVEN upstream v1.15.4 install, reproduced ──────────────────
+# These values reproduce the *effective* config of the manual `helm install
+# kube-ovn` v1.15.4 that dc-api was developed and verified against on lk-dev in
+# May 2026 (before Harvester's experimental v1.14.10 operator was switched on
+# and shadowed it). They are intentionally NOT "improved" — the goal is zero
+# functional change when this replaces that install. Two consequences:
+#   * ipv4 CIDRs are left at chart defaults (ovn-default 10.16.0.0/16, svc
+#     10.96.0.0/12). The original install's POD_CIDR/SVC_CIDR were placed under
+#     `networking:`, which the v1.15.4 chart ignores (CIDRs live under `ipv4:`),
+#     so it ran on these defaults. Correcting them (e.g. svc → the real
+#     10.53.0.0/16) is a deliberate follow-up, NOT part of this parity move.
+#   * Site-specific values (MASTER_NODES, networking.IFACE) are set by the
+#     consumer overlay, not here.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-ovn
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-ovn
+  namespace: kube-ovn
+spec:
+  interval: 30m
+  releaseName: kube-ovn
+  chart:
+    spec:
+      chart: kube-ovn
+      version: "v1.15.4"
+      sourceRef:
+        kind: HelmRepository
+        name: kubeovn
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    # ovn-central: single replica on the control-plane node. RKE2 labels it
+    # `node-role.kubernetes.io/control-plane=true` (value "true", unlike
+    # kubeadm's empty value); the chart does an exact-match selection. The
+    # consumer overlay sets MASTER_NODES (the CP node IP(s) ovn-central expects).
+    replicaCount: 1
+    MASTER_NODES_LABEL: "node-role.kubernetes.io/control-plane=true"
+    MASTER_NODES: ""
+
+    image:
+      registry: docker.io
+      repository: kubeovn/kube-ovn
+      tag: v1.15.4
+      pullPolicy: IfNotPresent
+
+    # Multus secondary CNI — priority "90" keeps the primary CNI's conflist
+    # (Canal's 10-canal) the cluster default; the chart default "01" would make
+    # kube-ovn primary. RKE2 CNI conf/bin paths (NOT vanilla /etc/cni/net.d).
+    cni_conf:
+      CNI_CONF_DIR: "/var/lib/rancher/rke2/agent/etc/cni/net.d"
+      CNI_BIN_DIR: "/opt/cni/bin"
+      MOUNT_LOCAL_BIN_DIR: "true"
+      CNI_CONFIG_PRIORITY: "90"
+
+    func:
+      # Tenant (custom) VPCs — REQUIRED by dc-api (chart default false).
+      ENABLE_EXTERNAL_VPC: "true"
+      # Live-migration IP persistence — M2 hard requirement.
+      ENABLE_KEEP_VM_IP: "true"
+      # OFF: dc-api's per-VPC DNS is its own CoreDNS+ConfigMap (never kube-ovn
+      # VpcDns), and LB on would clash with Harvester's kube-vip. ENABLE_NP off
+      # because Canal owns k8s NetworkPolicy; dc-api NSGs are subnet OVN ACLs.
+      ENABLE_LB: "false"
+      ENABLE_LB_SVC: "false"
+      ENABLE_NP: "false"
+      ENABLE_BIND_LOCAL_IP: "true"
+      ENABLE_METRICS: "true"
+      # NOTE: the proven install also carried `func.ENABLE_EIP_SNAT: "false"`,
+      # but that key lives under `networking:` in the chart, so it was a no-op —
+      # the install ran with the default ENABLE_EIP_SNAT=true. Omitted here to
+      # avoid reproducing a misleading no-op; effective behaviour is unchanged.
+
+    networking:
+      NET_STACK: ipv4
+      NETWORK_TYPE: geneve
+      TUNNEL_TYPE: geneve
+      ENABLE_SSL: "false"
+      # Geneve tunnel interface. Consumer overlay sets it (lk-dev: mgmt-br).
+      IFACE: ""
+
+    # ipv4 block intentionally omitted → chart defaults (POD 10.16.0.0/16,
+    # SVC 10.96.0.0/12, JOIN 100.64.0.0/16), matching the proven install. The
+    # cleanup phase introduces the corrected ipv4.SVC_CIDR (10.53.0.0/16) etc.

--- a/flux/infrastructure/kube-ovn/source.yaml
+++ b/flux/infrastructure/kube-ovn/source.yaml
@@ -1,0 +1,16 @@
+# Upstream KubeOVN Helm chart source.
+#
+# Self-contained in this base (NOT in flux/infrastructure/sources/) because
+# kube-ovn is HOST-cluster infrastructure: a host-cluster Flux overlay pulls
+# this directory directly and would not otherwise get the HelmRepository. The
+# control-plane cluster never installs kube-ovn, so its infrastructure
+# kustomization does not reference this base.
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kubeovn
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubeovn.github.io/kube-ovn


### PR DESCRIPTION
## What

Adds `flux/infrastructure/kube-ovn/` — a Flux base that installs upstream **kube-ovn v1.15.4** as a Multus secondary CNI on a Harvester host cluster. This is the SDN dc-api drives for tenant VPC networking (`Vpc`/`Subnet`/`VpcNatGateway`/NAD CRDs created at runtime). It is standalone — deliberately NOT added to the control-plane `flux/infrastructure/kustomization.yaml` — because a host-cluster Flux overlay references it directly; the control-plane workload cluster never installs kube-ovn.

## Why

dc-api was developed and verified against a manual upstream kube-ovn **v1.15.4** install on the Harvester host cluster (code is annotated "verified against KubeOVN v1.15 on lk-dev, 2026-05"). Harvester's bundled **experimental** `kubeovn-operator` Addon (v1.14.10) was switched on during early Harvester try-outs and has been shadowing that install — dc-api was never meant to ride that version. This base lets the host cluster run the intended upstream v1.15.4 under Flux as the single owner of the kube-ovn CRDs. KubeOVN's CRDs are cluster-scoped and the OVN central DB is a singleton, so the bundled Addon must be disabled first (the README documents the teardown).

## Identical-by-construction

The values reproduce the *effective* config of that proven v1.15.4 install — the goal is zero functional change for dc-api when it replaces the experimental Addon. `helm template` of these values renders `kube-ovn-controller` args byte-identical to the proven install: `--enable-external-vpc=true --keep-vm-ip=true --enable-lb=false --enable-np=false --enable-eip-snat=true --network-type=geneve --service-cluster-ip-range=10.96.0.0/12 --default-cidr=10.16.0.0/16`, plus `kube-ovn-cni --iface=mgmt-br`. `ENABLE_LB`/`ENABLE_NP` are off because dc-api uses its own per-VPC CoreDNS (never kube-ovn `VpcDns`) and LB-off avoids a clash with Harvester's kube-vip; CNI priority `90` keeps the primary CNI (Canal) the cluster default.

## Notes

The `ipv4` CIDRs are left at chart defaults (`ovn-default 10.16.0.0/16`, svc `10.96.0.0/12`) to match the proven install exactly — its `POD_CIDR`/`SVC_CIDR` overrides sat under `networking:`, which the v1.15.4 chart ignores. Correcting those (e.g. svc → the real `10.53.0.0/16`) is a deliberate follow-up, not part of this parity base. Site-specific values (`MASTER_NODES`, `networking.IFACE`) are patched by the consumer overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
