### PR TITLE
Add a new cluster-reader role to custom role templates

### DIFF
--- a/modules/tenancy/cluster-roles/main.tf
+++ b/modules/tenancy/cluster-roles/main.tf
@@ -499,6 +499,111 @@ resource "rancher2_role_template" "project_member_restricted" {
 # Grants read-only visibility into VM status and metrics for the Harvester
 # dashboard. Intentionally excludes all mutating verbs (update, patch, delete)
 # and subresources that control VM power state (start, stop, restart, migrate).
+# Read-only cluster membership for downstream RKE2/K8s clusters.
+# Mirrors the built-in cluster-member role template exactly, minus the
+# `management.cattle.io/projects: create` rule — preventing users from
+# spinning up new projects while retaining full cluster observability.
+#
+# Intended for users or groups that need visibility into a downstream cluster
+# (nodes, events, metrics, machine objects) without any write access.
+# Assign via rancher2_cluster_role_template_binding at the cluster scope.
+resource "rancher2_role_template" "cluster_reader" {
+  name        = "cluster-reader"
+  description = "Read-only view of a downstream cluster. Mirrors the built-in cluster-member role without the ability to create projects."
+  context     = "cluster"
+
+  rules {
+    api_groups = ["ui.cattle.io"]
+    resources  = ["navlinks"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["management.cattle.io"]
+    resources  = ["clusterroletemplatebindings"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["management.cattle.io"]
+    resources  = ["nodes", "nodepools"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = [""]
+    resources  = ["nodes"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = [""]
+    resources  = ["persistentvolumes"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["storageclasses"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["apiregistration.k8s.io"]
+    resources  = ["apiservices"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["management.cattle.io"]
+    resources  = ["clusterevents"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["catalog.cattle.io"]
+    resources  = ["clusterrepos"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups     = ["management.cattle.io"]
+    resources      = ["clusters"]
+    resource_names = ["local"]
+    verbs          = ["get"]
+  }
+
+  rules {
+    api_groups = ["cluster.x-k8s.io"]
+    resources  = ["machines"]
+    verbs      = ["get", "watch"]
+  }
+
+  rules {
+    api_groups = ["cluster.x-k8s.io"]
+    resources  = ["machinedeployments"]
+    verbs      = ["get", "watch"]
+  }
+
+  rules {
+    api_groups = ["rke-machine-config.cattle.io"]
+    resources  = ["*"]
+    verbs      = ["get", "watch"]
+  }
+
+  rules {
+    api_groups = ["rke-machine.cattle.io"]
+    resources  = ["*"]
+    verbs      = ["get", "watch"]
+  }
+
+  rules {
+    api_groups = ["metrics.k8s.io"]
+    resources  = ["nodemetrics", "nodes"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
 resource "rancher2_role_template" "vm_metrics_observer" {
   name        = "vm-metrics-observer"
   description = "Read-only access to VM status and metrics. Allows Harvester dashboard graphs without any control-plane permissions."

--- a/modules/tenancy/cluster-roles/outputs.tf
+++ b/modules/tenancy/cluster-roles/outputs.tf
@@ -38,6 +38,11 @@ output "cluster_operator_role_id" {
   description = "Role template ID for the cluster-operator cluster role. Pass to rancher2_cluster_role_template_binding for SREs who scale RKE2 node pools."
 }
 
+output "cluster_reader_role_id" {
+  value       = rancher2_role_template.cluster_reader.id
+  description = "Role template ID for the cluster-reader cluster role. Grants read-only visibility into a downstream cluster (nodes, events, metrics, machines) without any write access. Use in rancher2_cluster_role_template_binding for groups that observe but must not modify clusters."
+}
+
 output "cluster_contributor_role_id" {
   value       = rancher2_role_template.cluster_contributor.id
   description = "Role template ID for the cluster-contributor cluster role. Grants full workload/config management via kubectl (exec, logs, deploy, scale) without Rancher management-plane permissions. Use for SRE groups that operate downstream clusters but must not delete or reconfigure them."


### PR DESCRIPTION
## Summary

Adds a new cluster-reader custom role only allowing read only actions on the downstream guest clusters
