### PR TITLE
Enrich dc-agent channel connect/disconnect logging

### DIFF
--- a/dc-agent/internal/conn/conn.go
+++ b/dc-agent/internal/conn/conn.go
@@ -118,6 +118,13 @@ func NewRunner(cfg Config) *Runner {
 	if cfg.IdleLimit <= 0 {
 		cfg.IdleLimit = defaultIdleLimit
 	}
+	// Bind region/zone once so EVERY connection-loop line is attributable —
+	// not just the "connected to control plane" line. The reconnect Warn and
+	// shutdown lines inherit these fields from here.
+	cfg.Logger = cfg.Logger.With().
+		Str("region", cfg.Region).
+		Str("zone", cfg.Zone).
+		Logger()
 	return &Runner{cfg: cfg}
 }
 
@@ -190,13 +197,13 @@ func (r *Runner) runSession(ctx context.Context) (established bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	r.cfg.Logger.Info().
-		Str("agent_id", ack.AgentID).
-		Str("region", r.cfg.Region).
-		Str("zone", r.cfg.Zone).
-		Msg("connected to control plane")
+	// Per-session logger: region/zone are already bound on r.cfg.Logger; add
+	// agent_id so every line for this session (connected, ping/pong, op
+	// dispatch) carries it. Scoped to the session — a reconnect gets a new id.
+	sessionLog := r.cfg.Logger.With().Str("agent_id", ack.AgentID).Logger()
+	sessionLog.Info().Msg("connected to control plane")
 
-	return true, r.pingLoop(ctx, c)
+	return true, r.pingLoop(ctx, c, sessionLog)
 }
 
 // dial opens the WebSocket with the bearer token. The token is the only
@@ -257,7 +264,7 @@ func (r *Runner) handshake(ctx context.Context, c *websocket.Conn) (*protocol.He
 // (forward compatibility — a newer control plane may speak verbs this agent
 // doesn't know yet). Returns when the connection breaks, the server goes
 // silent past serverIdleLimit, or ctx is cancelled.
-func (r *Runner) pingLoop(ctx context.Context, c *websocket.Conn) error {
+func (r *Runner) pingLoop(ctx context.Context, c *websocket.Conn, log zerolog.Logger) error {
 	// sessionCtx bounds the op-dispatch goroutines to this connection: when the
 	// session ends they are cancelled, so a slow op can't write to the next
 	// session's socket.
@@ -298,7 +305,7 @@ func (r *Runner) pingLoop(ctx context.Context, c *websocket.Conn) error {
 				return fmt.Errorf("read: %w", res.err)
 			}
 			lastRead = time.Now()
-			r.handleFrame(sessionCtx, c, res.data)
+			r.handleFrame(sessionCtx, c, res.data, log)
 
 		case <-ticker.C:
 			if idle := time.Since(lastRead); idle > r.cfg.IdleLimit {
@@ -307,57 +314,61 @@ func (r *Runner) pingLoop(ctx context.Context, c *websocket.Conn) error {
 			if err := r.writeFrame(ctx, c, protocol.NewPing(time.Now())); err != nil {
 				return fmt.Errorf("send ping: %w", err)
 			}
-			r.cfg.Logger.Debug().Msg("ping sent")
+			log.Debug().Msg("ping sent")
 		}
 	}
 }
 
 // handleFrame processes one inbound steady-state frame: pongs refresh liveness,
 // req frames are dispatched (each in its own goroutine), and unknown/unexpected
-// types are logged and ignored (forward compatibility).
-func (r *Runner) handleFrame(ctx context.Context, c *websocket.Conn, data []byte) {
+// types are logged and ignored (forward compatibility). log is the per-session
+// logger (carries agent_id) — every line here fires inside an established
+// session.
+func (r *Runner) handleFrame(ctx context.Context, c *websocket.Conn, data []byte, log zerolog.Logger) {
 	frame, err := protocol.Decode(data)
 	if err != nil {
-		r.cfg.Logger.Warn().Err(err).Msg("dropping undecodable frame")
+		log.Warn().Err(err).Msg("dropping undecodable frame")
 		return
 	}
 	switch f := frame.(type) {
 	case *protocol.Pong:
-		r.cfg.Logger.Debug().Str("ts", f.TS).Msg("pong received")
+		log.Debug().Str("ts", f.TS).Msg("pong received")
 	case *protocol.Req:
 		// Run in its own goroutine so a slow op never stalls the ping loop or
 		// the reader; bounded by the session ctx.
-		go r.dispatch(ctx, c, f)
+		go r.dispatch(ctx, c, f, log)
 	case *protocol.Unknown:
-		r.cfg.Logger.Warn().Str("frame_type", f.Type).Msg("ignoring unknown frame type (newer protocol?)")
+		log.Warn().Str("frame_type", f.Type).Msg("ignoring unknown frame type (newer protocol?)")
 	default:
-		r.cfg.Logger.Warn().Str("frame_type", fmt.Sprintf("%T", f)).Msg("ignoring unexpected frame")
+		log.Warn().Str("frame_type", fmt.Sprintf("%T", f)).Msg("ignoring unexpected frame")
 	}
 }
 
 // dispatch runs one request's handler and writes its response. An op with no
-// handler returns OP_UNSUPPORTED; a handler error returns EXEC_ERROR.
-func (r *Runner) dispatch(ctx context.Context, c *websocket.Conn, req *protocol.Req) {
+// handler returns OP_UNSUPPORTED; a handler error returns EXEC_ERROR. log is the
+// per-session logger (carries agent_id).
+func (r *Runner) dispatch(ctx context.Context, c *websocket.Conn, req *protocol.Req, log zerolog.Logger) {
 	handler, ok := r.cfg.Dispatcher[req.Op]
 	if !ok {
-		r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeOpUnsupported, "unsupported op: "+req.Op))
+		r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeOpUnsupported, "unsupported op: "+req.Op), log)
 		return
 	}
 	result, err := handler(ctx, req.Params)
 	if err != nil {
-		r.cfg.Logger.Warn().Err(err).Str("op", req.Op).Msg("op handler failed")
-		r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeExecError, err.Error()))
+		log.Warn().Err(err).Str("op", req.Op).Msg("op handler failed")
+		r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeExecError, err.Error()), log)
 		return
 	}
-	r.cfg.Logger.Debug().Str("op", req.Op).Str("id", req.ID).Msg("op handled")
-	r.writeRes(ctx, c, protocol.NewRes(req.ID, result))
+	log.Debug().Str("op", req.Op).Str("id", req.ID).Msg("op handled")
+	r.writeRes(ctx, c, protocol.NewRes(req.ID, result), log)
 }
 
 // writeRes writes a response frame, logging (not returning) any error — the
-// caller is a fire-and-forget dispatch goroutine.
-func (r *Runner) writeRes(ctx context.Context, c *websocket.Conn, res *protocol.Res) {
+// caller is a fire-and-forget dispatch goroutine. log is the per-session logger
+// (carries agent_id).
+func (r *Runner) writeRes(ctx context.Context, c *websocket.Conn, res *protocol.Res, log zerolog.Logger) {
 	if err := r.writeFrame(ctx, c, res); err != nil {
-		r.cfg.Logger.Warn().Err(err).Str("id", res.ID).Msg("send response failed")
+		log.Warn().Err(err).Str("id", res.ID).Msg("send response failed")
 	}
 }
 

--- a/dc-api/internal/api/handlers/agentchannel.go
+++ b/dc-api/internal/api/handlers/agentchannel.go
@@ -166,14 +166,18 @@ func (s *Session) Call(ctx context.Context, op string, params json.RawMessage) (
 // answered with pongs, res frames are routed to the waiting Call, progress is
 // advisory (ignored in M-A), and unknown types are tolerated. onActivity (may be
 // nil) fires on every inbound frame so the caller can refresh liveness.
-func (s *Session) Serve(ctx context.Context, onActivity func()) {
+//
+// It returns a short, human-readable reason for the disconnect (clean close,
+// idle timeout, server shutdown, or transport error) so the caller can attribute
+// the teardown in its disconnect log.
+func (s *Session) Serve(ctx context.Context, onActivity func()) string {
 	defer s.close()
 	for {
 		readCtx, cancel := context.WithTimeout(ctx, serverReadDeadline)
 		_, data, err := s.conn.Read(readCtx)
 		cancel()
 		if err != nil {
-			return // normal close, deadline, or transport error
+			return disconnectReason(ctx, err)
 		}
 		if onActivity != nil {
 			onActivity()
@@ -191,7 +195,7 @@ func (s *Session) Serve(ctx context.Context, onActivity func()) {
 			pong := wsPong{Type: wsTypePong, TS: time.Now().UTC().Format(time.RFC3339)}
 			if err := s.writeFrame(ctx, pong); err != nil {
 				s.log.Warn().Err(err).Msg("send pong failed")
-				return
+				return "transport error"
 			}
 		case wsTypeRes:
 			var res wsRes
@@ -206,6 +210,30 @@ func (s *Session) Serve(ctx context.Context, onActivity func()) {
 		default:
 			// Forward compatibility: tolerate unknown / future frame types.
 			s.log.Debug().Str("frame_type", env.Type).Msg("ignoring unhandled agent frame")
+		}
+	}
+}
+
+// disconnectReason classifies why the read loop ended, for the disconnect log.
+// It distinguishes a server-initiated shutdown (outer ctx cancelled), the agent
+// closing cleanly (a WebSocket close frame), the agent going silent past
+// serverReadDeadline (the per-read deadline fired while the outer ctx is live),
+// and any other transport-level failure.
+func disconnectReason(ctx context.Context, err error) string {
+	switch {
+	case ctx.Err() != nil:
+		// The session context was cancelled — dc-api is shutting the channel down.
+		return "server shutdown"
+	case errors.Is(err, context.DeadlineExceeded):
+		// Only the per-read deadline could have fired (outer ctx is live): the
+		// agent stopped sending frames/pings.
+		return "idle timeout"
+	default:
+		switch websocket.CloseStatus(err) {
+		case websocket.StatusNormalClosure, websocket.StatusGoingAway, websocket.StatusNoStatusRcvd:
+			return "clean close"
+		default:
+			return "transport error"
 		}
 	}
 }
@@ -275,6 +303,11 @@ func (r *Registry) register(s *Session) {
 	r.sessions[key] = s
 	r.mu.Unlock()
 	if old != nil && old != s {
+		// A new connection superseded a still-registered session for this zone
+		// (a redeployed agent, or a stale socket the old reader hasn't noticed
+		// yet). Surface it: a flapping agent shows up as repeated replacements.
+		s.log.Warn().Str("region", s.region).Str("zone", s.zone).
+			Msg("replaced existing agent session for zone")
 		old.close()
 	}
 }

--- a/dc-api/internal/api/handlers/agentchannel_test.go
+++ b/dc-api/internal/api/handlers/agentchannel_test.go
@@ -242,6 +242,39 @@ func TestSessionCall_SessionClosed(t *testing.T) {
 	tc.srv.Close()
 }
 
+// TestDisconnectReason verifies the read-loop teardown is categorized correctly
+// so the "agent disconnected" log attributes the cause: a cancelled session ctx
+// is a server shutdown (regardless of the read error), a per-read deadline with a
+// live ctx is an idle timeout, a WebSocket close frame is a clean close, and
+// anything else is a transport error.
+func TestDisconnectReason(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want string
+	}{
+		{"server shutdown beats read error", cancelled, errors.New("read: connection reset"), "server shutdown"},
+		{"server shutdown beats deadline", cancelled, context.DeadlineExceeded, "server shutdown"},
+		{"idle timeout", context.Background(), context.DeadlineExceeded, "idle timeout"},
+		{"clean normal closure", context.Background(), websocket.CloseError{Code: websocket.StatusNormalClosure}, "clean close"},
+		{"clean going away", context.Background(), websocket.CloseError{Code: websocket.StatusGoingAway}, "clean close"},
+		{"clean no status received", context.Background(), websocket.CloseError{Code: websocket.StatusNoStatusRcvd}, "clean close"},
+		{"abnormal close is transport error", context.Background(), websocket.CloseError{Code: websocket.StatusAbnormalClosure}, "transport error"},
+		{"plain read error is transport error", context.Background(), errors.New("read: connection reset"), "transport error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := disconnectReason(tt.ctx, tt.err); got != tt.want {
+				t.Errorf("disconnectReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRegistry(t *testing.T) {
 	r := NewRegistry()
 	if _, ok := r.Session("lk", "zone-1"); ok {

--- a/dc-api/internal/api/handlers/agentws.go
+++ b/dc-api/internal/api/handlers/agentws.go
@@ -184,14 +184,18 @@ func (h *AgentWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		sess.close()
 	}()
 
-	sess.Serve(sessCtx, func() {
+	reason := sess.Serve(sessCtx, func() {
 		if err := h.repo.TouchAgent(sessCtx, agentID); err != nil {
 			h.log.Warn().Err(err).Msg("touch agent failed (non-fatal)")
 		}
 	})
 
 	_ = c.Close(websocket.StatusNormalClosure, "")
-	h.log.Info().Str("agent_id", agentID.String()).Msg("agent disconnected")
+	h.log.Info().
+		Str("agent_id", agentID.String()).
+		Str("region", region).Str("zone", zone).
+		Str("reason", reason).
+		Msg("agent disconnected")
 }
 
 // readHello reads and decodes the first frame, which must be a hello.

--- a/dc-api/internal/api/handlers/inventory.go
+++ b/dc-api/internal/api/handlers/inventory.go
@@ -48,6 +48,8 @@ func (h *InventoryHandler) Get(w http.ResponseWriter, r *http.Request) {
 	sess, ok := h.registry.Session(region, zone)
 	if !ok {
 		// No agent is currently connected for this zone — transient.
+		h.log.Info().Str("region", region).Str("zone", zone).
+			Msg("inventory requested but no agent connected for zone")
 		writeError(w, http.StatusServiceUnavailable, "no agent connected for this zone")
 		return
 	}
@@ -72,8 +74,12 @@ func (h *InventoryHandler) Get(w http.ResponseWriter, r *http.Request) {
 func (h *InventoryHandler) writeCallError(w http.ResponseWriter, region, zone string, err error) {
 	switch {
 	case errors.Is(err, ErrAgentUnavailable):
+		h.log.Warn().Str("region", region).Str("zone", zone).
+			Msg("inventory call failed: agent channel unavailable")
 		writeError(w, http.StatusServiceUnavailable, "agent channel unavailable")
 	case errors.Is(err, context.DeadlineExceeded):
+		h.log.Warn().Str("region", region).Str("zone", zone).
+			Msg("inventory call failed: agent did not respond in time")
 		writeError(w, http.StatusGatewayTimeout, "agent did not respond in time")
 	default:
 		var ae *AgentError


### PR DESCRIPTION
This makes the dc-agent command channel observable end to end, so an operator can answer "is the agent connected, for which zone, and if not why" from logs alone. It is logging-only — no wire-protocol, API, or behaviour change beyond capturing a disconnect reason — and is a fast-follow on the recently merged channel work.

On the agent side (dc-agent), `region` and `zone` are now bound on the logger once at startup, so every line — including the reconnect-forever warnings emitted while the control plane is unreachable — is attributable to a region/zone. Once a session is established its `agent_id` is bound too, so the connect line, ping/pong debug, and op-dispatch lines all carry it.

On the control-plane side (dc-api), the "agent disconnected" log now carries `region`, `zone`, and a categorized reason (clean close / idle timeout / transport error / server shutdown) instead of just an id; evicting a stale same-zone session (two agents claiming one zone) now emits a warning instead of happening silently; and the inventory endpoint now logs when it is called for a zone with no connected agent, or when the agent call times out.

Adds a focused unit test for the disconnect-reason categorization. `go build`, `go vet`, and `go test` pass for both the dc-agent and dc-api modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
