### PR TITLE
[Fix] Identify dcctl traffic and guard edge challenges

### DIFF
--- a/dcctl/internal/client/client.go
+++ b/dcctl/internal/client/client.go
@@ -17,6 +17,15 @@ import (
 	dcapi "github.com/wso2/dcctl/internal/client/generated"
 )
 
+// Version is the dcctl build version, surfaced in the User-Agent header on
+// every outbound DC-API request so the platform can identify CLI traffic.
+// dcctl has no release-versioning pipeline yet, so this is a single
+// package-level constant; wire it to a real build var here if one is added.
+const Version = "dev"
+
+// userAgent is the value sent in the User-Agent header on every API request.
+const userAgent = "dcctl/" + Version
+
 // Client carries the typed DC-API client plus the small bit of
 // dcctl-specific state needed to build it (base URL, access token,
 // TLS preference). The typed client is exposed directly as Typed.
@@ -42,8 +51,12 @@ func New(accessToken string) *Client {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // dev/self-signed support
 	}
 	httpClient := &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: transport,
+		Timeout: 30 * time.Second,
+		// guardTransport wraps the real transport so an edge bot-protection
+		// challenge (HTML, not JSON) is turned into an actionable error before
+		// the generated client tries to decode it. This covers both the typed
+		// client and the hand-written doJSON calls, which share this httpClient.
+		Transport: &guardTransport{next: transport},
 	}
 
 	typed, err := dcapi.NewClientWithResponses(
@@ -52,6 +65,7 @@ func New(accessToken string) *Client {
 		dcapi.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 			req.Header.Set("Accept", "application/json")
+			req.Header.Set("User-Agent", userAgent)
 			return nil
 		}),
 	)

--- a/dcctl/internal/client/cluster.go
+++ b/dcctl/internal/client/cluster.go
@@ -154,6 +154,7 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body interface{
 	// Simplest pragmatic fix: pass the token as a header directly using the
 	// token stored on the struct (requires adding the field — see below).
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent)
 	// Auth header is injected via c.token (set in New — see updated New func).
 	req.Header.Set("Authorization", "Bearer "+c.token)
 

--- a/dcctl/internal/client/guard.go
+++ b/dcctl/internal/client/guard.go
@@ -1,0 +1,121 @@
+// Package client — edge bot-protection guard.
+//
+// When dcctl points at the deployed API behind an edge proxy (Cloudflare) and
+// the source network isn't allowed through bot protection, the proxy returns an
+// HTML interstitial ("Just a moment...", referencing challenges.cloudflare.com)
+// instead of the JSON the API would have sent. The generated client only
+// decodes bodies whose Content-Type contains "json", so a challenge page leaves
+// every typed field nil and surfaces as an opaque "HTTP 403"/raw-HTML dump.
+//
+// checkAPIResponse turns that situation into one clear, actionable error, and
+// guardTransport wires it in front of every request the shared http.Client
+// makes — covering both the typed client and the hand-written doJSON helpers.
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// challengeMarkers are substrings that only appear in an edge bot-protection
+// interstitial, never in a legitimate DC-API JSON response.
+var challengeMarkers = []string{
+	"challenges.cloudflare.com",
+	"just a moment",
+	"cf-ray",
+	"cf-chl",
+	"__cf_chl",
+	"_cf_chl_opt",
+}
+
+// checkAPIResponse reports an actionable error when resp/body is clearly NOT
+// the JSON API response dcctl expects — i.e. it looks like an edge
+// bot-protection challenge or some other HTML interstitial. It returns nil for
+// any plausible JSON response (success OR a real API JSON error), so normal
+// error handling downstream is unchanged.
+//
+// Triggers when, for a non-2xx-or-not, the response is non-JSON: the
+// Content-Type is not JSON (e.g. text/html), OR the body does not look like
+// JSON, OR the body carries a Cloudflare challenge marker.
+func checkAPIResponse(resp *http.Response, body []byte) error {
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	jsonContentType := strings.Contains(contentType, "json")
+
+	// A JSON content type with a JSON-shaped body is the normal path — leave it
+	// alone so real API success/error responses flow through as today. A clear
+	// Cloudflare challenge marker overrides even a (spoofed) JSON content type.
+	if jsonContentType && looksLikeJSON(body) && !isChallengeBody(contentType, body) {
+		return nil
+	}
+
+	// Otherwise: a non-JSON content type, a body that plainly isn't JSON, or a
+	// Cloudflare challenge marker — all the same root cause (something other than
+	// dc-api answered) with the same actionable guidance.
+	return fmt.Errorf(
+		"dc-api returned a non-JSON response (HTTP %d) — this looks like an "+
+			"edge bot-protection challenge (Cloudflare). dcctl cannot solve a "+
+			"browser challenge. Check that your `dcapi_url` is correct and that "+
+			"your source network is allowed through the API's edge protection",
+		resp.StatusCode,
+	)
+}
+
+// looksLikeJSON reports whether body begins with a JSON object or array (after
+// leading whitespace). An empty body is treated as JSON-compatible — some
+// endpoints answer 202/204 with no payload, which is not a challenge.
+func looksLikeJSON(body []byte) bool {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return true
+	}
+	switch trimmed[0] {
+	case '{', '[':
+		return true
+	default:
+		return false
+	}
+}
+
+// isChallengeBody reports whether the response is an HTML bot-protection
+// interstitial, by content type and/or a Cloudflare challenge marker.
+func isChallengeBody(contentType string, body []byte) bool {
+	lower := strings.ToLower(string(body))
+	for _, m := range challengeMarkers {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	return strings.Contains(contentType, "text/html")
+}
+
+// guardTransport wraps an http.RoundTripper and fails fast with the
+// checkAPIResponse message when the response is an edge challenge / non-JSON
+// page, rather than letting the generated client decode it into nil fields.
+type guardTransport struct {
+	next http.RoundTripper
+}
+
+func (g *guardTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := g.next.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		// Restore an empty body and let the caller surface the read error.
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return resp, nil
+	}
+	// Refill the body so downstream parsers (typed client, doJSON) can read it.
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	if guardErr := checkAPIResponse(resp, body); guardErr != nil {
+		return nil, guardErr
+	}
+	return resp, nil
+}

--- a/dcctl/internal/client/guard_test.go
+++ b/dcctl/internal/client/guard_test.go
@@ -1,0 +1,97 @@
+package client
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// cloudflareChallengeHTML is a trimmed but representative Cloudflare bot-protection
+// interstitial — the kind of page returned instead of the JSON API response when
+// the source network isn't allowed through edge protection.
+const cloudflareChallengeHTML = `<!DOCTYPE html>
+<html lang="en-US">
+<head><title>Just a moment...</title></head>
+<body>
+<div id="challenge-running"></div>
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
+</body>
+</html>`
+
+func newResp(status int, contentType string) *http.Response {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	return &http.Response{StatusCode: status, Header: h}
+}
+
+func TestCheckAPIResponse_CloudflareChallenge(t *testing.T) {
+	resp := newResp(http.StatusForbidden, "text/html; charset=UTF-8")
+
+	err := checkAPIResponse(resp, []byte(cloudflareChallengeHTML))
+	if err == nil {
+		t.Fatal("expected an error for a Cloudflare challenge page, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"non-JSON response", "HTTP 403", "edge bot-protection", "Cloudflare", "dcapi_url"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\ngot: %s", want, msg)
+		}
+	}
+}
+
+func TestCheckAPIResponse_ValidJSON(t *testing.T) {
+	resp := newResp(http.StatusOK, "application/json")
+
+	if err := checkAPIResponse(resp, []byte(`{"id":"abc","name":"web-01"}`)); err != nil {
+		t.Fatalf("expected no error for a valid JSON body, got: %v", err)
+	}
+}
+
+func TestCheckAPIResponse_ValidJSONArray(t *testing.T) {
+	resp := newResp(http.StatusOK, "application/json")
+
+	if err := checkAPIResponse(resp, []byte(`[{"id":"abc"}]`)); err != nil {
+		t.Fatalf("expected no error for a valid JSON array body, got: %v", err)
+	}
+}
+
+func TestCheckAPIResponse_RealJSONAPIError(t *testing.T) {
+	// A genuine API error with a JSON body and JSON content type must flow
+	// through unchanged — the guard only catches non-JSON / challenge pages.
+	resp := newResp(http.StatusForbidden, "application/json")
+
+	if err := checkAPIResponse(resp, []byte(`{"error":"forbidden"}`)); err != nil {
+		t.Fatalf("expected no error for a JSON API error response, got: %v", err)
+	}
+}
+
+func TestCheckAPIResponse_EmptyBody(t *testing.T) {
+	// 202/204-style empty bodies are not challenges.
+	resp := newResp(http.StatusAccepted, "application/json")
+
+	if err := checkAPIResponse(resp, nil); err != nil {
+		t.Fatalf("expected no error for an empty body, got: %v", err)
+	}
+}
+
+func TestCheckAPIResponse_HTMLWithoutMarker(t *testing.T) {
+	// Any HTML interstitial (even without a Cloudflare marker) is not the JSON
+	// the CLI expects and should still produce the actionable error.
+	resp := newResp(http.StatusBadGateway, "text/html")
+
+	if err := checkAPIResponse(resp, []byte("<html><body>502 Bad Gateway</body></html>")); err == nil {
+		t.Fatal("expected an error for an HTML body, got nil")
+	}
+}
+
+func TestCheckAPIResponse_JSONContentTypeButHTMLBody(t *testing.T) {
+	// Defensive: a spoofed JSON content type carrying a challenge marker in the
+	// body must still be caught.
+	resp := newResp(http.StatusOK, "application/json")
+
+	if err := checkAPIResponse(resp, []byte(cloudflareChallengeHTML)); err == nil {
+		t.Fatal("expected an error when a challenge marker is present despite a JSON content type, got nil")
+	}
+}


### PR DESCRIPTION
## What

dcctl now sets a stable `User-Agent` header (`dcctl/<version>`) on every dc-api request instead of going out as a generic Go HTTP client, so CLI traffic is identifiable in upstream/edge logs and can be matched explicitly by edge policies.

It also adds a guard that detects when the API returns a non-JSON response — specifically an HTML bot-protection challenge page (e.g. a CDN "Just a moment…" interstitial) — and surfaces a single, actionable error instead of dumping raw HTML or failing with an opaque JSON-unmarshal error. Normal JSON success and error responses are unchanged.

## Why

When dc-api sits behind an edge WAF/CDN with bot protection enabled, a command-line client cannot solve a browser challenge, so requests from a network that has not been allowlisted yet came back as a confusing wall of HTML. This change does not (and should not) bypass that protection — it makes our traffic identifiable so it can be allowlisted at the edge, and makes the failure mode legible when it is not.

## Testing

Client-side only — no API, endpoint, or schema changes. `go build ./...` and `go test ./...` pass; new unit tests cover the guard (challenge HTML to actionable error, valid JSON to passthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
