### PR TITLE
Fix sealed-secrets Helm chart repository URL

### DIFF
--- a/flux/infrastructure/sources/helm-repositories.yaml
+++ b/flux/infrastructure/sources/helm-repositories.yaml
@@ -8,7 +8,10 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://bitnami-labs.github.io/sealed-secrets
+  # Chart repo moved from bitnami-labs.github.io (retired, now 404) to
+  # bitnami.github.io/sealed-secrets. The old URL fails the index fetch and
+  # blocks the infrastructure Kustomization's health check.
+  url: https://bitnami.github.io/sealed-secrets
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository


### PR DESCRIPTION
The sealed-secrets Helm chart repository moved from `https://bitnami-labs.github.io/sealed-secrets` (retired GitHub Pages site, now 404 on `index.yaml`) to `https://bitnami.github.io/sealed-secrets`. source-controller can no longer refresh the HelmRepository, leaving it `Ready=False`, which times out the `infrastructure` Kustomization's `wait` health check and blocks every Kustomization that depends on it (e.g. `platform`).

The running sealed-secrets release is unaffected — it serves from a cached chart; only the hourly index refresh was failing. Verified the new URL returns the index (HTTP 200) and the live HelmRepository goes Ready against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)