### PR TITLE
Add dc-agent Flux base and set its User-Agent

### DIFF
--- a/dc-agent/internal/conn/conn.go
+++ b/dc-agent/internal/conn/conn.go
@@ -208,6 +208,10 @@ func (r *Runner) dial(ctx context.Context) (*websocket.Conn, error) {
 
 	header := http.Header{}
 	header.Set("Authorization", "Bearer "+r.cfg.Token)
+	// A stable, identifiable User-Agent (dc-agent/<version>) so the connect
+	// traffic is recognizable in edge/CDN logs and rules rather than appearing
+	// as a generic Go WebSocket client — mirrors dcctl's User-Agent.
+	header.Set("User-Agent", "dc-agent/"+r.cfg.Version)
 
 	c, resp, err := websocket.Dial(dialCtx, r.cfg.Endpoint, &websocket.DialOptions{
 		HTTPHeader: header,

--- a/flux/platform/dc-agent/base/configmap.yaml
+++ b/flux/platform/dc-agent/base/configmap.yaml
@@ -1,0 +1,17 @@
+# Non-secret dc-agent config. Per-env values (endpoint host, region, zone) are
+# patched by the consumer overlay; the token is NOT here — it is the
+# dc-agent-token Secret referenced via secretKeyRef in the Deployment. The
+# placeholders below intentionally fail loadConfig (a non-wss endpoint / region
+# "placeholder") until an overlay patches them, so a half-configured agent never
+# silently dials the wrong control plane.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dc-agent-config
+  namespace: dc-agent-system
+data:
+  DCAGENT_ENDPOINT: "wss://connect.placeholder.example.com/v1/agent/ws"
+  DCAGENT_REGION: "placeholder"
+  DCAGENT_ZONE: "placeholder"
+  DCAGENT_LOG_LEVEL: "info"
+  # DCAGENT_KUBECONFIG intentionally unset → in-cluster ServiceAccount.

--- a/flux/platform/dc-agent/base/deployment.yaml
+++ b/flux/platform/dc-agent/base/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dc-agent
+  namespace: dc-agent-system
+  labels:
+    app: dc-agent
+spec:
+  replicas: 1   # one agent per (region,zone); the agents table is unique on it.
+  selector:
+    matchLabels:
+      app: dc-agent
+  template:
+    metadata:
+      labels:
+        app: dc-agent
+    spec:
+      serviceAccountName: dc-agent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agent
+          # Public image; tag pinned + auto-bumped by the consumer overlay.
+          image: ghcr.io/wso2/dc-agent:latest # {"$imagepolicy": "flux-system:dc-agent"}
+          imagePullPolicy: IfNotPresent
+          # No ports and no probes: dc-agent runs no server — it only dials OUT
+          # to DCAGENT_ENDPOINT over WSS. Liveness is observed control-plane-side
+          # via the agents table (last_seen, bumped on the 30s ping).
+          envFrom:
+            - configMapRef:
+                name: dc-agent-config
+          env:
+            - name: DCAGENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dc-agent-token
+                  key: DCAGENT_TOKEN
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]

--- a/flux/platform/dc-agent/base/image-automation.yaml
+++ b/flux/platform/dc-agent/base/image-automation.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: dc-agent
+  namespace: flux-system
+spec:
+  image: ghcr.io/wso2/dc-agent
+  interval: 5m
+  # Public image — no secretRef. (The host overlay would strip one anyway.)
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: dc-agent
+  namespace: flux-system
+spec:
+  imageRepositoryRef: { name: dc-agent }
+  # Same timestamp-prefixed tag scheme as dc-api / dc-webhook / keyvault-operator:
+  # <YYYYMMDD>-<HHMMSS>-<git-sha>, sorted numerically to pick the newest build.
+  filterTags:
+    pattern: '^(?P<ts>\d{8})-(?P<tm>\d{6})-[a-f0-9]+$'
+    extract: '$ts$tm'
+  policy:
+    numerical:
+      order: asc

--- a/flux/platform/dc-agent/base/kustomization.yaml
+++ b/flux/platform/dc-agent/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - image-automation.yaml

--- a/flux/platform/dc-agent/base/namespace.yaml
+++ b/flux/platform/dc-agent/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dc-agent-system

--- a/flux/platform/dc-agent/base/rbac.yaml
+++ b/flux/platform/dc-agent/base/rbac.yaml
@@ -1,0 +1,38 @@
+# The agent runs in-cluster and reads THIS datacenter's inventory (at the
+# control plane's request) via this ServiceAccount — no kubeconfig travels
+# (DCAGENT_KUBECONFIG is empty, so the executor uses in-cluster config). The
+# executor (dc-agent/internal/executor/kube.go GetInventory) reads exactly three
+# things, all read-only and cluster-wide: Nodes, Pods (all namespaces, to sum
+# allocated CPU/memory), and KubeVirt VirtualMachines (all namespaces, counted).
+# Tenant VMs live in dc-<id> namespaces not predictable at deploy time, so the
+# grant is cluster-scoped (ClusterRole), exactly as dc-webhook does for NADs.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dc-agent
+  namespace: dc-agent-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dc-agent
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dc-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dc-agent
+subjects:
+  - kind: ServiceAccount
+    name: dc-agent
+    namespace: dc-agent-system


### PR DESCRIPTION
Adds the Flux Kustomize base for **dc-agent** (the per-zone regional agent) so it can be deployed to a host cluster via Flux. The binary, CI image (`ghcr.io/wso2/dc-agent`), protocol (M-A), and dc-api server side already exist, but there was no `flux/platform/dc-agent/base/` to reference.

New base: `namespace.yaml`, `rbac.yaml`, `configmap.yaml`, `deployment.yaml`, `image-automation.yaml`, `kustomization.yaml` — mirroring `flux/platform/dc-webhook/base/` (same `app:` labels, `{"$imagepolicy": ...}` marker, distroless/65532 securityContext, timestamp-tag ImagePolicy). It omits TLS/Service/webhook/probes because dc-agent runs no server (it only dials out), and adds a `dc-agent-config` ConfigMap (per-env endpoint/region/zone patched by the consumer overlay) + a `DCAGENT_TOKEN` secretKeyRef. The ClusterRole is scoped to exactly what `executor.GetInventory` reads: `nodes`, `pods` (all namespaces), and `kubevirt.io/virtualmachines`.

Also sets a stable `User-Agent: dc-agent/<version>` on the agent's WebSocket dial (it previously sent only `Authorization`), mirroring the recent dcctl User-Agent change — so connect traffic is identifiable in edge/CDN logs/rules instead of looking like a generic Go WebSocket client.

Verified: `go build ./...` + `go vet` clean; `kubectl kustomize flux/platform/dc-agent/base` renders all objects with correct namespaces. The consumer flux-harvester overlay slots this in separately (image pin + endpoint/region/zone patch + sealed token Secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)