### PR TITLE
Adding a secondary route metric to storage network

### DIFF
--- a/modules/tenancy/k8s-cluster/templates/node-cloud-init.tpl
+++ b/modules/tenancy/k8s-cluster/templates/node-cloud-init.tpl
@@ -47,6 +47,7 @@ write_files:
             dhcp4: true
             dhcp4-overrides:
               use-routes: false
+              route-metric: 500
 %{~ endif }
 runcmd:
   - - systemctl


### PR DESCRIPTION
## Summary

```yaml
  route-metric: 500
```

Is set for the enp2s0 storage network interface so internet and dns routes wont use default routes received from storage vlan dhcp

This setting will be added via netplan