### PR TITLE
Add protocol v1 M-B mutating verbs to the agent channel

### DIFF
--- a/dc-agent/internal/conn/conn.go
+++ b/dc-agent/internal/conn/conn.go
@@ -71,19 +71,42 @@ type Config struct {
 	// Exposed for tests; production uses the default.
 	IdleLimit time.Duration
 
-	// Dispatcher maps the operation verbs this agent serves (protocol v1) to
-	// their handlers. Its keys are advertised in the hello frame. Empty (the
-	// zero value) keeps the agent presence-only — exactly v0 behaviour.
+	// Dispatcher maps the request/response operation verbs this agent serves
+	// (protocol v1) to their handlers. Its keys are advertised in the hello
+	// frame. Empty (the zero value) keeps the agent presence-only — exactly v0
+	// behaviour.
 	Dispatcher Dispatcher
+
+	// StreamDispatcher maps the streaming operation verbs (those that emit
+	// progress frames before their terminal res, e.g. watch_status) to their
+	// handlers. Its keys are advertised in the hello frame alongside Dispatcher's.
+	// A streaming and a non-streaming op must not share a name.
+	StreamDispatcher StreamDispatcher
 }
 
 // Handler runs one operation request: it receives the request's params and
 // returns the result payload, or an error (surfaced to the control plane as an
-// EXEC_ERROR response).
+// EXEC_ERROR response — or BAD_REQUEST if the error reports itself as a client
+// fault, see BadRequest).
 type Handler func(ctx context.Context, params json.RawMessage) (json.RawMessage, error)
 
 // Dispatcher maps op names to their handlers.
 type Dispatcher map[string]Handler
+
+// Emitter sends one advisory progress frame for an in-flight op, correlated by
+// the request's id. It is wired to writeFrame, so it is serialized against the
+// ping loop and every other op by the single-writer mutex — progress frames
+// never interleave on the wire. Safe for concurrent use; best-effort (a write
+// error is dropped, like any progress frame).
+type Emitter func(stage string, data json.RawMessage)
+
+// StreamHandler runs one streaming operation request: it may call emit zero or
+// more times to send progress frames before returning its terminal result (or
+// an error). Registered in a StreamDispatcher.
+type StreamHandler func(ctx context.Context, params json.RawMessage, emit Emitter) (json.RawMessage, error)
+
+// StreamDispatcher maps op names to their streaming handlers.
+type StreamDispatcher map[string]StreamHandler
 
 // ops returns the dispatcher's op names, sorted for a stable hello frame.
 func (d Dispatcher) ops() []string {
@@ -96,6 +119,53 @@ func (d Dispatcher) ops() []string {
 	}
 	sort.Strings(ops)
 	return ops
+}
+
+// advertisedOps returns the union of the request/response and streaming op
+// names, sorted and de-duplicated, for the hello frame. A name appearing in both
+// maps is listed once.
+func (c Config) advertisedOps() []string {
+	if len(c.Dispatcher) == 0 && len(c.StreamDispatcher) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(c.Dispatcher)+len(c.StreamDispatcher))
+	for op := range c.Dispatcher {
+		set[op] = struct{}{}
+	}
+	for op := range c.StreamDispatcher {
+		set[op] = struct{}{}
+	}
+	ops := make([]string, 0, len(set))
+	for op := range set {
+		ops = append(ops, op)
+	}
+	sort.Strings(ops)
+	return ops
+}
+
+// badRequester is implemented by handler (or executor) errors that are a
+// client/params fault — reported as BAD_REQUEST rather than EXEC_ERROR. The
+// executor package returns errors with this method (no import edge between the
+// two packages); conn also wraps params-unmarshal failures via BadRequest.
+type badRequester interface{ BadRequest() bool }
+
+// badRequestError marks a conn-side error (e.g. a params-unmarshal failure) as a
+// client fault. It satisfies badRequester.
+type badRequestError struct{ err error }
+
+func (e badRequestError) Error() string    { return e.err.Error() }
+func (e badRequestError) Unwrap() error    { return e.err }
+func (e badRequestError) BadRequest() bool { return true }
+
+// BadRequest wraps err so dispatch reports it as BAD_REQUEST instead of
+// EXEC_ERROR. Handlers use it for malformed params.
+func BadRequest(err error) error { return badRequestError{err: err} }
+
+// isBadRequest reports whether err (or anything it wraps) marks itself a
+// client/params fault via the badRequester interface.
+func isBadRequest(err error) bool {
+	var br badRequester
+	return errors.As(err, &br) && br.BadRequest()
 }
 
 // Runner maintains the agent↔control-plane channel for the life of the
@@ -237,7 +307,7 @@ func (r *Runner) dial(ctx context.Context) (*websocket.Conn, error) {
 // rather than timing out on a verb this agent lacks.
 func (r *Runner) handshake(ctx context.Context, c *websocket.Conn) (*protocol.HelloAck, error) {
 	hello := protocol.NewHello(r.cfg.Region, r.cfg.Zone, r.cfg.Version)
-	hello.Ops = r.cfg.Dispatcher.ops()
+	hello.Ops = r.cfg.advertisedOps()
 	if err := r.writeFrame(ctx, c, hello); err != nil {
 		return nil, fmt.Errorf("send hello: %w", err)
 	}
@@ -344,17 +414,42 @@ func (r *Runner) handleFrame(ctx context.Context, c *websocket.Conn, data []byte
 	}
 }
 
-// dispatch runs one request's handler and writes its response. An op with no
-// handler returns OP_UNSUPPORTED; a handler error returns EXEC_ERROR. log is the
-// per-session logger (carries agent_id).
+// dispatch runs one request's handler and writes its terminal response. A
+// request/response op is looked up in Dispatcher first; a streaming op (which may
+// emit progress frames before its res) in StreamDispatcher; an op in neither
+// returns OP_UNSUPPORTED. A handler error returns BAD_REQUEST if it reports
+// itself a client fault (see badRequester/BadRequest), else EXEC_ERROR. log is
+// the per-session logger (carries agent_id).
 func (r *Runner) dispatch(ctx context.Context, c *websocket.Conn, req *protocol.Req, log zerolog.Logger) {
-	handler, ok := r.cfg.Dispatcher[req.Op]
-	if !ok {
-		r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeOpUnsupported, "unsupported op: "+req.Op), log)
+	if handler, ok := r.cfg.Dispatcher[req.Op]; ok {
+		result, err := handler(ctx, req.Params)
+		r.finishDispatch(ctx, c, req, result, err, log)
 		return
 	}
-	result, err := handler(ctx, req.Params)
+	if handler, ok := r.cfg.StreamDispatcher[req.Op]; ok {
+		// The emitter is bound to this req's id and the current connection, and
+		// goes through the mutex-guarded writeFrame so progress frames never
+		// interleave with pongs or other ops' frames.
+		emit := func(stage string, data json.RawMessage) {
+			_ = r.writeFrame(ctx, c, protocol.NewProgressData(req.ID, stage, data))
+		}
+		result, err := handler(ctx, req.Params, emit)
+		r.finishDispatch(ctx, c, req, result, err, log)
+		return
+	}
+	r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeOpUnsupported, "unsupported op: "+req.Op), log)
+}
+
+// finishDispatch writes the single terminal res for a (streaming or
+// request/response) op: a client-fault error → BAD_REQUEST, any other error →
+// EXEC_ERROR, success → the result. Exactly one res ends every request.
+func (r *Runner) finishDispatch(ctx context.Context, c *websocket.Conn, req *protocol.Req, result json.RawMessage, err error, log zerolog.Logger) {
 	if err != nil {
+		if isBadRequest(err) {
+			log.Warn().Err(err).Str("op", req.Op).Msg("op rejected (bad request)")
+			r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeBadRequest, err.Error()), log)
+			return
+		}
 		log.Warn().Err(err).Str("op", req.Op).Msg("op handler failed")
 		r.writeRes(ctx, c, protocol.NewErrRes(req.ID, protocol.ErrCodeExecError, err.Error()), log)
 		return

--- a/dc-agent/internal/conn/conn_test.go
+++ b/dc-agent/internal/conn/conn_test.go
@@ -314,6 +314,284 @@ func TestSessionDispatch(t *testing.T) {
 	}
 }
 
+// TestAdvertisedOps verifies the hello advertisement merges the request/response
+// and streaming dispatchers: sorted, de-duplicated, and nil when both are empty.
+func TestAdvertisedOps(t *testing.T) {
+	noop := func(context.Context, json.RawMessage) (json.RawMessage, error) { return nil, nil }
+	noopStream := func(context.Context, json.RawMessage, Emitter) (json.RawMessage, error) { return nil, nil }
+
+	cases := []struct {
+		name   string
+		disp   Dispatcher
+		stream StreamDispatcher
+		want   []string
+	}{
+		{
+			name: "both empty",
+			want: nil,
+		},
+		{
+			name: "request/response only",
+			disp: Dispatcher{"get_inventory": noop, "apply": noop},
+			want: []string{"apply", "get_inventory"},
+		},
+		{
+			name:   "streaming only",
+			stream: StreamDispatcher{"watch_status": noopStream},
+			want:   []string{"watch_status"},
+		},
+		{
+			name:   "union sorted",
+			disp:   Dispatcher{"get_inventory": noop, "delete": noop, "apply": noop, "get_status": noop},
+			stream: StreamDispatcher{"watch_status": noopStream},
+			want:   []string{"apply", "delete", "get_inventory", "get_status", "watch_status"},
+		},
+		{
+			name:   "name in both maps listed once",
+			disp:   Dispatcher{"shared": noop},
+			stream: StreamDispatcher{"shared": noopStream},
+			want:   []string{"shared"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Config{Dispatcher: tc.disp, StreamDispatcher: tc.stream}.advertisedOps()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("advertisedOps() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSessionStreamDispatch runs the v1 streaming path against an in-process
+// server: a StreamHandler emits two progress frames, then returns its terminal
+// res. The test asserts (1) the streaming op is advertised in hello alongside the
+// request/response op, (2) the two progress frames arrive before the terminal res,
+// in order, all correlated to the request id, and (3) the terminal res carries the
+// handler's result. This pins the single-writer ordering guarantee: progress
+// frames never land after the res that ends the request.
+func TestSessionStreamDispatch(t *testing.T) {
+	stream := StreamDispatcher{
+		"watch_status": func(_ context.Context, _ json.RawMessage, emit Emitter) (json.RawMessage, error) {
+			emit("added", json.RawMessage(`{"found":true,"resource_version":"1"}`))
+			emit("modified", json.RawMessage(`{"found":true,"resource_version":"2"}`))
+			return json.RawMessage(`{"snapshots_sent":2,"reason":"max_snapshots"}`), nil
+		},
+	}
+	disp := Dispatcher{
+		"get_inventory": func(context.Context, json.RawMessage) (json.RawMessage, error) {
+			return json.RawMessage(`{"vm_count":0}`), nil
+		},
+	}
+
+	gotOps := make(chan []string, 1)
+	done := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		c, err := websocket.Accept(w, req, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "test over")
+		ctx := req.Context()
+
+		// hello → capture ops → hello_ack.
+		_, data, err := c.Read(ctx)
+		if err != nil {
+			return
+		}
+		frame, _ := protocol.Decode(data)
+		hello, ok := frame.(*protocol.Hello)
+		if !ok {
+			t.Errorf("first frame %T, want *protocol.Hello", frame)
+			return
+		}
+		gotOps <- hello.Ops
+		ack, _ := protocol.Encode(&protocol.HelloAck{Type: protocol.TypeHelloAck, AgentID: "agent-1"})
+		if err := c.Write(ctx, websocket.MessageText, ack); err != nil {
+			return
+		}
+
+		// Issue the watch_status req and read frames until the terminal res.
+		reqBytes, _ := protocol.Encode(&protocol.Req{Type: protocol.TypeReq, ID: "watch-1", Op: "watch_status"})
+		if err := c.Write(ctx, websocket.MessageText, reqBytes); err != nil {
+			t.Errorf("server write watch req: %v", err)
+			return
+		}
+
+		var progresses []*protocol.Progress
+		for {
+			_, data, err := c.Read(ctx)
+			if err != nil {
+				t.Errorf("server read stream frame: %v", err)
+				return
+			}
+			f, err := protocol.Decode(data)
+			if err != nil {
+				t.Errorf("server decode stream frame: %v", err)
+				return
+			}
+			switch fr := f.(type) {
+			case *protocol.Progress:
+				progresses = append(progresses, fr)
+			case *protocol.Res:
+				// Terminal res: validate ordering and contents, then finish.
+				if fr.ID != "watch-1" {
+					t.Errorf("res id = %q, want watch-1", fr.ID)
+				}
+				if !fr.Ok || string(fr.Result) != `{"snapshots_sent":2,"reason":"max_snapshots"}` {
+					t.Errorf("terminal res = %+v, want ok with the watch summary", fr)
+				}
+				if len(progresses) != 2 {
+					t.Fatalf("got %d progress frames before res, want 2", len(progresses))
+				}
+				if progresses[0].Stage != "added" || string(progresses[0].Data) != `{"found":true,"resource_version":"1"}` {
+					t.Errorf("progress[0] = %+v, want added/rv-1", progresses[0])
+				}
+				if progresses[1].Stage != "modified" || string(progresses[1].Data) != `{"found":true,"resource_version":"2"}` {
+					t.Errorf("progress[1] = %+v, want modified/rv-2", progresses[1])
+				}
+				for i, p := range progresses {
+					if p.ID != "watch-1" {
+						t.Errorf("progress[%d] id = %q, want watch-1 (correlation broken)", i, p.ID)
+					}
+				}
+				close(done)
+				<-ctx.Done()
+				return
+			default:
+				t.Errorf("unexpected frame %T in stream", fr)
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	r := NewRunner(Config{
+		Endpoint:         "ws" + strings.TrimPrefix(srv.URL, "http"),
+		Token:            "dcagent_x",
+		Region:           "region-a",
+		Zone:             "zone-1",
+		Version:          "test",
+		Logger:           zerolog.Nop(),
+		PingInterval:     time.Hour, // keep pings out of the stream exchange
+		Dispatcher:       disp,
+		StreamDispatcher: stream,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go r.runSession(ctx)
+
+	select {
+	case ops := <-gotOps:
+		want := []string{"get_inventory", "watch_status"} // merged + sorted
+		if !reflect.DeepEqual(ops, want) {
+			t.Errorf("hello.ops = %v, want %v", ops, want)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for hello")
+	}
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for the streaming exchange to complete")
+	}
+}
+
+// TestSessionDispatchBadRequest verifies a handler error wrapped with BadRequest
+// (the path main.go uses for params-unmarshal failures) surfaces as a BAD_REQUEST
+// res — distinct from the EXEC_ERROR a plain handler error yields — for both a
+// request/response handler and a streaming handler.
+func TestSessionDispatchBadRequest(t *testing.T) {
+	disp := Dispatcher{
+		"bad_params": func(context.Context, json.RawMessage) (json.RawMessage, error) {
+			return nil, BadRequest(errors.New("unparseable params"))
+		},
+	}
+	stream := StreamDispatcher{
+		"bad_stream_params": func(context.Context, json.RawMessage, Emitter) (json.RawMessage, error) {
+			return nil, BadRequest(errors.New("unparseable stream params"))
+		},
+	}
+
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		c, err := websocket.Accept(w, req, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "test over")
+		ctx := req.Context()
+
+		if _, _, err := c.Read(ctx); err != nil { // hello
+			return
+		}
+		ack, _ := protocol.Encode(&protocol.HelloAck{Type: protocol.TypeHelloAck, AgentID: "agent-1"})
+		if err := c.Write(ctx, websocket.MessageText, ack); err != nil {
+			return
+		}
+
+		send := func(id, op string) *protocol.Res {
+			b, _ := protocol.Encode(&protocol.Req{Type: protocol.TypeReq, ID: id, Op: op})
+			if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+				t.Errorf("server write req %q: %v", op, err)
+				return nil
+			}
+			_, data, err := c.Read(ctx)
+			if err != nil {
+				t.Errorf("server read res for %q: %v", op, err)
+				return nil
+			}
+			f, _ := protocol.Decode(data)
+			res, ok := f.(*protocol.Res)
+			if !ok {
+				t.Errorf("response is %T, want *protocol.Res", f)
+				return nil
+			}
+			return res
+		}
+
+		if res := send("id-rr", "bad_params"); res != nil {
+			if res.Ok || res.Error == nil || res.Error.Code != protocol.ErrCodeBadRequest {
+				t.Errorf("request/response bad-params res = %+v, want BAD_REQUEST", res)
+			}
+		}
+		if res := send("id-stream", "bad_stream_params"); res != nil {
+			if res.Ok || res.Error == nil || res.Error.Code != protocol.ErrCodeBadRequest {
+				t.Errorf("streaming bad-params res = %+v, want BAD_REQUEST", res)
+			}
+		}
+
+		close(done)
+		<-ctx.Done()
+	}))
+	defer srv.Close()
+
+	r := NewRunner(Config{
+		Endpoint:         "ws" + strings.TrimPrefix(srv.URL, "http"),
+		Token:            "dcagent_x",
+		Region:           "region-a",
+		Zone:             "zone-1",
+		Version:          "test",
+		Logger:           zerolog.Nop(),
+		PingInterval:     time.Hour,
+		Dispatcher:       disp,
+		StreamDispatcher: stream,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go r.runSession(ctx)
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for the bad-request exchanges to complete")
+	}
+}
+
 // TestRunSessionRejectsBadAck verifies the agent treats a non-hello_ack
 // first frame as a handshake failure (and reports established=false so the
 // backoff schedule keeps escalating).

--- a/dc-agent/internal/executor/executor.go
+++ b/dc-agent/internal/executor/executor.go
@@ -3,14 +3,29 @@
 // lives here, in the zone, and never travels to dc-api — which is the whole
 // point of the agent. See docs/multi-region-protocol-v1.md.
 //
-// M-A defines one read-only verb (get_inventory). The mutating verbs
-// (apply/delete) are added in M-B against this same interface.
+// M-A defines one read-only verb (get_inventory). M-B adds the mutating and
+// status verbs (apply/delete/get_status/watch_status) against this same
+// interface.
 package executor
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
-// OpGetInventory is the protocol op name for the read-only inventory request.
-const OpGetInventory = "get_inventory"
+// Protocol op names. These exact strings are the wire contract with dc-api,
+// which defines structurally-identical constants in its own package. Both sides
+// match on the string, never on a shared Go symbol.
+const (
+	// OpGetInventory is the read-only inventory request (M-A).
+	OpGetInventory = "get_inventory"
+
+	// M-B mutating/status verbs.
+	OpApply       = "apply"        // server-side apply a manifest
+	OpDelete      = "delete"       // delete one object (idempotent)
+	OpGetStatus   = "get_status"   // read an object's .status once
+	OpWatchStatus = "watch_status" // stream status snapshots, then terminate
+)
 
 // Inventory is a snapshot of the zone cluster's capacity, returned by
 // get_inventory. These node/capacity figures are operator-facing — dc-api
@@ -31,20 +46,147 @@ type Node struct {
 	MemUsedMB        int64  `json:"mem_used_mb"`
 }
 
+// ResourceRef identifies one Kubernetes object by GVK (api_version + kind),
+// namespace, and name. The mutating/status verbs that target an existing object
+// all carry this identical shape. GVK form (not GVR) is the wire contract: the
+// agent owns the GVK→GVR resolution via a RESTMapper because it — not dc-api —
+// has cluster discovery. Namespace is empty for cluster-scoped objects.
+type ResourceRef struct {
+	APIVersion string `json:"api_version"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name"`
+}
+
+// ApplyResult is the result of a server-side apply: the applied object's
+// identity plus its post-apply uid and resourceVersion.
+type ApplyResult struct {
+	APIVersion      string `json:"api_version"`
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace,omitempty"`
+	Name            string `json:"name"`
+	UID             string `json:"uid"`
+	ResourceVersion string `json:"resource_version"`
+}
+
+// DeleteResult reports whether the object existed at delete time. A delete of a
+// missing object is success with Existed=false (idempotent delete: the desired
+// end-state — object gone — is already satisfied).
+type DeleteResult struct {
+	Existed bool `json:"existed"`
+}
+
+// StatusSnapshot is one read of an object's status. It is shared by the
+// get_status result AND each watch_status progress-frame payload, so the
+// single-read and streaming cases carry one identical shape. Found is false when
+// the object is absent (status/resourceVersion omitted); Status is the object's
+// .status subobject verbatim (nil/{} when it has none).
+type StatusSnapshot struct {
+	Found           bool            `json:"found"`
+	ResourceVersion string          `json:"resource_version,omitempty"`
+	Generation      int64           `json:"generation,omitempty"`
+	Status          json.RawMessage `json:"status,omitempty"`
+}
+
+// WatchResult is the terminal summary of a watch_status stream: how many
+// snapshots were emitted and why the stream stopped.
+type WatchResult struct {
+	SnapshotsSent int    `json:"snapshots_sent"`
+	Reason        string `json:"reason"` // "max_snapshots" | "deadline" | "watch_closed"
+}
+
+// Reasons a watch_status stream terminates.
+const (
+	WatchReasonMaxSnapshots = "max_snapshots"
+	WatchReasonDeadline     = "deadline"
+	WatchReasonClosed       = "watch_closed"
+)
+
 // Executor runs operations against the local zone cluster.
 type Executor interface {
 	GetInventory(ctx context.Context) (Inventory, error)
+
+	// Apply server-side-applies manifest (a complete Kubernetes object) to the
+	// agent's own cluster, owned by fieldManager (defaults to "dc-api" when
+	// empty). force takes ownership of conflicting fields.
+	Apply(ctx context.Context, manifest json.RawMessage, fieldManager string, force bool) (ApplyResult, error)
+
+	// Delete removes the referenced object. propagationPolicy, when non-empty,
+	// must be one of Foreground/Background/Orphan. A missing object is success
+	// (DeleteResult{Existed:false}).
+	Delete(ctx context.Context, ref ResourceRef, propagationPolicy string) (DeleteResult, error)
+
+	// GetStatus reads the referenced object's status once. A missing object is
+	// success (StatusSnapshot{Found:false}).
+	GetStatus(ctx context.Context, ref ResourceRef) (StatusSnapshot, error)
+
+	// WatchStatus opens a watch on the single referenced object and calls emit
+	// once per observed event (initial added + subsequent modified), then returns
+	// a summary when it stops — after maxSnapshots events, when ctx is done, or
+	// when the watch closes. emit MUST be safe to call from WatchStatus's
+	// goroutine; the dispatcher wires it to a single-writer progress send. The
+	// stage passed to emit is the lowercased event type ("added"/"modified").
+	WatchStatus(ctx context.Context, ref ResourceRef, maxSnapshots int, emit func(stage string, snap StatusSnapshot)) (WatchResult, error)
 }
 
-// Stub is a no-cluster Executor that returns a fixed Inventory (or error). It
-// lets the agent's dispatch path run end to end before the real
-// Kubernetes-backed executor (M-A step 4) is wired in, and backs unit tests.
+// BadRequestError marks an executor error as a client/params fault — an
+// unparseable manifest, an unresolvable kind (GVK NoMatch), a missing name, or
+// an illegal propagation policy. The conn dispatcher detects the BadRequest()
+// method (via an interface, no import edge) and reports BAD_REQUEST instead of
+// EXEC_ERROR. Construct with badRequest().
+type BadRequestError struct{ err error }
+
+func (e *BadRequestError) Error() string { return e.err.Error() }
+func (e *BadRequestError) Unwrap() error { return e.err }
+
+// BadRequest reports that this error is a client/params fault. The conn package
+// checks for this method through an unexported interface, keeping executor and
+// conn decoupled (no import edge).
+func (e *BadRequestError) BadRequest() bool { return true }
+
+// badRequest wraps err as a BAD_REQUEST-class fault.
+func badRequest(err error) error { return &BadRequestError{err: err} }
+
+// Stub is a no-cluster Executor that returns fixed values (or a configured
+// error). It lets the agent's dispatch path run end to end without a real
+// cluster and backs unit/dispatcher tests. The per-verb result fields and
+// WatchEmits let tests drive each op deterministically.
 type Stub struct {
 	Inv Inventory
 	Err error
+
+	ApplyRes   ApplyResult
+	DeleteRes  DeleteResult
+	StatusRes  StatusSnapshot
+	WatchRes   WatchResult
+	WatchEmits []StatusSnapshot // emitted in order (stage "modified") before WatchRes
 }
 
 // GetInventory returns the stub's configured inventory or error.
 func (s Stub) GetInventory(_ context.Context) (Inventory, error) {
 	return s.Inv, s.Err
+}
+
+// Apply returns the stub's configured ApplyRes/Err.
+func (s Stub) Apply(_ context.Context, _ json.RawMessage, _ string, _ bool) (ApplyResult, error) {
+	return s.ApplyRes, s.Err
+}
+
+// Delete returns the stub's configured DeleteRes/Err.
+func (s Stub) Delete(_ context.Context, _ ResourceRef, _ string) (DeleteResult, error) {
+	return s.DeleteRes, s.Err
+}
+
+// GetStatus returns the stub's configured StatusRes/Err.
+func (s Stub) GetStatus(_ context.Context, _ ResourceRef) (StatusSnapshot, error) {
+	return s.StatusRes, s.Err
+}
+
+// WatchStatus emits each WatchEmits entry (stage "modified") via emit, then
+// returns the configured WatchRes/Err.
+func (s Stub) WatchStatus(_ context.Context, _ ResourceRef, _ int, emit func(stage string, snap StatusSnapshot)) (WatchResult, error) {
+	for _, snap := range s.WatchEmits {
+		emit("modified", snap)
+	}
+	return s.WatchRes, s.Err
 }

--- a/dc-agent/internal/executor/executor_test.go
+++ b/dc-agent/internal/executor/executor_test.go
@@ -2,7 +2,9 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -23,5 +25,96 @@ func TestStubReturnsInventory(t *testing.T) {
 func TestStubReturnsError(t *testing.T) {
 	if _, err := (Stub{Err: errors.New("down")}).GetInventory(context.Background()); err == nil {
 		t.Error("want the configured error, got nil")
+	}
+}
+
+// TestStubMutatingVerbs verifies the Stub returns its configured result for each
+// M-B request/response verb. The Stub is what dispatcher e2e tests drive, so a
+// drifted return wiring would silently break those.
+func TestStubMutatingVerbs(t *testing.T) {
+	s := Stub{
+		ApplyRes:  ApplyResult{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1", UID: "u-1", ResourceVersion: "12345"},
+		DeleteRes: DeleteResult{Existed: true},
+		StatusRes: StatusSnapshot{Found: true, ResourceVersion: "12345", Generation: 7, Status: json.RawMessage(`{"phase":"Running"}`)},
+	}
+
+	t.Run("apply", func(t *testing.T) {
+		got, err := s.Apply(context.Background(), json.RawMessage(`{}`), "dc-api", false)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		if !reflect.DeepEqual(got, s.ApplyRes) {
+			t.Errorf("Apply = %+v, want %+v", got, s.ApplyRes)
+		}
+	})
+	t.Run("delete", func(t *testing.T) {
+		got, err := s.Delete(context.Background(), ResourceRef{Name: "vm-1"}, "")
+		if err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if got != s.DeleteRes {
+			t.Errorf("Delete = %+v, want %+v", got, s.DeleteRes)
+		}
+	})
+	t.Run("get_status", func(t *testing.T) {
+		got, err := s.GetStatus(context.Background(), ResourceRef{Name: "vm-1"})
+		if err != nil {
+			t.Fatalf("GetStatus: %v", err)
+		}
+		if got.Found != s.StatusRes.Found || got.ResourceVersion != s.StatusRes.ResourceVersion ||
+			got.Generation != s.StatusRes.Generation || string(got.Status) != string(s.StatusRes.Status) {
+			t.Errorf("GetStatus = %+v, want %+v", got, s.StatusRes)
+		}
+	})
+}
+
+// TestStubMutatingVerbsError verifies the configured error propagates through the
+// mutating verbs (the watch verb returns it as its terminal error too).
+func TestStubMutatingVerbsError(t *testing.T) {
+	s := Stub{Err: errors.New("down")}
+	if _, err := s.Apply(context.Background(), nil, "", false); err == nil {
+		t.Error("Apply: want configured error, got nil")
+	}
+	if _, err := s.Delete(context.Background(), ResourceRef{}, ""); err == nil {
+		t.Error("Delete: want configured error, got nil")
+	}
+	if _, err := s.GetStatus(context.Background(), ResourceRef{}); err == nil {
+		t.Error("GetStatus: want configured error, got nil")
+	}
+	if _, err := s.WatchStatus(context.Background(), ResourceRef{}, 0, func(string, StatusSnapshot) {}); err == nil {
+		t.Error("WatchStatus: want configured error, got nil")
+	}
+}
+
+// TestStubWatchStatusEmitsInOrder verifies the Stub emits each configured
+// snapshot, in order, before returning its terminal summary — the behavior
+// dispatcher streaming tests rely on to produce a deterministic frame sequence.
+func TestStubWatchStatusEmitsInOrder(t *testing.T) {
+	s := Stub{
+		WatchEmits: []StatusSnapshot{
+			{Found: true, ResourceVersion: "1", Status: json.RawMessage(`{"phase":"Pending"}`)},
+			{Found: true, ResourceVersion: "2", Status: json.RawMessage(`{"phase":"Running"}`)},
+		},
+		WatchRes: WatchResult{SnapshotsSent: 2, Reason: WatchReasonMaxSnapshots},
+	}
+
+	var gotStages []string
+	var gotRVs []string
+	res, err := s.WatchStatus(context.Background(), ResourceRef{Name: "vm-1"}, 2, func(stage string, snap StatusSnapshot) {
+		gotStages = append(gotStages, stage)
+		gotRVs = append(gotRVs, snap.ResourceVersion)
+	})
+	if err != nil {
+		t.Fatalf("WatchStatus: %v", err)
+	}
+	if res != s.WatchRes {
+		t.Errorf("WatchResult = %+v, want %+v", res, s.WatchRes)
+	}
+	// The Stub emits every entry with stage "modified" (it has no event source).
+	if !reflect.DeepEqual(gotStages, []string{"modified", "modified"}) {
+		t.Errorf("emit stages = %v, want two modified", gotStages)
+	}
+	if !reflect.DeepEqual(gotRVs, []string{"1", "2"}) {
+		t.Errorf("emit order (by resourceVersion) = %v, want [1 2]", gotRVs)
 	}
 }

--- a/dc-agent/internal/executor/kube.go
+++ b/dc-agent/internal/executor/kube.go
@@ -2,15 +2,34 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	// defaultFieldManager owns the fields a server-side apply sets when the
+	// caller leaves field_manager empty. dc-api is the field owner end to end.
+	defaultFieldManager = "dc-api"
+
+	// defaultWatchSnapshots / maxWatchSnapshots bound a watch_status stream when
+	// the caller omits / over-asks max_snapshots.
+	defaultWatchSnapshots = 10
+	maxWatchSnapshots     = 100
 )
 
 // kubevirtVMGVR is the GroupVersionResource for KubeVirt VirtualMachines. We
@@ -18,16 +37,28 @@ import (
 // (heavy, version-touchy) client-go.
 var kubevirtVMGVR = schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}
 
-// KubeExecutor reads zone inventory from the local Kubernetes (Harvester)
-// cluster. The cluster credential lives here and never travels to dc-api.
+// KubeExecutor reads zone inventory from, and mutates, the local Kubernetes
+// (Harvester) cluster. The cluster credential lives here and never travels to
+// dc-api. mapper resolves GVK→GVR for the mutating/status verbs (M-B) and may be
+// nil for an inventory-only executor.
 type KubeExecutor struct {
-	kube kubernetes.Interface
-	dyn  dynamic.Interface
+	kube   kubernetes.Interface
+	dyn    dynamic.Interface
+	mapper meta.RESTMapper
 }
 
 // NewKubeExecutor builds a KubeExecutor from injected clients (used in tests).
+// The RESTMapper is nil — get_inventory needs no mapping. Tests exercising the
+// M-B verbs use NewKubeExecutorWithMapper with a static mapper.
 func NewKubeExecutor(kube kubernetes.Interface, dyn dynamic.Interface) *KubeExecutor {
 	return &KubeExecutor{kube: kube, dyn: dyn}
+}
+
+// NewKubeExecutorWithMapper builds a KubeExecutor with an explicit RESTMapper —
+// the test-injection path for the GVK→GVR-resolving M-B verbs, where a static
+// meta.RESTMapper stands in for cluster discovery.
+func NewKubeExecutorWithMapper(kube kubernetes.Interface, dyn dynamic.Interface, mapper meta.RESTMapper) *KubeExecutor {
+	return &KubeExecutor{kube: kube, dyn: dyn, mapper: mapper}
 }
 
 // NewKubeExecutorFromConfig builds a KubeExecutor against the local cluster. An
@@ -56,7 +87,50 @@ func NewKubeExecutorFromConfig(kubeconfigPath string) (*KubeExecutor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dynamic client: %w", err)
 	}
-	return &KubeExecutor{kube: kube, dyn: dyn}, nil
+	// A deferred, memcached discovery RESTMapper resolves GVK→GVR for the M-B
+	// verbs. Deferred + memcache means it lazy-loads discovery on first use and
+	// can Reset() on a NoMatch (e.g. a freshly-installed CRD), so a manifest for
+	// a kind that appeared after startup still resolves.
+	disco, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("discovery client: %w", err)
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disco))
+	return &KubeExecutor{kube: kube, dyn: dyn, mapper: mapper}, nil
+}
+
+// resolve maps a ResourceRef's GVK to the dynamic ResourceInterface scoped to
+// its namespace (or cluster-wide). A GVK NoMatch — an unknown/uninstalled kind —
+// is a BAD_REQUEST-class fault; a missing name is too. On a NoMatch the deferred
+// mapper is Reset so a subsequent call re-reads discovery (handles a CRD that was
+// installed after the mapper last cached).
+func (k *KubeExecutor) resolve(ref ResourceRef) (dynamic.ResourceInterface, error) {
+	if k.mapper == nil {
+		return nil, badRequest(fmt.Errorf("no RESTMapper configured (inventory-only executor)"))
+	}
+	if ref.Name == "" {
+		return nil, badRequest(fmt.Errorf("name is required"))
+	}
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return nil, badRequest(fmt.Errorf("invalid api_version %q: %w", ref.APIVersion, err))
+	}
+	gvk := gv.WithKind(ref.Kind)
+	mapping, err := k.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			if reset, ok := k.mapper.(interface{ Reset() }); ok {
+				reset.Reset()
+			}
+			return nil, badRequest(fmt.Errorf("unknown kind %s: %w", gvk, err))
+		}
+		return nil, fmt.Errorf("rest mapping for %s: %w", gvk, err)
+	}
+	client := k.dyn.Resource(mapping.Resource)
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		return client.Namespace(ref.Namespace), nil
+	}
+	return client, nil // cluster-scoped: namespace is ignored
 }
 
 // GetInventory lists nodes (readiness + allocatable/allocated CPU & memory) and
@@ -116,4 +190,216 @@ func nodeReady(n *corev1.Node) bool {
 		}
 	}
 	return false
+}
+
+// Apply server-side-applies manifest to the agent's own cluster. The manifest's
+// GVK/namespace/name are taken from the object itself — the agent never injects
+// a namespace and never cross-cluster-routes (the manifest's cluster is always
+// this zone's, token-authoritative). force takes ownership of fields another
+// manager holds; without it a conflict surfaces as an EXEC_ERROR.
+//
+// TODO(rbac): apply needs create+patch on the managed CR groups (kubevirt,
+// KubeOVN, Rancher provisioning, …). The agent's current in-cluster ClusterRole
+// is read-only; against a live cluster this returns Forbidden until the widened
+// role lands (separate Flux/manifest follow-up PR — not this change). M-B tests
+// use fake clients with no RBAC, so they are unaffected.
+func (k *KubeExecutor) Apply(ctx context.Context, manifest json.RawMessage, fieldManager string, force bool) (ApplyResult, error) {
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(manifest); err != nil {
+		return ApplyResult{}, badRequest(fmt.Errorf("unparseable manifest: %w", err))
+	}
+	gvk := obj.GroupVersionKind()
+	if gvk.Kind == "" || gvk.Version == "" {
+		return ApplyResult{}, badRequest(fmt.Errorf("manifest missing apiVersion/kind"))
+	}
+	name := obj.GetName()
+	if name == "" {
+		return ApplyResult{}, badRequest(fmt.Errorf("manifest missing metadata.name"))
+	}
+	if fieldManager == "" {
+		fieldManager = defaultFieldManager
+	}
+
+	// Server-side apply rejects an incoming object that already carries
+	// metadata.managedFields ("cannot apply an object with managed fields already
+	// set"), so strip it. Also clear metadata.resourceVersion: an apply declares
+	// desired state and must not assert an optimistic-concurrency precondition the
+	// caller didn't intend (a stale RV would spuriously conflict). Both are
+	// server-managed and safe to drop from a manifest we re-apply.
+	unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "resourceVersion")
+
+	ri, err := k.resolve(ResourceRef{
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
+		Namespace:  obj.GetNamespace(),
+		Name:       name,
+	})
+	if err != nil {
+		return ApplyResult{}, err
+	}
+
+	applied, err := ri.Apply(ctx, name, obj, metav1.ApplyOptions{FieldManager: fieldManager, Force: force})
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("apply %s %s/%s: %w", gvk, obj.GetNamespace(), name, err)
+	}
+	return ApplyResult{
+		APIVersion:      gvk.GroupVersion().String(),
+		Kind:            gvk.Kind,
+		Namespace:       applied.GetNamespace(),
+		Name:            applied.GetName(),
+		UID:             string(applied.GetUID()),
+		ResourceVersion: applied.GetResourceVersion(),
+	}, nil
+}
+
+// Delete removes the referenced object. A missing object is success
+// (Existed=false) — the idempotent-delete contract. An illegal propagation
+// policy is a BAD_REQUEST.
+//
+// TODO(rbac): delete needs the delete verb on the managed CR groups; see the
+// note on Apply. Live calls return Forbidden until the widened ClusterRole lands.
+func (k *KubeExecutor) Delete(ctx context.Context, ref ResourceRef, propagationPolicy string) (DeleteResult, error) {
+	opts := metav1.DeleteOptions{}
+	if propagationPolicy != "" {
+		policy, err := parsePropagationPolicy(propagationPolicy)
+		if err != nil {
+			return DeleteResult{}, err
+		}
+		opts.PropagationPolicy = &policy
+	}
+
+	ri, err := k.resolve(ref)
+	if err != nil {
+		return DeleteResult{}, err
+	}
+
+	if err := ri.Delete(ctx, ref.Name, opts); err != nil {
+		if apierrors.IsNotFound(err) {
+			return DeleteResult{Existed: false}, nil
+		}
+		return DeleteResult{}, fmt.Errorf("delete %s/%s/%s: %w", ref.Kind, ref.Namespace, ref.Name, err)
+	}
+	return DeleteResult{Existed: true}, nil
+}
+
+// GetStatus reads the referenced object's status once. A missing object is
+// success (Found=false).
+func (k *KubeExecutor) GetStatus(ctx context.Context, ref ResourceRef) (StatusSnapshot, error) {
+	ri, err := k.resolve(ref)
+	if err != nil {
+		return StatusSnapshot{}, err
+	}
+	obj, err := ri.Get(ctx, ref.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return StatusSnapshot{Found: false}, nil
+		}
+		return StatusSnapshot{}, fmt.Errorf("get %s/%s/%s: %w", ref.Kind, ref.Namespace, ref.Name, err)
+	}
+	return snapshotOf(obj)
+}
+
+// WatchStatus opens a watch on the single named object and calls emit once per
+// observed Added/Modified event, stopping after maxSnapshots events, on
+// ctx.Done(), or when the watch channel closes/errors. It never touches the
+// socket — emit is the dispatcher's single-writer progress sender. Object
+// absence is not an error: the watch simply yields no Added event.
+//
+// TODO(rbac): watch_status needs the watch verb on the managed CR groups; see
+// the note on Apply.
+func (k *KubeExecutor) WatchStatus(ctx context.Context, ref ResourceRef, maxSnapshots int, emit func(stage string, snap StatusSnapshot)) (WatchResult, error) {
+	if maxSnapshots < 0 {
+		return WatchResult{}, badRequest(fmt.Errorf("max_snapshots must be >= 0, got %d", maxSnapshots))
+	}
+	switch {
+	case maxSnapshots == 0:
+		maxSnapshots = defaultWatchSnapshots
+	case maxSnapshots > maxWatchSnapshots:
+		maxSnapshots = maxWatchSnapshots
+	}
+
+	ri, err := k.resolve(ref)
+	if err != nil {
+		return WatchResult{}, err
+	}
+	w, err := ri.Watch(ctx, metav1.ListOptions{FieldSelector: "metadata.name=" + ref.Name})
+	if err != nil {
+		return WatchResult{}, fmt.Errorf("watch %s/%s/%s: %w", ref.Kind, ref.Namespace, ref.Name, err)
+	}
+	defer w.Stop()
+
+	sent := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return WatchResult{SnapshotsSent: sent, Reason: WatchReasonDeadline}, nil
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return WatchResult{SnapshotsSent: sent, Reason: WatchReasonClosed}, nil
+			}
+			if event.Type != watch.Added && event.Type != watch.Modified {
+				continue // skip Deleted/Bookmark/Error frames — only status snapshots
+			}
+			obj, ok := event.Object.(*unstructured.Unstructured)
+			if !ok {
+				continue // a non-unstructured (e.g. Status) object carries no snapshot
+			}
+			snap, err := snapshotOf(obj)
+			if err != nil {
+				return WatchResult{SnapshotsSent: sent, Reason: WatchReasonClosed}, err
+			}
+			emit(eventStage(event.Type), snap)
+			sent++
+			if sent >= maxSnapshots {
+				return WatchResult{SnapshotsSent: sent, Reason: WatchReasonMaxSnapshots}, nil
+			}
+		}
+	}
+}
+
+// snapshotOf builds a found StatusSnapshot from an unstructured object: its
+// resourceVersion, generation, and .status subobject (omitted when absent).
+func snapshotOf(obj *unstructured.Unstructured) (StatusSnapshot, error) {
+	snap := StatusSnapshot{
+		Found:           true,
+		ResourceVersion: obj.GetResourceVersion(),
+		Generation:      obj.GetGeneration(),
+	}
+	status, found, err := unstructured.NestedMap(obj.Object, "status")
+	if err != nil {
+		return StatusSnapshot{}, fmt.Errorf("read .status of %s: %w", obj.GetName(), err)
+	}
+	if found {
+		raw, err := json.Marshal(status)
+		if err != nil {
+			return StatusSnapshot{}, fmt.Errorf("marshal .status of %s: %w", obj.GetName(), err)
+		}
+		snap.Status = raw
+	}
+	return snap, nil
+}
+
+// eventStage maps a watch event type to the wire stage string ("added"/
+// "modified"). Only Added/Modified reach it (see WatchStatus's filter).
+func eventStage(t watch.EventType) string {
+	if t == watch.Added {
+		return "added"
+	}
+	return "modified"
+}
+
+// parsePropagationPolicy validates a propagation_policy param against the three
+// legal values, returning a BAD_REQUEST-class error otherwise.
+func parsePropagationPolicy(p string) (metav1.DeletionPropagation, error) {
+	switch metav1.DeletionPropagation(p) {
+	case metav1.DeletePropagationForeground:
+		return metav1.DeletePropagationForeground, nil
+	case metav1.DeletePropagationBackground:
+		return metav1.DeletePropagationBackground, nil
+	case metav1.DeletePropagationOrphan:
+		return metav1.DeletePropagationOrphan, nil
+	default:
+		return "", badRequest(fmt.Errorf("invalid propagation_policy %q (want Foreground|Background|Orphan)", p))
+	}
 }

--- a/dc-agent/internal/executor/kube_test.go
+++ b/dc-agent/internal/executor/kube_test.go
@@ -2,17 +2,139 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	dynfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
+
+// ── M-B test scaffolding ───────────────────────────────────────────────────────
+//
+// The four M-B verbs resolve GVK→GVR through a RESTMapper and act through the
+// dynamic client. Tests inject a static meta.RESTMapper (cluster discovery stands
+// nowhere in a fake) registering one namespaced kind (ConfigMap) and one
+// cluster-scoped kind (a stand-in CRD, kubeovn.io/v1 Vpc) so both scopes are
+// exercised. ConfigMap/Vpc are convenient unstructured carriers — the verbs are
+// kind-agnostic, so the kinds chosen don't matter beyond their scope.
+
+var (
+	cmGVR  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	vpcGVR = schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}
+)
+
+// mbMapper is the static RESTMapper the M-B verb tests inject: ConfigMap
+// (namespaced) and Vpc (cluster-scoped). An unregistered kind yields a NoMatch,
+// which the executor maps to a BAD_REQUEST-class fault.
+func mbMapper() meta.RESTMapper {
+	m := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{Group: "", Version: "v1"},
+		{Group: "kubeovn.io", Version: "v1"},
+	})
+	m.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, meta.RESTScopeNamespace)
+	m.Add(schema.GroupVersionKind{Group: "kubeovn.io", Version: "v1", Kind: "Vpc"}, meta.RESTScopeRoot)
+	return m
+}
+
+// mbListKinds maps the test GVRs to their list kinds for the dynamic fake.
+func mbListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		cmGVR:  "ConfigMapList",
+		vpcGVR: "VpcList",
+	}
+}
+
+// configMap builds an unstructured ConfigMap with the given name/namespace and an
+// optional .status.phase (empty phase ⇒ no .status subobject at all).
+func configMap(name, namespace, statusPhase string) *unstructured.Unstructured {
+	o := &unstructured.Unstructured{}
+	o.SetAPIVersion("v1")
+	o.SetKind("ConfigMap")
+	o.SetName(name)
+	if namespace != "" {
+		o.SetNamespace(namespace)
+	}
+	if statusPhase != "" {
+		_ = unstructured.SetNestedField(o.Object, statusPhase, "status", "phase")
+	}
+	return o
+}
+
+// installSSAReactor makes the dynamic fake honor server-side apply as an upsert.
+//
+// The fake's ResourceInterface.Apply issues an ApplyPatchType PATCH to the object
+// tracker, whose default reactor does NOT implement SSA: it requires the object to
+// pre-exist (apply-create → "not found") and cannot strategic-merge an
+// unstructured object (apply-update → "unable to find api field…"). This reactor
+// emulates the real apiserver's apply upsert: decode the manifest, create it
+// (uid + rv "1") when absent, or replace it (rv bumped, uid preserved) when
+// present, then return the stored object — which is exactly what KubeExecutor.Apply
+// reads its result from. It is a TEST shim for the fake's limitation, not
+// production behavior.
+func installSSAReactor(t *testing.T, dc *dynfake.FakeDynamicClient) {
+	t.Helper()
+	tracker := dc.Tracker()
+	dc.PrependReactor("patch", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+		pa, ok := action.(ktesting.PatchAction)
+		if !ok || pa.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil // not an apply — let the default chain handle it
+		}
+		gvr := pa.GetResource()
+		ns := pa.GetNamespace()
+		name := pa.GetName()
+
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(pa.GetPatch()); err != nil {
+			return true, nil, err
+		}
+		obj.SetName(name)
+		if ns != "" {
+			obj.SetNamespace(ns)
+		}
+
+		existing, err := tracker.Get(gvr, ns, name)
+		switch {
+		case apierrors.IsNotFound(err):
+			obj.SetUID(types.UID("uid-" + name))
+			obj.SetResourceVersion("1")
+			if cerr := tracker.Create(gvr, obj, ns); cerr != nil {
+				return true, nil, cerr
+			}
+			return true, obj, nil
+		case err != nil:
+			return true, nil, err
+		default:
+			ex := existing.(*unstructured.Unstructured)
+			obj.SetUID(ex.GetUID()) // identity is stable across applies
+			obj.SetResourceVersion("2")
+			if uerr := tracker.Update(gvr, obj, ns); uerr != nil {
+				return true, nil, uerr
+			}
+			return true, obj, nil
+		}
+	})
+}
+
+// isBadRequestFault reports whether err (or anything it wraps) is the executor's
+// BAD_REQUEST-class fault — the same BadRequest() bool marker the conn dispatcher
+// keys on to return a BAD_REQUEST res rather than EXEC_ERROR.
+func isBadRequestFault(err error) bool {
+	var br interface{ BadRequest() bool }
+	return errors.As(err, &br) && br.BadRequest()
+}
 
 func TestKubeExecutorGetInventory(t *testing.T) {
 	node := &corev1.Node{
@@ -105,5 +227,636 @@ func TestNodeReady(t *testing.T) {
 	noCondition := &corev1.Node{}
 	if nodeReady(noCondition) {
 		t.Error("nodeReady = true for a node with no Ready condition")
+	}
+}
+
+// ── Apply ───────────────────────────────────────────────────────────────────
+
+// TestKubeExecutorApply_Create applies a manifest for a not-yet-existing object
+// and asserts the result identity and that the object now exists in the cluster.
+// SSA upsert against the dynamic fake is provided by installSSAReactor (the fake's
+// own apply reactor can't create — see that helper's comment).
+func TestKubeExecutorApply_Create(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	installSSAReactor(t, dc)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	manifest, err := configMap("cm-1", "tenant-abc", "").MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	res, err := k.Apply(context.Background(), manifest, "dc-api", false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.APIVersion != "v1" || res.Kind != "ConfigMap" || res.Namespace != "tenant-abc" || res.Name != "cm-1" {
+		t.Errorf("ApplyResult identity = %+v, want v1/ConfigMap tenant-abc/cm-1", res)
+	}
+	if res.UID == "" || res.ResourceVersion == "" {
+		t.Errorf("ApplyResult uid/resourceVersion empty: %+v", res)
+	}
+
+	// The object must actually exist post-apply.
+	got, err := dc.Resource(cmGVR).Namespace("tenant-abc").Get(context.Background(), "cm-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("post-apply Get: %v", err)
+	}
+	if got.GetUID() != types.UID(res.UID) || got.GetResourceVersion() != res.ResourceVersion {
+		t.Errorf("post-apply object uid/rv (%q/%q) != ApplyResult (%q/%q)",
+			got.GetUID(), got.GetResourceVersion(), res.UID, res.ResourceVersion)
+	}
+}
+
+// TestKubeExecutorApply_StripsServerManagedFields guards the SSA pre-strip: a
+// manifest that arrives carrying metadata.managedFields (and a stale
+// metadata.resourceVersion) must have BOTH removed before the apply patch goes to
+// the cluster. The real apiserver hard-errors ("cannot apply an object with
+// managed fields already set") on a managedFields-bearing apply; a stale
+// resourceVersion would assert an unintended optimistic-concurrency precondition.
+// The fake doesn't enforce either, so we assert directly on the patch bytes the
+// executor sent: neither field may be present.
+func TestKubeExecutorApply_StripsServerManagedFields(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+
+	// Capture the apply-patch payload (the object the executor sent upstream).
+	// installSSAReactor is prepended first; this observer is prepended AFTER it so
+	// it sits at the FRONT of the chain (PrependReactor pushes to the head) and
+	// runs before the SSA reactor consumes the action — it observes, then falls
+	// through.
+	installSSAReactor(t, dc)
+	var capturedPatch []byte
+	dc.PrependReactor("patch", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if pa, ok := action.(ktesting.PatchAction); ok && pa.GetPatchType() == types.ApplyPatchType {
+			capturedPatch = append([]byte(nil), pa.GetPatch()...)
+		}
+		return false, nil, nil // observe only; let installSSAReactor handle it
+	})
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	// Build a manifest that carries server-managed metadata an apply must not send.
+	obj := configMap("cm-1", "tenant-abc", "Running")
+	obj.SetResourceVersion("12345")
+	_ = unstructured.SetNestedSlice(obj.Object, []interface{}{
+		map[string]interface{}{
+			"manager":    "kubectl-client-side-apply",
+			"operation":  "Update",
+			"apiVersion": "v1",
+		},
+	}, "metadata", "managedFields")
+	manifest, err := obj.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	// Sanity: the field is really present in the input we hand to Apply.
+	if !json.Valid(manifest) {
+		t.Fatalf("test manifest is not valid JSON")
+	}
+
+	res, err := k.Apply(context.Background(), manifest, "dc-api", false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.Name != "cm-1" || res.Namespace != "tenant-abc" {
+		t.Errorf("ApplyResult identity = %+v, want tenant-abc/cm-1", res)
+	}
+
+	if capturedPatch == nil {
+		t.Fatal("apply patch was never captured")
+	}
+	patched := &unstructured.Unstructured{}
+	if err := patched.UnmarshalJSON(capturedPatch); err != nil {
+		t.Fatalf("decode captured patch: %v", err)
+	}
+	if _, found, _ := unstructured.NestedSlice(patched.Object, "metadata", "managedFields"); found {
+		t.Error("apply patch still carried metadata.managedFields (must be stripped before SSA)")
+	}
+	if patched.GetResourceVersion() != "" {
+		t.Errorf("apply patch still carried metadata.resourceVersion %q (must be cleared before SSA)", patched.GetResourceVersion())
+	}
+	// The substantive content must survive the strip.
+	if phase, _, _ := unstructured.NestedString(patched.Object, "status", "phase"); phase != "Running" {
+		t.Errorf("apply patch lost .status.phase: got %q, want Running", phase)
+	}
+}
+
+// TestKubeExecutorApply_Update applies over an existing object and asserts the uid
+// is preserved (stable identity) while the resourceVersion advances.
+func TestKubeExecutorApply_Update(t *testing.T) {
+	seed := configMap("cm-1", "tenant-abc", "Pending")
+	seed.SetUID("uid-existing")
+	seed.SetResourceVersion("100")
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), seed)
+	installSSAReactor(t, dc)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	manifest, _ := configMap("cm-1", "tenant-abc", "Running").MarshalJSON()
+	res, err := k.Apply(context.Background(), manifest, "dc-api", true)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.UID != "uid-existing" {
+		t.Errorf("Apply over existing object changed uid: got %q, want uid-existing", res.UID)
+	}
+	if res.ResourceVersion == "100" || res.ResourceVersion == "" {
+		t.Errorf("Apply did not advance resourceVersion: got %q", res.ResourceVersion)
+	}
+}
+
+// TestKubeExecutorApply_DefaultsFieldManager applies with an empty field manager
+// and asserts the executor substitutes the "dc-api" default (the apply still
+// succeeds; the default is documented contract).
+func TestKubeExecutorApply_DefaultsFieldManager(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	// A single reactor both observes the field manager on the apply PATCH and
+	// satisfies the apply (a chained observe-only reactor would never run, since
+	// the SSA reactor at the chain front returns handled=true first).
+	var seenFM string
+	tracker := dc.Tracker()
+	dc.PrependReactor("patch", "configmaps", func(action ktesting.Action) (bool, runtime.Object, error) {
+		pa, ok := action.(ktesting.PatchAction)
+		if !ok || pa.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		seenFM = action.(ktesting.PatchActionImpl).PatchOptions.FieldManager
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(pa.GetPatch()); err != nil {
+			return true, nil, err
+		}
+		obj.SetName(pa.GetName())
+		obj.SetNamespace(pa.GetNamespace())
+		obj.SetUID("uid-1")
+		obj.SetResourceVersion("1")
+		if err := tracker.Create(pa.GetResource(), obj, pa.GetNamespace()); err != nil {
+			return true, nil, err
+		}
+		return true, obj, nil
+	})
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	manifest, _ := configMap("cm-1", "tenant-abc", "").MarshalJSON()
+	if _, err := k.Apply(context.Background(), manifest, "", false); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if seenFM != defaultFieldManager {
+		t.Errorf("empty field_manager not defaulted: PatchOptions.FieldManager = %q, want %q", seenFM, defaultFieldManager)
+	}
+}
+
+// TestKubeExecutorApply_BadManifest asserts an unparseable manifest, and one
+// missing kind/name, are BAD_REQUEST-class faults (not EXEC_ERROR, not a panic).
+func TestKubeExecutorApply_BadManifest(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	cases := []struct {
+		name     string
+		manifest string
+	}{
+		{"not json", `this is not json`},
+		{"missing kind", `{"apiVersion":"v1","metadata":{"name":"cm-1","namespace":"x"}}`},
+		{"missing name", `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"namespace":"x"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := k.Apply(context.Background(), json.RawMessage(tc.manifest), "dc-api", false)
+			if err == nil {
+				t.Fatalf("Apply(%s) err = nil, want BAD_REQUEST fault", tc.name)
+			}
+			if !isBadRequestFault(err) {
+				t.Errorf("Apply(%s) err = %v, want a BadRequest()=true fault", tc.name, err)
+			}
+		})
+	}
+}
+
+// ── Delete ──────────────────────────────────────────────────────────────────
+
+// TestKubeExecutorDelete_Exists deletes a seeded object and asserts Existed:true
+// and that the object is gone.
+func TestKubeExecutorDelete_Exists(t *testing.T) {
+	seed := configMap("cm-1", "tenant-abc", "")
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), seed)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	res, err := k.Delete(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}, "")
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !res.Existed {
+		t.Errorf("Delete of present object Existed = false, want true")
+	}
+	_, err = dc.Resource(cmGVR).Namespace("tenant-abc").Get(context.Background(), "cm-1", metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("object still present after Delete (err=%v), want NotFound", err)
+	}
+}
+
+// TestKubeExecutorDelete_Absent deletes a missing object and asserts the
+// idempotent-delete contract: success with Existed:false, NOT an error.
+func TestKubeExecutorDelete_Absent(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	res, err := k.Delete(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "ghost"}, "")
+	if err != nil {
+		t.Fatalf("Delete of absent object returned error %v, want nil (idempotent)", err)
+	}
+	if res.Existed {
+		t.Errorf("Delete of absent object Existed = true, want false")
+	}
+}
+
+// TestKubeExecutorDelete_PropagationPolicy asserts each legal policy is accepted
+// and an illegal one is a BAD_REQUEST-class fault before any cluster call.
+func TestKubeExecutorDelete_PropagationPolicy(t *testing.T) {
+	legal := []string{"Foreground", "Background", "Orphan"}
+	for _, policy := range legal {
+		t.Run("legal/"+policy, func(t *testing.T) {
+			seed := configMap("cm-1", "tenant-abc", "")
+			dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), seed)
+			k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+			res, err := k.Delete(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}, policy)
+			if err != nil {
+				t.Fatalf("Delete with policy %q: %v", policy, err)
+			}
+			if !res.Existed {
+				t.Errorf("Delete with policy %q Existed = false, want true", policy)
+			}
+		})
+	}
+
+	t.Run("illegal", func(t *testing.T) {
+		seed := configMap("cm-1", "tenant-abc", "")
+		dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), seed)
+		k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+		_, err := k.Delete(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}, "Nope")
+		if err == nil {
+			t.Fatal("Delete with illegal policy err = nil, want BAD_REQUEST fault")
+		}
+		if !isBadRequestFault(err) {
+			t.Errorf("illegal policy err = %v, want a BadRequest()=true fault", err)
+		}
+		// The object must NOT have been deleted — the policy is rejected first.
+		if _, gerr := dc.Resource(cmGVR).Namespace("tenant-abc").Get(context.Background(), "cm-1", metav1.GetOptions{}); gerr != nil {
+			t.Errorf("object deleted despite illegal policy (err=%v), want still present", gerr)
+		}
+	})
+}
+
+// ── GetStatus ─────────────────────────────────────────────────────────────────
+
+// TestKubeExecutorGetStatus_Found reads a seeded object's status and asserts the
+// .status subobject, resourceVersion, and generation round-trip.
+func TestKubeExecutorGetStatus_Found(t *testing.T) {
+	seed := configMap("cm-1", "tenant-abc", "Running")
+	seed.SetResourceVersion("12345")
+	seed.SetGeneration(7)
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), seed)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	snap, err := k.GetStatus(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"})
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if !snap.Found {
+		t.Fatal("GetStatus Found = false, want true")
+	}
+	if snap.ResourceVersion != "12345" {
+		t.Errorf("ResourceVersion = %q, want 12345", snap.ResourceVersion)
+	}
+	if snap.Generation != 7 {
+		t.Errorf("Generation = %d, want 7", snap.Generation)
+	}
+	var status struct {
+		Phase string `json:"phase"`
+	}
+	if err := json.Unmarshal(snap.Status, &status); err != nil {
+		t.Fatalf("unmarshal status: %v (raw=%s)", err, snap.Status)
+	}
+	if status.Phase != "Running" {
+		t.Errorf("status.phase = %q, want Running (raw=%s)", status.Phase, snap.Status)
+	}
+}
+
+// TestKubeExecutorGetStatus_NoStatus reads an object that has no .status and
+// asserts Found:true with an omitted (nil) status — the verb still succeeds.
+func TestKubeExecutorGetStatus_NoStatus(t *testing.T) {
+	seed := configMap("cm-1", "tenant-abc", "") // no status subobject
+	seed.SetResourceVersion("5")
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), seed)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	snap, err := k.GetStatus(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"})
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if !snap.Found {
+		t.Error("Found = false, want true for a present object with no status")
+	}
+	if snap.Status != nil {
+		t.Errorf("Status = %s, want nil for an object with no .status", snap.Status)
+	}
+}
+
+// TestKubeExecutorGetStatus_Absent reads a missing object and asserts the
+// not-found-is-success contract: Found:false, nil error (lets a poller ask
+// "gone yet?" without treating 404 as failure).
+func TestKubeExecutorGetStatus_Absent(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	snap, err := k.GetStatus(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "ghost"})
+	if err != nil {
+		t.Fatalf("GetStatus of absent object returned error %v, want nil", err)
+	}
+	if snap.Found {
+		t.Error("Found = true for an absent object, want false")
+	}
+	if snap.ResourceVersion != "" || snap.Status != nil {
+		t.Errorf("absent snapshot carries data: %+v, want zero", snap)
+	}
+}
+
+// TestKubeExecutorGetStatus_ClusterScoped reads a cluster-scoped object (namespace
+// ignored) — proves the RESTMapper scope branch and the cluster-scoped dynamic
+// client path.
+func TestKubeExecutorGetStatus_ClusterScoped(t *testing.T) {
+	vpc := &unstructured.Unstructured{}
+	vpc.SetAPIVersion("kubeovn.io/v1")
+	vpc.SetKind("Vpc")
+	vpc.SetName("vpc-1")
+	vpc.SetResourceVersion("9")
+	_ = unstructured.SetNestedField(vpc.Object, "ready", "status", "phase")
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), vpc)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	// Namespace is set on the ref but must be ignored for a cluster-scoped kind.
+	snap, err := k.GetStatus(context.Background(), ResourceRef{APIVersion: "kubeovn.io/v1", Kind: "Vpc", Namespace: "should-be-ignored", Name: "vpc-1"})
+	if err != nil {
+		t.Fatalf("GetStatus cluster-scoped: %v", err)
+	}
+	if !snap.Found || snap.ResourceVersion != "9" {
+		t.Errorf("cluster-scoped snapshot = %+v, want found rv=9", snap)
+	}
+}
+
+// ── GVK resolution failures (shared by all four verbs) ──────────────────────────
+
+// TestKubeExecutor_UnknownKind asserts an unregistered kind is a BAD_REQUEST-class
+// fault on every verb that resolves a ref. The mapper has no "Widget" kind.
+func TestKubeExecutor_UnknownKind(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+	ref := ResourceRef{APIVersion: "example.com/v1", Kind: "Widget", Namespace: "x", Name: "w-1"}
+
+	t.Run("delete", func(t *testing.T) {
+		if _, err := k.Delete(context.Background(), ref, ""); err == nil || !isBadRequestFault(err) {
+			t.Errorf("Delete unknown kind err = %v, want BAD_REQUEST fault", err)
+		}
+	})
+	t.Run("get_status", func(t *testing.T) {
+		if _, err := k.GetStatus(context.Background(), ref); err == nil || !isBadRequestFault(err) {
+			t.Errorf("GetStatus unknown kind err = %v, want BAD_REQUEST fault", err)
+		}
+	})
+	t.Run("watch_status", func(t *testing.T) {
+		if _, err := k.WatchStatus(context.Background(), ref, 1, func(string, StatusSnapshot) {}); err == nil || !isBadRequestFault(err) {
+			t.Errorf("WatchStatus unknown kind err = %v, want BAD_REQUEST fault", err)
+		}
+	})
+	t.Run("apply", func(t *testing.T) {
+		manifest := []byte(`{"apiVersion":"example.com/v1","kind":"Widget","metadata":{"name":"w-1","namespace":"x"}}`)
+		if _, err := k.Apply(context.Background(), manifest, "dc-api", false); err == nil || !isBadRequestFault(err) {
+			t.Errorf("Apply unknown kind err = %v, want BAD_REQUEST fault", err)
+		}
+	})
+}
+
+// TestKubeExecutor_MissingName asserts an empty name is a BAD_REQUEST-class fault
+// at resolve time, before any cluster call.
+func TestKubeExecutor_MissingName(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "x", Name: ""}
+	if _, err := k.GetStatus(context.Background(), ref); err == nil || !isBadRequestFault(err) {
+		t.Errorf("GetStatus missing name err = %v, want BAD_REQUEST fault", err)
+	}
+}
+
+// TestKubeExecutor_NoMapper asserts an inventory-only executor (nil RESTMapper, as
+// built by NewKubeExecutor) rejects a ref-resolving verb as BAD_REQUEST rather
+// than panicking on the nil mapper.
+func TestKubeExecutor_NoMapper(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	k := NewKubeExecutor(fake.NewSimpleClientset(), dc) // no mapper
+	if _, err := k.GetStatus(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "x", Name: "cm-1"}); err == nil || !isBadRequestFault(err) {
+		t.Errorf("GetStatus on inventory-only executor err = %v, want BAD_REQUEST fault", err)
+	}
+}
+
+// ── WatchStatus ────────────────────────────────────────────────────────────────
+//
+// The watch verb tests inject a test-controlled fake watcher via a watch reactor:
+// the test calls fw.Add/fw.Modify/fw.Stop directly and synchronizes on the emit
+// channel, so the stream is fully deterministic with no sleeps. (The dynamic
+// fake's default watcher streams tracker events but racing a Create against the
+// executor opening the watch would be timing-dependent.)
+
+// newWatchHarness returns a KubeExecutor whose ConfigMap watch is driven by the
+// returned controllable watcher.
+func newWatchHarness(t *testing.T) (*KubeExecutor, *watch.RaceFreeFakeWatcher) {
+	t.Helper()
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	fw := watch.NewRaceFreeFake()
+	dc.PrependWatchReactor("configmaps", func(ktesting.Action) (bool, watch.Interface, error) {
+		return true, fw, nil
+	})
+	return NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper()), fw
+}
+
+// TestKubeExecutorWatchStatus_EmitsAndCapsAtMax drives an ADDED then a MODIFIED
+// event and asserts the stages/snapshots emitted in order, plus termination at
+// max_snapshots with the right reason.
+func TestKubeExecutorWatchStatus_EmitsAndCapsAtMax(t *testing.T) {
+	k, fw := newWatchHarness(t)
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}
+
+	type emitted struct {
+		stage string
+		phase string
+	}
+	emits := make(chan emitted, 8)
+	done := make(chan WatchResult, 1)
+	go func() {
+		res, err := k.WatchStatus(context.Background(), ref, 2, func(stage string, snap StatusSnapshot) {
+			var s struct {
+				Phase string `json:"phase"`
+			}
+			_ = json.Unmarshal(snap.Status, &s)
+			emits <- emitted{stage: stage, phase: s.Phase}
+		})
+		if err != nil {
+			t.Errorf("WatchStatus: %v", err)
+		}
+		done <- res
+	}()
+
+	fw.Add(configMap("cm-1", "tenant-abc", "Pending"))
+	if e := <-emits; e.stage != "added" || e.phase != "Pending" {
+		t.Errorf("event 1 = %+v, want {added Pending}", e)
+	}
+	fw.Modify(configMap("cm-1", "tenant-abc", "Running"))
+	if e := <-emits; e.stage != "modified" || e.phase != "Running" {
+		t.Errorf("event 2 = %+v, want {modified Running}", e)
+	}
+
+	select {
+	case res := <-done:
+		if res.SnapshotsSent != 2 {
+			t.Errorf("SnapshotsSent = %d, want 2", res.SnapshotsSent)
+		}
+		if res.Reason != WatchReasonMaxSnapshots {
+			t.Errorf("Reason = %q, want %q", res.Reason, WatchReasonMaxSnapshots)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WatchStatus did not terminate after max_snapshots reached")
+	}
+}
+
+// TestKubeExecutorWatchStatus_DefaultMax asserts an omitted max_snapshots (0) uses
+// the documented default of 10 (not unbounded, not 0). We assert the default by
+// emitting one event under the default and confirming the stream does NOT
+// terminate at it, then closing the watch.
+func TestKubeExecutorWatchStatus_DefaultMax(t *testing.T) {
+	k, fw := newWatchHarness(t)
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}
+
+	emits := make(chan struct{}, 16)
+	done := make(chan WatchResult, 1)
+	go func() {
+		res, _ := k.WatchStatus(context.Background(), ref, 0, func(string, StatusSnapshot) { emits <- struct{}{} })
+		done <- res
+	}()
+
+	// One event: with default=10 the stream stays open (a 0 default would have
+	// terminated immediately; a 1 default would terminate here).
+	fw.Add(configMap("cm-1", "tenant-abc", "Pending"))
+	<-emits
+	select {
+	case res := <-done:
+		t.Fatalf("stream terminated after one event (sent=%d reason=%s); default max_snapshots should be %d",
+			res.SnapshotsSent, res.Reason, defaultWatchSnapshots)
+	case <-time.After(100 * time.Millisecond):
+		// Still open, as expected under the default cap.
+	}
+
+	fw.Stop()
+	select {
+	case res := <-done:
+		if res.SnapshotsSent != 1 || res.Reason != WatchReasonClosed {
+			t.Errorf("after close: sent=%d reason=%s, want sent=1 reason=%s", res.SnapshotsSent, res.Reason, WatchReasonClosed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WatchStatus did not terminate after the watch closed")
+	}
+}
+
+// TestKubeExecutorWatchStatus_CtxCancel asserts a cancelled context terminates the
+// stream with reason "deadline" and whatever snapshots were sent so far (here 0).
+func TestKubeExecutorWatchStatus_CtxCancel(t *testing.T) {
+	k, fw := newWatchHarness(t)
+	_ = fw // watcher stays idle; cancellation drives termination
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan WatchResult, 1)
+	go func() {
+		res, err := k.WatchStatus(ctx, ref, 10, func(string, StatusSnapshot) {})
+		if err != nil {
+			t.Errorf("WatchStatus on ctx-cancel returned error %v, want nil", err)
+		}
+		done <- res
+	}()
+
+	cancel()
+	select {
+	case res := <-done:
+		if res.Reason != WatchReasonDeadline {
+			t.Errorf("Reason = %q, want %q on ctx cancel", res.Reason, WatchReasonDeadline)
+		}
+		if res.SnapshotsSent != 0 {
+			t.Errorf("SnapshotsSent = %d, want 0 (no events before cancel)", res.SnapshotsSent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WatchStatus did not terminate on context cancellation")
+	}
+}
+
+// TestKubeExecutorWatchStatus_WatchClosed asserts that a closed watch channel
+// terminates the stream with reason "watch_closed".
+func TestKubeExecutorWatchStatus_WatchClosed(t *testing.T) {
+	k, fw := newWatchHarness(t)
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}
+
+	done := make(chan WatchResult, 1)
+	go func() {
+		res, err := k.WatchStatus(context.Background(), ref, 10, func(string, StatusSnapshot) {})
+		if err != nil {
+			t.Errorf("WatchStatus on watch-close returned error %v, want nil", err)
+		}
+		done <- res
+	}()
+
+	fw.Stop()
+	select {
+	case res := <-done:
+		if res.Reason != WatchReasonClosed {
+			t.Errorf("Reason = %q, want %q on watch close", res.Reason, WatchReasonClosed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WatchStatus did not terminate after the watch closed")
+	}
+}
+
+// TestKubeExecutorWatchStatus_NegativeMax asserts a negative max_snapshots is a
+// BAD_REQUEST-class fault, with no watch opened.
+func TestKubeExecutorWatchStatus_NegativeMax(t *testing.T) {
+	k, _ := newWatchHarness(t)
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}
+	if _, err := k.WatchStatus(context.Background(), ref, -1, func(string, StatusSnapshot) {}); err == nil || !isBadRequestFault(err) {
+		t.Errorf("WatchStatus(max=-1) err = %v, want BAD_REQUEST fault", err)
+	}
+}
+
+// TestKubeExecutorWatchStatus_SkipsNonAddModify asserts the watch ignores event
+// types that aren't Added/Modified (e.g. Deleted) — only status snapshots count
+// toward the cap.
+func TestKubeExecutorWatchStatus_SkipsNonAddModify(t *testing.T) {
+	k, fw := newWatchHarness(t)
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"}
+
+	emits := make(chan string, 8)
+	done := make(chan WatchResult, 1)
+	go func() {
+		res, _ := k.WatchStatus(context.Background(), ref, 1, func(stage string, _ StatusSnapshot) { emits <- stage })
+		done <- res
+	}()
+
+	// A Deleted event must NOT be emitted nor counted.
+	fw.Delete(configMap("cm-1", "tenant-abc", ""))
+	// Then a real Added event reaches the cap of 1.
+	fw.Add(configMap("cm-1", "tenant-abc", "Pending"))
+
+	if s := <-emits; s != "added" {
+		t.Errorf("first emitted stage = %q, want added (Deleted must be skipped)", s)
+	}
+	select {
+	case res := <-done:
+		if res.SnapshotsSent != 1 || res.Reason != WatchReasonMaxSnapshots {
+			t.Errorf("result = %+v, want sent=1 reason=%s", res, WatchReasonMaxSnapshots)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WatchStatus did not terminate")
 	}
 }

--- a/dc-agent/internal/protocol/protocol.go
+++ b/dc-agent/internal/protocol/protocol.go
@@ -112,11 +112,17 @@ type FrameError struct {
 
 // Progress is an optional, advisory in-flight update emitted zero or more times
 // before the terminal Res, correlated by ID. Receivers may ignore it.
+//
+// Data (added in M-B) carries a structured payload — e.g. a status snapshot for
+// watch_status. It is additive and omitempty: v0/M-A receivers decode Progress
+// into a struct without the field and encoding/json silently drops the unknown
+// key, so the wire stays backward compatible.
 type Progress struct {
-	Type   string `json:"type"`
-	ID     string `json:"id"`
-	Stage  string `json:"stage"`
-	Detail string `json:"detail,omitempty"`
+	Type   string          `json:"type"`
+	ID     string          `json:"id"`
+	Stage  string          `json:"stage"`
+	Detail string          `json:"detail,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
 }
 
 // Unknown is returned by Decode for frame types this agent version does not
@@ -152,9 +158,16 @@ func NewErrRes(id, code, message string) *Res {
 	return &Res{Type: TypeRes, ID: id, Ok: false, Error: &FrameError{Code: code, Message: message}}
 }
 
-// NewProgress builds an advisory progress frame.
+// NewProgress builds an advisory progress frame with a human-readable detail
+// string. Unchanged from M-A for existing callers.
 func NewProgress(id, stage, detail string) *Progress {
 	return &Progress{Type: TypeProgress, ID: id, Stage: stage, Detail: detail}
+}
+
+// NewProgressData builds an advisory progress frame carrying a structured Data
+// payload (M-B) — e.g. a watch_status status snapshot. Detail is left empty.
+func NewProgressData(id, stage string, data json.RawMessage) *Progress {
+	return &Progress{Type: TypeProgress, ID: id, Stage: stage, Data: data}
 }
 
 // Encode marshals a frame to its JSON wire representation.

--- a/dc-agent/internal/protocol/protocol_test.go
+++ b/dc-agent/internal/protocol/protocol_test.go
@@ -172,10 +172,84 @@ func TestV1FrameRoundTrip(t *testing.T) {
 		if !ok {
 			t.Fatalf("Decode returned %T, want *Progress", got)
 		}
-		if *p != *want {
+		// Progress carries a json.RawMessage (Data) and so is not comparable with
+		// ==; compare the scalar fields, and assert Data is absent for a
+		// detail-only NewProgress (omitempty keeps it off the wire).
+		if p.Type != want.Type || p.ID != want.ID || p.Stage != want.Stage || p.Detail != want.Detail {
 			t.Errorf("progress round-trip mismatch: got %+v, want %+v", p, want)
 		}
+		if p.Data != nil {
+			t.Errorf("progress Data = %s, want nil for a detail-only frame", p.Data)
+		}
 	})
+}
+
+// TestProgressDataRoundTrip verifies the M-B addition to the Progress frame:
+// NewProgressData carries a structured Data payload that survives a round-trip,
+// and the constructor leaves Detail empty (the streaming case uses Data, not the
+// human-readable Detail string).
+func TestProgressDataRoundTrip(t *testing.T) {
+	snapshot := json.RawMessage(`{"found":true,"resource_version":"12346","generation":7,"status":{"phase":"Running"}}`)
+	want := NewProgressData("watch-1", "modified", snapshot)
+
+	got := roundTrip(t, want)
+	p, ok := got.(*Progress)
+	if !ok {
+		t.Fatalf("Decode returned %T, want *Progress", got)
+	}
+	if p.Type != TypeProgress || p.ID != "watch-1" || p.Stage != "modified" {
+		t.Errorf("progress envelope mismatch: got %+v", p)
+	}
+	if p.Detail != "" {
+		t.Errorf("NewProgressData Detail = %q, want empty (streaming uses Data)", p.Detail)
+	}
+	// Data must round-trip byte-for-byte as raw JSON.
+	if string(p.Data) != string(snapshot) {
+		t.Errorf("progress Data = %s, want %s", p.Data, snapshot)
+	}
+}
+
+// TestProgressDataWireFormat pins the JSON the streaming path puts on the wire:
+// when Data is set it appears as the "data" key; when it is empty (the M-A
+// detail-only constructor) the key is omitted, so a v0/M-A receiver decoding into
+// a Progress without the field sees no change. This is the backward-compat
+// guarantee for the additive field.
+func TestProgressDataWireFormat(t *testing.T) {
+	// With Data set: the "data" key is present and "detail" is omitted.
+	b, err := Encode(NewProgressData("id-1", "added", json.RawMessage(`{"found":true}`)))
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if m["type"] != "progress" || m["id"] != "id-1" || m["stage"] != "added" {
+		t.Errorf("progress wire envelope wrong: %s", b)
+	}
+	data, ok := m["data"].(map[string]any)
+	if !ok || data["found"] != true {
+		t.Errorf("progress data key missing/wrong: %s", b)
+	}
+	if _, has := m["detail"]; has {
+		t.Errorf("NewProgressData must omit empty detail: %s", b)
+	}
+
+	// Detail-only (M-A) constructor: no "data" key on the wire at all.
+	b, err = Encode(NewProgress("id-2", "applying", "step 1/2"))
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	m = nil
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, has := m["data"]; has {
+		t.Errorf("detail-only NewProgress must omit data (backward compat): %s", b)
+	}
+	if m["detail"] != "step 1/2" {
+		t.Errorf("detail-only progress detail wrong: %s", b)
+	}
 }
 
 // TestReqResWireFormat pins the v1 frame JSON — the wire format is the contract

--- a/dc-agent/main.go
+++ b/dc-agent/main.go
@@ -147,34 +147,136 @@ func main() {
 	// clients; a real call happens only when the control plane requests an op.
 	// No cluster access is not fatal — the agent runs presence-only, exactly as
 	// before v1, and advertises no ops (the server returns OP_UNSUPPORTED).
-	var dispatcher conn.Dispatcher
+	var (
+		dispatcher       conn.Dispatcher
+		streamDispatcher conn.StreamDispatcher
+	)
 	if exec, err := executor.NewKubeExecutorFromConfig(cfg.kubeconfig); err != nil {
 		logger.Warn().Err(err).Msg("no local-cluster access; running presence-only (set DCAGENT_KUBECONFIG for local dev)")
 	} else {
-		dispatcher = conn.Dispatcher{
-			executor.OpGetInventory: func(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
-				inv, err := exec.GetInventory(ctx)
-				if err != nil {
-					return nil, err
-				}
-				return json.Marshal(inv)
-			},
-		}
-		logger.Info().Strs("ops", []string{executor.OpGetInventory}).Msg("local-cluster executor ready")
+		dispatcher, streamDispatcher = buildDispatchers(exec, logger)
+		logger.Info().
+			Strs("ops", []string{executor.OpGetInventory, executor.OpApply, executor.OpDelete, executor.OpGetStatus, executor.OpWatchStatus}).
+			Msg("local-cluster executor ready")
 	}
 
 	// ── Connection loop ───────────────────────────────────────────────────────
 	// Runs until the context is cancelled, reconnecting on any failure.
 	runner := conn.NewRunner(conn.Config{
-		Endpoint:   cfg.endpoint,
-		Token:      cfg.token,
-		Region:     cfg.region,
-		Zone:       cfg.zone,
-		Version:    version,
-		Logger:     logger,
-		Dispatcher: dispatcher,
+		Endpoint:         cfg.endpoint,
+		Token:            cfg.token,
+		Region:           cfg.region,
+		Zone:             cfg.zone,
+		Version:          version,
+		Logger:           logger,
+		Dispatcher:       dispatcher,
+		StreamDispatcher: streamDispatcher,
 	})
 	runner.Run(ctx)
 
 	logger.Info().Msg("dc-agent stopped")
+}
+
+// buildDispatchers wires the protocol-v1 op handlers onto exec. Each
+// request/response handler unmarshals its params, calls the matching executor
+// method, and marshals the result: a returned error becomes an EXEC_ERROR res,
+// while a conn.BadRequest-wrapped error (params-unmarshal failure) or an executor
+// BAD_REQUEST fault becomes a BAD_REQUEST res. The streaming watch_status handler
+// emits one progress frame per observed event before its terminal summary.
+//
+// It is a package-level function (not inline in main) so the wire path — params
+// field names, result shapes, error mapping — is unit-testable against an
+// executor.Stub driven through the real conn loop.
+func buildDispatchers(exec executor.Executor, logger zerolog.Logger) (conn.Dispatcher, conn.StreamDispatcher) {
+	dispatcher := conn.Dispatcher{
+		executor.OpGetInventory: func(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+			inv, err := exec.GetInventory(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(inv)
+		},
+		executor.OpApply: func(ctx context.Context, params json.RawMessage) (json.RawMessage, error) {
+			var p struct {
+				Manifest     json.RawMessage `json:"manifest"`
+				FieldManager string          `json:"field_manager"`
+				Force        bool            `json:"force"`
+			}
+			if err := json.Unmarshal(params, &p); err != nil {
+				return nil, conn.BadRequest(fmt.Errorf("apply params: %w", err))
+			}
+			res, err := exec.Apply(ctx, p.Manifest, p.FieldManager, p.Force)
+			if err != nil {
+				return nil, err
+			}
+			logger.Info().
+				Str("op", executor.OpApply).
+				Str("gvk", res.APIVersion+"/"+res.Kind).
+				Str("object", res.Namespace+"/"+res.Name).
+				Str("resource_version", res.ResourceVersion).
+				Msg("applied object")
+			return json.Marshal(res)
+		},
+		executor.OpDelete: func(ctx context.Context, params json.RawMessage) (json.RawMessage, error) {
+			var p struct {
+				executor.ResourceRef
+				PropagationPolicy string `json:"propagation_policy"`
+			}
+			if err := json.Unmarshal(params, &p); err != nil {
+				return nil, conn.BadRequest(fmt.Errorf("delete params: %w", err))
+			}
+			res, err := exec.Delete(ctx, p.ResourceRef, p.PropagationPolicy)
+			if err != nil {
+				return nil, err
+			}
+			logger.Info().
+				Str("op", executor.OpDelete).
+				Str("gvk", p.APIVersion+"/"+p.Kind).
+				Str("object", p.Namespace+"/"+p.Name).
+				Bool("existed", res.Existed).
+				Msg("deleted object")
+			return json.Marshal(res)
+		},
+		executor.OpGetStatus: func(ctx context.Context, params json.RawMessage) (json.RawMessage, error) {
+			var ref executor.ResourceRef
+			if err := json.Unmarshal(params, &ref); err != nil {
+				return nil, conn.BadRequest(fmt.Errorf("get_status params: %w", err))
+			}
+			res, err := exec.GetStatus(ctx, ref)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(res)
+		},
+	}
+	streamDispatcher := conn.StreamDispatcher{
+		executor.OpWatchStatus: func(ctx context.Context, params json.RawMessage, emit conn.Emitter) (json.RawMessage, error) {
+			var p struct {
+				executor.ResourceRef
+				MaxSnapshots int `json:"max_snapshots"`
+			}
+			if err := json.Unmarshal(params, &p); err != nil {
+				return nil, conn.BadRequest(fmt.Errorf("watch_status params: %w", err))
+			}
+			res, err := exec.WatchStatus(ctx, p.ResourceRef, p.MaxSnapshots, func(stage string, snap executor.StatusSnapshot) {
+				b, err := json.Marshal(snap)
+				if err != nil {
+					return // a snapshot that won't marshal is dropped, not fatal
+				}
+				emit(stage, b)
+			})
+			if err != nil {
+				return nil, err
+			}
+			logger.Info().
+				Str("op", executor.OpWatchStatus).
+				Str("gvk", p.APIVersion+"/"+p.Kind).
+				Str("object", p.Namespace+"/"+p.Name).
+				Int("snapshots_sent", res.SnapshotsSent).
+				Str("reason", res.Reason).
+				Msg("watch_status stream ended")
+			return json.Marshal(res)
+		},
+	}
+	return dispatcher, streamDispatcher
 }

--- a/dc-agent/main_test.go
+++ b/dc-agent/main_test.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/rs/zerolog"
+
+	"github.com/wso2/dc-agent/internal/conn"
+	"github.com/wso2/dc-agent/internal/executor"
+	"github.com/wso2/dc-agent/internal/protocol"
+)
+
+// recordingExecutor wraps an executor.Stub and captures the arguments each verb
+// received, so a dispatcher test can assert the params decoded off the wire (the
+// JSON field names in §1–§2 of the wire contract) reach the executor intact.
+type recordingExecutor struct {
+	executor.Stub
+
+	applyManifest json.RawMessage
+	applyFM        string
+	applyForce     bool
+
+	deleteRef    executor.ResourceRef
+	deletePolicy string
+
+	statusRef executor.ResourceRef
+
+	watchRef executor.ResourceRef
+	watchMax int
+}
+
+func (r *recordingExecutor) Apply(ctx context.Context, manifest json.RawMessage, fm string, force bool) (executor.ApplyResult, error) {
+	r.applyManifest, r.applyFM, r.applyForce = manifest, fm, force
+	return r.Stub.Apply(ctx, manifest, fm, force)
+}
+
+func (r *recordingExecutor) Delete(ctx context.Context, ref executor.ResourceRef, policy string) (executor.DeleteResult, error) {
+	r.deleteRef, r.deletePolicy = ref, policy
+	return r.Stub.Delete(ctx, ref, policy)
+}
+
+func (r *recordingExecutor) GetStatus(ctx context.Context, ref executor.ResourceRef) (executor.StatusSnapshot, error) {
+	r.statusRef = ref
+	return r.Stub.GetStatus(ctx, ref)
+}
+
+func (r *recordingExecutor) WatchStatus(ctx context.Context, ref executor.ResourceRef, max int, emit func(string, executor.StatusSnapshot)) (executor.WatchResult, error) {
+	r.watchRef, r.watchMax = ref, max
+	return r.Stub.WatchStatus(ctx, ref, max, emit)
+}
+
+// dispatchHarness drives buildDispatchers(exec) through the real conn.Runner loop
+// against an in-process WebSocket server. The server-side function it takes runs
+// after the handshake and exchanges req/res frames over the live socket — exactly
+// how dc-api drives the agent — then must return to end the test.
+func dispatchHarness(t *testing.T, exec executor.Executor, serverExchange func(t *testing.T, ctx context.Context, c *websocket.Conn)) {
+	t.Helper()
+	disp, stream := buildDispatchers(exec, zerolog.Nop())
+
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		c, err := websocket.Accept(w, req, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "test over")
+		ctx := req.Context()
+
+		if _, _, err := c.Read(ctx); err != nil { // hello
+			return
+		}
+		ack, _ := protocol.Encode(&protocol.HelloAck{Type: protocol.TypeHelloAck, AgentID: "agent-1"})
+		if err := c.Write(ctx, websocket.MessageText, ack); err != nil {
+			return
+		}
+
+		serverExchange(t, ctx, c)
+		close(done)
+		<-ctx.Done()
+	}))
+	defer srv.Close()
+
+	r := conn.NewRunner(conn.Config{
+		Endpoint:         "ws" + strings.TrimPrefix(srv.URL, "http"),
+		Token:            "dcagent_x",
+		Region:           "region-a",
+		Zone:             "zone-1",
+		Version:          "test",
+		Logger:           zerolog.Nop(),
+		PingInterval:     time.Hour, // keep pings out of the req/res exchange
+		Dispatcher:       disp,
+		StreamDispatcher: stream,
+	})
+
+	// Run (not runSession) is the exported entry point reachable from package
+	// main. It maintains the session and would reconnect on a drop, but the server
+	// holds the connection open until the test cancels, so exactly one session
+	// serves the whole exchange.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	runDone := make(chan struct{})
+	go func() {
+		r.Run(ctx)
+		close(runDone)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for the dispatch exchange to complete")
+	}
+
+	// Unwind the connection loop and confirm it returns promptly.
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+// sendReq writes a req and reads back the correlated terminal res. It fails the
+// test on any transport error or correlation mismatch.
+func sendReq(t *testing.T, ctx context.Context, c *websocket.Conn, id, op string, params json.RawMessage) *protocol.Res {
+	t.Helper()
+	b, _ := protocol.Encode(&protocol.Req{Type: protocol.TypeReq, ID: id, Op: op, Params: params})
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write req %q: %v", op, err)
+	}
+	_, data, err := c.Read(ctx)
+	if err != nil {
+		t.Fatalf("read res for %q: %v", op, err)
+	}
+	f, err := protocol.Decode(data)
+	if err != nil {
+		t.Fatalf("decode res for %q: %v", op, err)
+	}
+	res, ok := f.(*protocol.Res)
+	if !ok {
+		t.Fatalf("response for %q is %T, want *protocol.Res", op, f)
+	}
+	if res.ID != id {
+		t.Errorf("res id = %q, want %q (correlation broken)", res.ID, id)
+	}
+	return res
+}
+
+// TestBuildDispatchers_Apply drives the apply op end to end: the server sends an
+// apply req with a manifest/field_manager/force, and the test asserts the stub's
+// ApplyResult comes back as the res result AND that the executor saw the params
+// decoded from the wire field names.
+func TestBuildDispatchers_Apply(t *testing.T) {
+	exec := &recordingExecutor{Stub: executor.Stub{
+		ApplyRes: executor.ApplyResult{
+			APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine",
+			Namespace: "tenant-abc", Name: "vm-1", UID: "u-1", ResourceVersion: "12345",
+		},
+	}}
+
+	dispatchHarness(t, exec, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		params := json.RawMessage(`{"manifest":{"apiVersion":"kubevirt.io/v1","kind":"VirtualMachine","metadata":{"name":"vm-1","namespace":"tenant-abc"}},"field_manager":"dc-api","force":true}`)
+		res := sendReq(t, ctx, c, "id-apply", executor.OpApply, params)
+		if !res.Ok {
+			t.Fatalf("apply res not ok: %+v", res)
+		}
+		var got executor.ApplyResult
+		if err := json.Unmarshal(res.Result, &got); err != nil {
+			t.Fatalf("unmarshal apply result: %v", err)
+		}
+		if !reflect.DeepEqual(got, exec.ApplyRes) {
+			t.Errorf("apply result = %+v, want %+v", got, exec.ApplyRes)
+		}
+	})
+
+	// The executor must have received the params decoded from the wire.
+	if exec.applyFM != "dc-api" || !exec.applyForce {
+		t.Errorf("executor saw field_manager=%q force=%v, want dc-api/true", exec.applyFM, exec.applyForce)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(exec.applyManifest, &manifest); err != nil {
+		t.Fatalf("executor manifest not valid JSON: %v", err)
+	}
+	if manifest["kind"] != "VirtualMachine" {
+		t.Errorf("executor manifest kind = %v, want VirtualMachine", manifest["kind"])
+	}
+}
+
+// TestBuildDispatchers_Delete drives the delete op and asserts the Existed result
+// and that the ref + propagation_policy reached the executor.
+func TestBuildDispatchers_Delete(t *testing.T) {
+	exec := &recordingExecutor{Stub: executor.Stub{DeleteRes: executor.DeleteResult{Existed: true}}}
+
+	dispatchHarness(t, exec, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		params := json.RawMessage(`{"api_version":"kubevirt.io/v1","kind":"VirtualMachine","namespace":"tenant-abc","name":"vm-1","propagation_policy":"Foreground"}`)
+		res := sendReq(t, ctx, c, "id-del", executor.OpDelete, params)
+		if !res.Ok {
+			t.Fatalf("delete res not ok: %+v", res)
+		}
+		var got executor.DeleteResult
+		if err := json.Unmarshal(res.Result, &got); err != nil {
+			t.Fatalf("unmarshal delete result: %v", err)
+		}
+		if !got.Existed {
+			t.Errorf("delete result Existed = false, want true")
+		}
+	})
+
+	want := executor.ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	if exec.deleteRef != want {
+		t.Errorf("executor delete ref = %+v, want %+v", exec.deleteRef, want)
+	}
+	if exec.deletePolicy != "Foreground" {
+		t.Errorf("executor propagation policy = %q, want Foreground", exec.deletePolicy)
+	}
+}
+
+// TestBuildDispatchers_GetStatus drives get_status and asserts the snapshot
+// round-trips and the ref reached the executor.
+func TestBuildDispatchers_GetStatus(t *testing.T) {
+	exec := &recordingExecutor{Stub: executor.Stub{StatusRes: executor.StatusSnapshot{
+		Found: true, ResourceVersion: "12345", Generation: 7, Status: json.RawMessage(`{"phase":"Running"}`),
+	}}}
+
+	dispatchHarness(t, exec, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		params := json.RawMessage(`{"api_version":"kubevirt.io/v1","kind":"VirtualMachine","namespace":"tenant-abc","name":"vm-1"}`)
+		res := sendReq(t, ctx, c, "id-status", executor.OpGetStatus, params)
+		if !res.Ok {
+			t.Fatalf("get_status res not ok: %+v", res)
+		}
+		var got executor.StatusSnapshot
+		if err := json.Unmarshal(res.Result, &got); err != nil {
+			t.Fatalf("unmarshal status result: %v", err)
+		}
+		if !got.Found || got.ResourceVersion != "12345" || got.Generation != 7 || string(got.Status) != `{"phase":"Running"}` {
+			t.Errorf("status snapshot = %+v, want found rv=12345 gen=7 phase=Running", got)
+		}
+	})
+
+	want := executor.ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	if exec.statusRef != want {
+		t.Errorf("executor status ref = %+v, want %+v", exec.statusRef, want)
+	}
+}
+
+// TestBuildDispatchers_WatchStatus drives the streaming watch_status op: the stub
+// emits two snapshots, and the test asserts two progress frames (with data)
+// precede the terminal summary res, all correlated, and that max_snapshots reached
+// the executor.
+func TestBuildDispatchers_WatchStatus(t *testing.T) {
+	exec := &recordingExecutor{Stub: executor.Stub{
+		WatchEmits: []executor.StatusSnapshot{
+			{Found: true, ResourceVersion: "1", Status: json.RawMessage(`{"phase":"Pending"}`)},
+			{Found: true, ResourceVersion: "2", Status: json.RawMessage(`{"phase":"Running"}`)},
+		},
+		WatchRes: executor.WatchResult{SnapshotsSent: 2, Reason: executor.WatchReasonMaxSnapshots},
+	}}
+
+	dispatchHarness(t, exec, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		params := json.RawMessage(`{"api_version":"kubevirt.io/v1","kind":"VirtualMachine","namespace":"tenant-abc","name":"vm-1","max_snapshots":5}`)
+		b, _ := protocol.Encode(&protocol.Req{Type: protocol.TypeReq, ID: "id-watch", Op: executor.OpWatchStatus, Params: params})
+		if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+			t.Fatalf("write watch req: %v", err)
+		}
+
+		var progresses []*protocol.Progress
+		for {
+			_, data, err := c.Read(ctx)
+			if err != nil {
+				t.Fatalf("read stream frame: %v", err)
+			}
+			f, err := protocol.Decode(data)
+			if err != nil {
+				t.Fatalf("decode stream frame: %v", err)
+			}
+			switch fr := f.(type) {
+			case *protocol.Progress:
+				if fr.ID != "id-watch" {
+					t.Errorf("progress id = %q, want id-watch", fr.ID)
+				}
+				progresses = append(progresses, fr)
+			case *protocol.Res:
+				if fr.ID != "id-watch" || !fr.Ok {
+					t.Fatalf("terminal res = %+v, want ok id-watch", fr)
+				}
+				var summary executor.WatchResult
+				if err := json.Unmarshal(fr.Result, &summary); err != nil {
+					t.Fatalf("unmarshal watch summary: %v", err)
+				}
+				if summary.SnapshotsSent != 2 || summary.Reason != executor.WatchReasonMaxSnapshots {
+					t.Errorf("watch summary = %+v, want sent=2 reason=max_snapshots", summary)
+				}
+				if len(progresses) != 2 {
+					t.Fatalf("got %d progress frames, want 2 before the res", len(progresses))
+				}
+				// Each progress frame's data is a marshaled StatusSnapshot.
+				var snap0 executor.StatusSnapshot
+				if err := json.Unmarshal(progresses[0].Data, &snap0); err != nil {
+					t.Fatalf("unmarshal progress[0] data: %v", err)
+				}
+				if snap0.ResourceVersion != "1" || string(snap0.Status) != `{"phase":"Pending"}` {
+					t.Errorf("progress[0] snapshot = %+v, want rv=1 phase=Pending", snap0)
+				}
+				return
+			default:
+				t.Fatalf("unexpected frame %T in stream", fr)
+			}
+		}
+	})
+
+	if exec.watchMax != 5 {
+		t.Errorf("executor max_snapshots = %d, want 5", exec.watchMax)
+	}
+	want := executor.ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	if exec.watchRef != want {
+		t.Errorf("executor watch ref = %+v, want %+v", exec.watchRef, want)
+	}
+}
+
+// TestBuildDispatchers_BadParams asserts that malformed params for each verb map
+// to a BAD_REQUEST res (the conn.BadRequest path), not EXEC_ERROR — exercising the
+// real unmarshal-failure handling in the main.go closures.
+func TestBuildDispatchers_BadParams(t *testing.T) {
+	exec := &recordingExecutor{}
+
+	dispatchHarness(t, exec, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		bad := json.RawMessage(`"not an object"`)
+		for _, op := range []string{executor.OpApply, executor.OpDelete, executor.OpGetStatus, executor.OpWatchStatus} {
+			res := sendReq(t, ctx, c, "id-"+op, op, bad)
+			if res.Ok || res.Error == nil || res.Error.Code != protocol.ErrCodeBadRequest {
+				t.Errorf("%s with bad params res = %+v, want BAD_REQUEST", op, res)
+			}
+		}
+	})
+}
+
+// TestBuildDispatchers_RegistersAllOps asserts buildDispatchers wires exactly the
+// five M-B ops: the four request/response verbs in Dispatcher and watch_status in
+// StreamDispatcher. The hello advertisement (the merge of these two maps, sorted)
+// is covered in the conn package's TestAdvertisedOps; here we pin the registration
+// so a verb added to the executor without a handler is caught.
+func TestBuildDispatchers_RegistersAllOps(t *testing.T) {
+	disp, stream := buildDispatchers(&recordingExecutor{}, zerolog.Nop())
+
+	wantRR := []string{executor.OpApply, executor.OpDelete, executor.OpGetInventory, executor.OpGetStatus}
+	for _, op := range wantRR {
+		if _, ok := disp[op]; !ok {
+			t.Errorf("Dispatcher missing request/response op %q", op)
+		}
+	}
+	if len(disp) != len(wantRR) {
+		t.Errorf("Dispatcher has %d ops, want %d (%v)", len(disp), len(wantRR), wantRR)
+	}
+	if _, ok := stream[executor.OpWatchStatus]; !ok {
+		t.Errorf("StreamDispatcher missing %q", executor.OpWatchStatus)
+	}
+	if len(stream) != 1 {
+		t.Errorf("StreamDispatcher has %d ops, want 1 (watch_status)", len(stream))
+	}
+}

--- a/dc-api/internal/api/handlers/agentchannel.go
+++ b/dc-api/internal/api/handlers/agentchannel.go
@@ -45,6 +45,13 @@ const (
 	errCodeExecError     = "EXEC_ERROR"
 
 	opGetInventory = "get_inventory"
+
+	// M-B mutating/status verbs (protocol v1). These exact strings are the wire
+	// contract with dc-agent; the two are separate Go modules.
+	opApply       = "apply"
+	opDelete      = "delete"
+	opGetStatus   = "get_status"
+	opWatchStatus = "watch_status"
 )
 
 // wsReq / wsRes / wsProgress are the server-side mirror of dc-agent's v1 frames
@@ -67,6 +74,89 @@ type wsRes struct {
 type wsFrameError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+// wsProgress is an advisory, mid-flight frame an agent emits for a streaming op
+// (watch_status), correlated to the in-flight req by ID. Data carries an
+// op-specific structured payload (a status snapshot for watch_status); it is an
+// additive, omitempty field — an older receiver ignores the unknown key.
+type wsProgress struct {
+	Type   string          `json:"type"`
+	ID     string          `json:"id"`
+	Stage  string          `json:"stage"`
+	Detail string          `json:"detail,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+// ── M-B op param/result shapes ───────────────────────────────────────────────
+//
+// These mirror dc-agent's executor structs by JSON tag only (no shared Go
+// package): the field names below ARE the wire contract. dc-api builds the
+// reference from objects it already holds, so it addresses by GVK
+// (api_version + kind), not GVR — the agent owns the GVK→GVR mapping.
+
+// ResourceRef identifies one Kubernetes object by GVK + namespace/name. It is
+// embedded inline (not nested) in delete/get_status/watch_status params.
+type ResourceRef struct {
+	APIVersion string `json:"api_version"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name"`
+}
+
+// applyParams is the request body for the apply op: a full manifest plus the SSA
+// field manager and force-conflicts flag.
+type applyParams struct {
+	Manifest     json.RawMessage `json:"manifest"`
+	FieldManager string          `json:"field_manager,omitempty"`
+	Force        bool            `json:"force,omitempty"`
+}
+
+// ApplyResult is the apply op's result: the applied object's identity and its
+// post-apply version.
+type ApplyResult struct {
+	APIVersion      string `json:"api_version"`
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace,omitempty"`
+	Name            string `json:"name"`
+	UID             string `json:"uid"`
+	ResourceVersion string `json:"resource_version"`
+}
+
+// deleteParams is the request body for the delete op: a ResourceRef plus an
+// optional propagation policy.
+type deleteParams struct {
+	ResourceRef
+	PropagationPolicy string `json:"propagation_policy,omitempty"`
+}
+
+// DeleteResult is the delete op's result. Existed is false when the object was
+// already absent (a 404 is a successful, idempotent delete — not an error).
+type DeleteResult struct {
+	Existed bool `json:"existed"`
+}
+
+// StatusSnapshot is the result of get_status AND the payload of each
+// watch_status progress frame — one shape for both the single read and the
+// stream. Found is false when the object is absent (not an error).
+type StatusSnapshot struct {
+	Found           bool            `json:"found"`
+	ResourceVersion string          `json:"resource_version,omitempty"`
+	Generation      int64           `json:"generation,omitempty"`
+	Status          json.RawMessage `json:"status,omitempty"`
+}
+
+// watchStatusParams is the request body for the watch_status op: a ResourceRef
+// plus the stream's snapshot cap.
+type watchStatusParams struct {
+	ResourceRef
+	MaxSnapshots int `json:"max_snapshots,omitempty"`
+}
+
+// WatchResult is the terminal summary of a watch_status stream.
+type WatchResult struct {
+	SnapshotsSent int    `json:"snapshots_sent"`
+	Reason        string `json:"reason"`
 }
 
 // ErrAgentUnavailable is returned when no live agent session exists for a zone,
@@ -98,11 +188,28 @@ type Session struct {
 	// interleave on the wire.
 	writeMu sync.Mutex
 
-	// mu guards pending and closed.
+	// mu guards pending, streams, and closed.
 	mu      sync.Mutex
 	pending map[string]chan *wsRes
+	// streams routes progress frames to an in-flight WatchStatus, keyed by req
+	// id. It is separate from pending (which is single-shot, terminal-only):
+	// progress is multi-shot, the terminal res still flows through pending.
+	//
+	// Each value is a per-watch buffered channel. deliverProgress (on the Serve
+	// read goroutine) does a NON-BLOCKING send onto it; WatchStatus (on the
+	// caller's goroutine) drains it and runs onSnapshot. Routing progress through
+	// a channel — rather than calling a sink inline on the Serve goroutine — means
+	// a slow onSnapshot can never head-of-line-block the single reader, and
+	// onSnapshot can never fire after WatchStatus has returned.
+	streams map[string]chan *wsProgress
 	closed  bool
 }
+
+// watchProgressBuffer is the per-watch progress channel's buffer. A watch that
+// can't keep up drops the oldest-beyond-buffer snapshots (deliverProgress's
+// non-blocking send) rather than stalling the Serve reader — snapshots are
+// advisory and the terminal res is authoritative.
+const watchProgressBuffer = 16
 
 func newSession(conn *websocket.Conn, region, zone string, log zerolog.Logger) *Session {
 	return &Session{
@@ -111,6 +218,7 @@ func newSession(conn *websocket.Conn, region, zone string, log zerolog.Logger) *
 		zone:    zone,
 		log:     log,
 		pending: make(map[string]chan *wsRes),
+		streams: make(map[string]chan *wsProgress),
 	}
 }
 
@@ -161,11 +269,172 @@ func (s *Session) Call(ctx context.Context, op string, params json.RawMessage) (
 	}
 }
 
+// ── M-B op drivers ───────────────────────────────────────────────────────────
+//
+// Apply / Delete / GetStatus are thin wrappers over Call (marshal params →
+// Call → unmarshal result), mirroring how inventory.go drives get_inventory.
+// Errors from Call (*AgentError, ErrAgentUnavailable, ctx.Err()) pass through
+// unchanged for the caller to map to an HTTP status.
+
+// Apply server-side-applies manifest in the agent's zone cluster. fieldManager
+// defaults to "dc-api" on the agent when empty; force toggles SSA
+// force-conflicts. It returns the applied object's identity and version.
+func (s *Session) Apply(ctx context.Context, manifest json.RawMessage, fieldManager string, force bool) (ApplyResult, error) {
+	var res ApplyResult
+	params, err := json.Marshal(applyParams{Manifest: manifest, FieldManager: fieldManager, Force: force})
+	if err != nil {
+		return res, err
+	}
+	raw, err := s.Call(ctx, opApply, params)
+	if err != nil {
+		return res, err
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return ApplyResult{}, err
+	}
+	return res, nil
+}
+
+// Delete removes the referenced object. A missing object is a successful,
+// idempotent delete (DeleteResult.Existed == false), not an error.
+// propagationPolicy, when non-empty, is one of Foreground/Background/Orphan.
+func (s *Session) Delete(ctx context.Context, ref ResourceRef, propagationPolicy string) (DeleteResult, error) {
+	var res DeleteResult
+	params, err := json.Marshal(deleteParams{ResourceRef: ref, PropagationPolicy: propagationPolicy})
+	if err != nil {
+		return res, err
+	}
+	raw, err := s.Call(ctx, opDelete, params)
+	if err != nil {
+		return res, err
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return DeleteResult{}, err
+	}
+	return res, nil
+}
+
+// GetStatus reads the referenced object's status once. A missing object yields
+// StatusSnapshot{Found: false}, not an error — a reconciler can poll for "gone
+// yet?" without treating a 404 as a failure.
+func (s *Session) GetStatus(ctx context.Context, ref ResourceRef) (StatusSnapshot, error) {
+	var res StatusSnapshot
+	params, err := json.Marshal(ref)
+	if err != nil {
+		return res, err
+	}
+	raw, err := s.Call(ctx, opGetStatus, params)
+	if err != nil {
+		return res, err
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return StatusSnapshot{}, err
+	}
+	return res, nil
+}
+
+// WatchStatus drives the watch_status streaming op: it sends one req and invokes
+// onSnapshot for each progress frame the agent emits (correlated by id), then
+// returns the terminal summary. It blocks until the terminal res, ctx is done,
+// or the session dies (ErrAgentUnavailable).
+//
+// Unlike Call, it registers BOTH a terminal waiter (in pending) and a progress
+// channel (in streams) under one id, because Call's one-shot waiter has no
+// progress hook and deletes itself on return.
+//
+// onSnapshot is invoked ONLY from this function's own select loop, on the
+// caller's goroutine — never on the Serve read goroutine. deliverProgress just
+// does a non-blocking send onto the per-watch buffered channel drained here, so
+// (a) a slow onSnapshot cannot head-of-line-block the single Serve reader (it
+// would only fill this watch's buffer, then drop), and (b) onSnapshot can never
+// fire after WatchStatus has returned — once the select exits, the deferred
+// cleanup removes the channel and nothing else reads it.
+func (s *Session) WatchStatus(
+	ctx context.Context,
+	ref ResourceRef,
+	maxSnapshots int,
+	onSnapshot func(stage string, snap StatusSnapshot),
+) (WatchResult, error) {
+	var zero WatchResult
+
+	params, err := json.Marshal(watchStatusParams{ResourceRef: ref, MaxSnapshots: maxSnapshots})
+	if err != nil {
+		return zero, err
+	}
+
+	id := uuid.NewString()
+	ch := make(chan *wsRes, 1)
+	progressCh := make(chan *wsProgress, watchProgressBuffer)
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return zero, ErrAgentUnavailable
+	}
+	s.pending[id] = ch
+	s.streams[id] = progressCh
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.pending, id)
+		delete(s.streams, id)
+		s.mu.Unlock()
+	}()
+
+	if err := s.writeFrame(ctx, wsReq{Type: wsTypeReq, ID: id, Op: opWatchStatus, Params: params}); err != nil {
+		return zero, err
+	}
+
+	// deliver a single progress frame to onSnapshot, on this (the caller's)
+	// goroutine. An undecodable snapshot is dropped, not fatal — the stream
+	// continues.
+	deliver := func(p *wsProgress) {
+		if onSnapshot == nil {
+			return
+		}
+		var snap StatusSnapshot
+		if len(p.Data) > 0 {
+			if err := json.Unmarshal(p.Data, &snap); err != nil {
+				s.log.Warn().Err(err).Str("id", p.ID).Msg("dropping undecodable watch_status snapshot")
+				return
+			}
+		}
+		onSnapshot(p.Stage, snap)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		case p := <-progressCh:
+			deliver(p)
+		case res := <-ch:
+			if res == nil { // session closed under us
+				return zero, ErrAgentUnavailable
+			}
+			if !res.Ok {
+				code, msg := errCodeExecError, ""
+				if res.Error != nil {
+					code, msg = res.Error.Code, res.Error.Message
+				}
+				return zero, &AgentError{Code: code, Message: msg}
+			}
+			var out WatchResult
+			if err := json.Unmarshal(res.Result, &out); err != nil {
+				return zero, err
+			}
+			return out, nil
+		}
+	}
+}
+
 // Serve runs the steady-state read loop until the agent disconnects or goes
 // silent past serverReadDeadline. It is the only reader of the socket: pings are
-// answered with pongs, res frames are routed to the waiting Call, progress is
-// advisory (ignored in M-A), and unknown types are tolerated. onActivity (may be
-// nil) fires on every inbound frame so the caller can refresh liveness.
+// answered with pongs, res frames are routed to the waiting Call, progress
+// frames are routed to an in-flight WatchStatus stream (or dropped if none),
+// and unknown types are tolerated. onActivity (may be nil) fires on every
+// inbound frame so the caller can refresh liveness.
 //
 // It returns a short, human-readable reason for the disconnect (clean close,
 // idle timeout, server shutdown, or transport error) so the caller can attribute
@@ -205,8 +474,12 @@ func (s *Session) Serve(ctx context.Context, onActivity func()) string {
 			}
 			s.deliver(&res)
 		case wsTypeProgress:
-			// Advisory; no streaming consumer in M-A.
-			s.log.Debug().Msg("ignoring progress frame (no consumer in M-A)")
+			var p wsProgress
+			if err := json.Unmarshal(data, &p); err != nil {
+				s.log.Warn().Err(err).Msg("dropping undecodable progress frame")
+				continue
+			}
+			s.deliverProgress(&p)
 		default:
 			// Forward compatibility: tolerate unknown / future frame types.
 			s.log.Debug().Str("frame_type", env.Type).Msg("ignoring unhandled agent frame")
@@ -249,6 +522,30 @@ func (s *Session) deliver(res *wsRes) {
 	}
 }
 
+// deliverProgress routes a progress frame to its in-flight WatchStatus stream's
+// buffered channel. A frame whose id has no registered stream (a stray frame, or
+// one arriving after the watch ended or the session closed) is dropped. The send
+// is NON-BLOCKING by design: this runs on the single Serve read goroutine, so it
+// must never block on a slow consumer (which would head-of-line-block every other
+// Call's res frame). If the watch's buffer is full the snapshot is dropped —
+// snapshots are advisory; the terminal res, routed through pending, is
+// authoritative. onSnapshot is NOT run here; WatchStatus drains the channel on
+// the caller's goroutine.
+func (s *Session) deliverProgress(p *wsProgress) {
+	s.mu.Lock()
+	ch, ok := s.streams[p.ID]
+	s.mu.Unlock()
+	if !ok {
+		s.log.Debug().Str("id", p.ID).Msg("progress for unknown/closed stream; dropping")
+		return
+	}
+	select {
+	case ch <- p:
+	default:
+		s.log.Warn().Str("id", p.ID).Msg("watch buffer full; dropping snapshot")
+	}
+}
+
 // close marks the session dead and fails every in-flight Call so callers return
 // promptly instead of waiting out their own deadline. Idempotent.
 func (s *Session) close() {
@@ -259,8 +556,18 @@ func (s *Session) close() {
 	}
 	s.closed = true
 	for id, ch := range s.pending {
-		ch <- nil // signal "closed" to Call
+		ch <- nil // signal "closed" to Call (incl. a WatchStatus terminal waiter)
 		delete(s.pending, id)
+	}
+	// Drop every progress channel so no late progress is routed after close. The
+	// matching pending-terminal waiter above already unblocked any WatchStatus
+	// select with nil → ErrAgentUnavailable, so it returns without draining what
+	// remains. We delete (rather than close) the channels: deliverProgress holds
+	// s.mu while sending, so once a channel is unreachable here no further send
+	// can target it, and an un-closed buffered channel is simply garbage-collected
+	// — this avoids any send-on-closed-channel hazard.
+	for id := range s.streams {
+		delete(s.streams, id)
 	}
 }
 

--- a/dc-api/internal/api/handlers/agentchannel_mb_test.go
+++ b/dc-api/internal/api/handlers/agentchannel_mb_test.go
@@ -1,0 +1,896 @@
+package handlers
+
+// agentchannel_mb_test.go — unit tests for the protocol-v1 M-B mutating/status
+// verbs on the dc-api side: Session.{Apply,Delete,GetStatus,WatchStatus}.
+//
+// These reuse the in-process channel harness from agentchannel_test.go
+// (newTestChannel + runAgent): an httptest server runs the server-side
+// Session.Serve loop and the test drives the agent end of the socket, returning
+// crafted res/progress JSON. No live cluster, no dc-agent package — only the
+// JSON wire contract.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// resErr crafts a terminal res with ok=false and a {code,message} error, the
+// agent's failure reply for any op.
+func resErr(id, code, msg string) string {
+	return `{"type":"res","id":"` + id + `","ok":false,"error":{"code":"` + code + `","message":"` + msg + `"}}`
+}
+
+// progressFrame crafts a watch_status progress frame correlated by id, carrying
+// a status snapshot in data (the §2.5 encoding).
+func progressFrame(id, stage, dataJSON string) string {
+	return `{"type":"progress","id":"` + id + `","stage":"` + stage + `","data":` + dataJSON + `}`
+}
+
+// runAgentMulti plays the agent for streaming ops: for each req it calls
+// respond(req) for an ordered slice of frame strings, written in sequence under
+// one write mutex. This is the multi-frame analogue of runAgent (which sends a
+// single reply) — used to emit N progress frames followed by a terminal res for
+// one watch_status req, with the frame ordering the wire guarantees.
+func (tc *testChannel) runAgentMulti(respond func(req wsReq) []string) {
+	var writeMu sync.Mutex
+	go func() {
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+			_, data, err := tc.client.Read(ctx)
+			cancel()
+			if err != nil {
+				return
+			}
+			var req wsReq
+			if json.Unmarshal(data, &req) != nil {
+				continue
+			}
+			go func(req wsReq) {
+				frames := respond(req)
+				for _, f := range frames {
+					if f == "" {
+						continue
+					}
+					wctx, wcancel := context.WithTimeout(context.Background(), 3*time.Second)
+					writeMu.Lock()
+					_ = tc.client.Write(wctx, websocket.MessageText, []byte(f))
+					writeMu.Unlock()
+					wcancel()
+				}
+			}(req)
+		}
+	}()
+}
+
+// ── Apply ────────────────────────────────────────────────────────────────────
+
+func TestSessionApply_Success(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	type seen struct {
+		op     string
+		params applyParams
+	}
+	got := make(chan seen, 1)
+	const result = `{"api_version":"kubevirt.io/v1","kind":"VirtualMachine","namespace":"tenant-abc","name":"vm-1","uid":"abc-123","resource_version":"12345"}`
+	tc.runAgent(func(req wsReq) string {
+		var p applyParams
+		_ = json.Unmarshal(req.Params, &p)
+		got <- seen{op: req.Op, params: p}
+		return resOK(req.ID, result)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	manifest := json.RawMessage(`{"apiVersion":"kubevirt.io/v1","kind":"VirtualMachine","metadata":{"name":"vm-1","namespace":"tenant-abc"}}`)
+	res, err := tc.sess.Apply(ctx, manifest, "dc-api", true)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Assert the result unmarshaled.
+	want := ApplyResult{
+		APIVersion:      "kubevirt.io/v1",
+		Kind:            "VirtualMachine",
+		Namespace:       "tenant-abc",
+		Name:            "vm-1",
+		UID:             "abc-123",
+		ResourceVersion: "12345",
+	}
+	if res != want {
+		t.Errorf("ApplyResult = %+v, want %+v", res, want)
+	}
+
+	// Assert the agent saw op=="apply" and the params carried manifest/field_manager/force.
+	s := <-got
+	if s.op != opApply {
+		t.Errorf("agent saw op %q, want %q", s.op, opApply)
+	}
+	if s.params.FieldManager != "dc-api" {
+		t.Errorf("field_manager = %q, want dc-api", s.params.FieldManager)
+	}
+	if !s.params.Force {
+		t.Error("force = false, want true")
+	}
+	if !json.Valid(s.params.Manifest) || !strings.Contains(string(s.params.Manifest), `"kind":"VirtualMachine"`) {
+		t.Errorf("manifest not passed through: %s", s.params.Manifest)
+	}
+}
+
+func TestSessionApply_AgentError(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resErr(req.ID, errCodeExecError, "ssa conflict")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := tc.sess.Apply(ctx, json.RawMessage(`{}`), "", false)
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeExecError || ae.Message != "ssa conflict" {
+		t.Errorf("AgentError = %+v", ae)
+	}
+}
+
+// TestSessionApply_BadRequest covers the agent-side BAD_REQUEST: a manifest that
+// is valid JSON but not a usable Kubernetes object (e.g. missing kind) reaches
+// the agent, which rejects it. The driver surfaces *AgentError{Code:BAD_REQUEST}.
+// Note: a manifest that is not even valid JSON fails earlier, at the dc-api
+// marshal boundary (json.RawMessage) — see TestSessionApply_InvalidManifestJSON.
+func TestSessionApply_BadRequest(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resErr(req.ID, errCodeBadRequest, "manifest missing kind")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// Valid JSON, but not a usable manifest (no apiVersion/kind) — the agent
+	// rejects it after it arrives.
+	_, err := tc.sess.Apply(ctx, json.RawMessage(`{"foo":"bar"}`), "", false)
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeBadRequest {
+		t.Errorf("code = %q, want %q", ae.Code, errCodeBadRequest)
+	}
+}
+
+// TestSessionApply_InvalidManifestJSON documents the local-marshal boundary: a
+// manifest that is not valid JSON fails inside Apply when it marshals
+// applyParams (a json.RawMessage must be valid JSON), before any agent round
+// trip. The error is a marshal error, NOT an *AgentError — there is no agent
+// involved, so it cannot be a BAD_REQUEST reply.
+func TestSessionApply_InvalidManifestJSON(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		t.Error("agent received a req for an invalid-JSON manifest; it should fail locally")
+		return resOK(req.ID, `{}`)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := tc.sess.Apply(ctx, json.RawMessage(`not-json`), "", false)
+	if err == nil {
+		t.Fatal("want a local marshal error, got nil")
+	}
+	var ae *AgentError
+	if errors.As(err, &ae) {
+		t.Fatalf("want a local marshal error, got *AgentError %v", err)
+	}
+}
+
+// ── Delete ───────────────────────────────────────────────────────────────────
+
+func TestSessionDelete_Existed(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	type seen struct {
+		op     string
+		params deleteParams
+	}
+	got := make(chan seen, 1)
+	tc.runAgent(func(req wsReq) string {
+		var p deleteParams
+		_ = json.Unmarshal(req.Params, &p)
+		got <- seen{op: req.Op, params: p}
+		return resOK(req.ID, `{"existed":true}`)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	res, err := tc.sess.Delete(ctx, ref, "Foreground")
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !res.Existed {
+		t.Error("Existed = false, want true")
+	}
+
+	s := <-got
+	if s.op != opDelete {
+		t.Errorf("agent saw op %q, want %q", s.op, opDelete)
+	}
+	if s.params.ResourceRef != ref {
+		t.Errorf("ref = %+v, want %+v", s.params.ResourceRef, ref)
+	}
+	if s.params.PropagationPolicy != "Foreground" {
+		t.Errorf("propagation_policy = %q, want Foreground", s.params.PropagationPolicy)
+	}
+}
+
+// TestSessionDelete_Absent covers the idempotent-delete decision: a missing
+// object is success with existed:false, NOT an error.
+func TestSessionDelete_Absent(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resOK(req.ID, `{"existed":false}`)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "gone"}
+	res, err := tc.sess.Delete(ctx, ref, "")
+	if err != nil {
+		t.Fatalf("Delete of absent object errored: %v", err)
+	}
+	if res.Existed {
+		t.Error("Existed = true, want false for an already-absent object")
+	}
+}
+
+func TestSessionDelete_BadRequest(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resErr(req.ID, errCodeBadRequest, "invalid propagation policy")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	_, err := tc.sess.Delete(ctx, ref, "Nope")
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeBadRequest {
+		t.Errorf("code = %q, want %q", ae.Code, errCodeBadRequest)
+	}
+}
+
+// ── GetStatus ──────────────────────────────────────────────────────────────────
+
+func TestSessionGetStatus_Found(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	gotOp := make(chan string, 1)
+	gotRef := make(chan ResourceRef, 1)
+	const result = `{"found":true,"resource_version":"12345","generation":7,"status":{"phase":"Running","ready":true}}`
+	tc.runAgent(func(req wsReq) string {
+		var ref ResourceRef
+		_ = json.Unmarshal(req.Params, &ref)
+		gotOp <- req.Op
+		gotRef <- ref
+		return resOK(req.ID, result)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	res, err := tc.sess.GetStatus(ctx, ref)
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if !res.Found {
+		t.Error("Found = false, want true")
+	}
+	if res.ResourceVersion != "12345" {
+		t.Errorf("ResourceVersion = %q, want 12345", res.ResourceVersion)
+	}
+	if res.Generation != 7 {
+		t.Errorf("Generation = %d, want 7", res.Generation)
+	}
+	var status struct {
+		Phase string `json:"phase"`
+		Ready bool   `json:"ready"`
+	}
+	if err := json.Unmarshal(res.Status, &status); err != nil {
+		t.Fatalf("status did not round-trip: %v", err)
+	}
+	if status.Phase != "Running" || !status.Ready {
+		t.Errorf("status = %+v, want {Running true}", status)
+	}
+
+	if op := <-gotOp; op != opGetStatus {
+		t.Errorf("agent saw op %q, want %q", op, opGetStatus)
+	}
+	if r := <-gotRef; r != ref {
+		t.Errorf("ref = %+v, want %+v", r, ref)
+	}
+}
+
+// TestSessionGetStatus_Absent covers the not-found-is-success decision: a
+// missing object yields Found:false with no error, so a reconciler can poll for
+// "gone yet?" without treating a 404 as a failure.
+func TestSessionGetStatus_Absent(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resOK(req.ID, `{"found":false}`)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "gone"}
+	res, err := tc.sess.GetStatus(ctx, ref)
+	if err != nil {
+		t.Fatalf("GetStatus of absent object errored: %v", err)
+	}
+	if res.Found {
+		t.Error("Found = true, want false for an absent object")
+	}
+	if res.ResourceVersion != "" || res.Generation != 0 || res.Status != nil {
+		t.Errorf("absent snapshot carried data: %+v", res)
+	}
+}
+
+func TestSessionGetStatus_AgentError(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resErr(req.ID, errCodeExecError, "read failed")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "ns", Name: "cm"}
+	_, err := tc.sess.GetStatus(ctx, ref)
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeExecError {
+		t.Errorf("code = %q, want %q", ae.Code, errCodeExecError)
+	}
+}
+
+// ── Error pass-through (shared mapping inputs) ─────────────────────────────────
+
+// TestSessionMutating_OpUnsupported confirms an agent that doesn't advertise a
+// verb replies ok=false/OP_UNSUPPORTED and the driver surfaces *AgentError with
+// that code (which writeCallError maps to 501) — the v0/M-A-agent safety net.
+func TestSessionMutating_OpUnsupported(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resErr(req.ID, errCodeOpUnsupported, "unknown op")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := tc.sess.Apply(ctx, json.RawMessage(`{}`), "", false)
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeOpUnsupported {
+		t.Errorf("code = %q, want %q", ae.Code, errCodeOpUnsupported)
+	}
+}
+
+// TestSessionMutating_Timeout: an agent that reads but never replies → the
+// driver returns context.DeadlineExceeded (not a hang).
+func TestSessionMutating_Timeout(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string { return "" }) // reads but never replies
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Name: "cm"}
+	_, err := tc.sess.GetStatus(ctx, ref)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want context.DeadlineExceeded, got %v", err)
+	}
+}
+
+// TestSessionMutating_SessionClosed: the channel dies mid-call → the driver
+// returns ErrAgentUnavailable promptly instead of waiting out its deadline.
+func TestSessionMutating_SessionClosed(t *testing.T) {
+	tc := newTestChannel(t)
+	tc.runAgent(func(req wsReq) string { return "" }) // never replies
+
+	errc := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+		_, err := tc.sess.Delete(ctx, ref, "")
+		errc <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond) // let the call register and send its req
+	tc.client.CloseNow()              // kill the channel → server Serve returns → close() fails pending
+
+	select {
+	case err := <-errc:
+		if !errors.Is(err, ErrAgentUnavailable) {
+			t.Fatalf("want ErrAgentUnavailable, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Delete did not return after the session closed")
+	}
+	tc.srv.Close()
+}
+
+// ── WatchStatus (streaming) ────────────────────────────────────────────────────
+
+// TestSessionWatchStatus_Streaming is the key new test: the fake agent writes N
+// progress frames (each a status snapshot) followed by the terminal res, in
+// order. Assert onSnapshot fired N times with the right stage+snapshot, in
+// order, and that WatchStatus returned the summary.
+func TestSessionWatchStatus_Streaming(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	gotOp := make(chan string, 1)
+	gotParams := make(chan watchStatusParams, 1)
+	tc.runAgentMulti(func(req wsReq) []string {
+		var p watchStatusParams
+		_ = json.Unmarshal(req.Params, &p)
+		gotOp <- req.Op
+		gotParams <- p
+		return []string{
+			progressFrame(req.ID, "added", `{"found":true,"resource_version":"100","generation":1,"status":{"phase":"Pending"}}`),
+			progressFrame(req.ID, "modified", `{"found":true,"resource_version":"101","generation":1,"status":{"phase":"Scheduling"}}`),
+			progressFrame(req.ID, "modified", `{"found":true,"resource_version":"102","generation":2,"status":{"phase":"Running"}}`),
+			resOK(req.ID, `{"snapshots_sent":3,"reason":"max_snapshots"}`),
+		}
+	})
+
+	type snap struct {
+		stage string
+		snap  StatusSnapshot
+	}
+	var mu sync.Mutex
+	var snaps []snap
+	onSnapshot := func(stage string, s StatusSnapshot) {
+		mu.Lock()
+		snaps = append(snaps, snap{stage: stage, snap: s})
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	res, err := tc.sess.WatchStatus(ctx, ref, 3, onSnapshot)
+	if err != nil {
+		t.Fatalf("WatchStatus: %v", err)
+	}
+
+	// Terminal summary.
+	if res.SnapshotsSent != 3 || res.Reason != "max_snapshots" {
+		t.Errorf("WatchResult = %+v, want {3 max_snapshots}", res)
+	}
+
+	// onSnapshot fired 3× with the right stages in order.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(snaps) != 3 {
+		t.Fatalf("onSnapshot fired %d times, want 3", len(snaps))
+	}
+	wantStages := []string{"added", "modified", "modified"}
+	wantRV := []string{"100", "101", "102"}
+	for i, s := range snaps {
+		if s.stage != wantStages[i] {
+			t.Errorf("snapshot[%d] stage = %q, want %q", i, s.stage, wantStages[i])
+		}
+		if !s.snap.Found {
+			t.Errorf("snapshot[%d] Found = false, want true", i)
+		}
+		if s.snap.ResourceVersion != wantRV[i] {
+			t.Errorf("snapshot[%d] rv = %q, want %q", i, s.snap.ResourceVersion, wantRV[i])
+		}
+		if len(s.snap.Status) == 0 {
+			t.Errorf("snapshot[%d] carried no status", i)
+		}
+	}
+
+	// The agent saw op=="watch_status" with the ref + max_snapshots.
+	if op := <-gotOp; op != opWatchStatus {
+		t.Errorf("agent saw op %q, want %q", op, opWatchStatus)
+	}
+	p := <-gotParams
+	if p.ResourceRef != ref {
+		t.Errorf("ref = %+v, want %+v", p.ResourceRef, ref)
+	}
+	if p.MaxSnapshots != 3 {
+		t.Errorf("max_snapshots = %d, want 3", p.MaxSnapshots)
+	}
+}
+
+// TestSessionWatchStatus_NoSnapshots covers a watch that yields zero events
+// before terminating (object absent + deadline): snapshots_sent:0, a non-error
+// terminal res, and onSnapshot never fires.
+func TestSessionWatchStatus_NoSnapshots(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgentMulti(func(req wsReq) []string {
+		return []string{resOK(req.ID, `{"snapshots_sent":0,"reason":"deadline"}`)}
+	})
+
+	var fired int
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "never"}
+	res, err := tc.sess.WatchStatus(ctx, ref, 10, func(string, StatusSnapshot) { fired++ })
+	if err != nil {
+		t.Fatalf("WatchStatus: %v", err)
+	}
+	if res.SnapshotsSent != 0 || res.Reason != "deadline" {
+		t.Errorf("WatchResult = %+v, want {0 deadline}", res)
+	}
+	if fired != 0 {
+		t.Errorf("onSnapshot fired %d times, want 0", fired)
+	}
+}
+
+func TestSessionWatchStatus_AgentError(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgentMulti(func(req wsReq) []string {
+		return []string{resErr(req.ID, errCodeBadRequest, "max_snapshots < 0")}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	_, err := tc.sess.WatchStatus(ctx, ref, -1, func(string, StatusSnapshot) {
+		t.Error("onSnapshot fired on an error reply")
+	})
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeBadRequest {
+		t.Errorf("code = %q, want %q", ae.Code, errCodeBadRequest)
+	}
+}
+
+// TestSessionWatchStatus_TeardownOnClose: kill the channel mid-watch after some
+// progress → WatchStatus returns ErrAgentUnavailable, and no onSnapshot fires
+// after close (the streams entry is removed in close()).
+func TestSessionWatchStatus_TeardownOnClose(t *testing.T) {
+	tc := newTestChannel(t)
+
+	firstSent := make(chan struct{}, 1)
+	// The agent sends one progress frame, signals, then stalls (no terminal res)
+	// so the test can close the channel mid-stream.
+	tc.runAgentMulti(func(req wsReq) []string {
+		// Single frame; the goroutine returns after writing it, leaving the watch
+		// open with no terminal res.
+		defer func() { firstSent <- struct{}{} }()
+		return []string{progressFrame(req.ID, "added", `{"found":true,"resource_version":"1","status":{}}`)}
+	})
+
+	var mu sync.Mutex
+	var afterClose int
+	closed := make(chan struct{})
+	onSnapshot := func(string, StatusSnapshot) {
+		select {
+		case <-closed:
+			mu.Lock()
+			afterClose++
+			mu.Unlock()
+		default:
+		}
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+		_, err := tc.sess.WatchStatus(ctx, ref, 10, onSnapshot)
+		errc <- err
+	}()
+
+	<-firstSent                       // first progress delivered
+	time.Sleep(50 * time.Millisecond) // let deliverProgress run
+	close(closed)
+	tc.client.CloseNow() // kill the channel → Serve returns → close() fails pending + drops streams
+
+	select {
+	case err := <-errc:
+		if !errors.Is(err, ErrAgentUnavailable) {
+			t.Fatalf("want ErrAgentUnavailable, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchStatus did not return after the session closed")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if afterClose != 0 {
+		t.Errorf("onSnapshot fired %d times after close, want 0", afterClose)
+	}
+	tc.srv.Close()
+}
+
+// TestSessionWatchStatus_CtxCancel: cancel the caller ctx mid-stream →
+// WatchStatus returns ctx.Err(); a late terminal res for that id is dropped
+// (deliver finds no waiter), no panic.
+func TestSessionWatchStatus_CtxCancel(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	firstSent := make(chan struct{}, 1)
+	release := make(chan struct{})
+	tc.runAgentMulti(func(req wsReq) []string {
+		// First frame, then block until released, then a (late) terminal res that
+		// must be safely dropped after the caller cancelled.
+		frames := []string{progressFrame(req.ID, "added", `{"found":true,"resource_version":"1","status":{}}`)}
+		go func() {
+			firstSent <- struct{}{}
+			<-release
+			wctx, wcancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer wcancel()
+			_ = tc.client.Write(wctx, websocket.MessageText, []byte(resOK(req.ID, `{"snapshots_sent":1,"reason":"watch_closed"}`)))
+		}()
+		return frames
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+		_, err := tc.sess.WatchStatus(ctx, ref, 10, func(string, StatusSnapshot) {})
+		errc <- err
+	}()
+
+	<-firstSent
+	time.Sleep(50 * time.Millisecond)
+	cancel() // cancel the caller ctx mid-stream
+
+	select {
+	case err := <-errc:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchStatus did not return after ctx cancel")
+	}
+
+	// Release the late terminal res; deliver must find no waiter and drop it
+	// without panicking. Give the read loop a moment to process it.
+	close(release)
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestSessionWatchStatus_NoSnapshotAfterReturn is the regression guard for the
+// head-of-line / use-after-return hazard: onSnapshot must NEVER fire after
+// WatchStatus has returned. We cancel the caller ctx so WatchStatus returns,
+// THEN have the agent deliver a late progress frame for that same id, and assert
+// onSnapshot was never invoked for it (and nothing panics).
+//
+// In the old model deliverProgress looked up a sink under the lock and called it
+// inline on the Serve read goroutine — so a progress frame arriving after
+// WatchStatus's deferred delete(streams,id) was at best dropped, but if it raced
+// the delete it ran onSnapshot after return (a send-on-closed-channel hazard for
+// real callers). Now progress is routed through a buffered channel drained only
+// inside WatchStatus's own select loop; once that loop exits and the deferred
+// cleanup removes the channel, deliverProgress finds no entry and drops the frame.
+func TestSessionWatchStatus_NoSnapshotAfterReturn(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	reqSeen := make(chan string, 1)   // carries the watch req id to the test
+	deliverLate := make(chan struct{}) // test → agent: send the late progress now
+	lateDone := make(chan struct{})    // agent → test: late frame written
+
+	// The agent records the watch req id and signals; it sends NO terminal res
+	// (the watch stays open) until the test releases deliverLate, at which point it
+	// writes a single late progress frame for that id — after the caller has
+	// already cancelled and WatchStatus has returned.
+	tc.runAgentMulti(func(req wsReq) []string {
+		if req.Op != opWatchStatus {
+			return nil
+		}
+		go func() {
+			reqSeen <- req.ID
+			<-deliverLate
+			wctx, wcancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer wcancel()
+			_ = tc.client.Write(wctx, websocket.MessageText,
+				[]byte(progressFrame(req.ID, "modified", `{"found":true,"resource_version":"99","status":{"phase":"Running"}}`)))
+			close(lateDone)
+		}()
+		return nil // no frames inline; the goroutine drives the late write
+	})
+
+	var mu sync.Mutex
+	var calls int
+	onSnapshot := func(string, StatusSnapshot) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+		_, err := tc.sess.WatchStatus(ctx, ref, 10, onSnapshot)
+		errc <- err
+	}()
+
+	// Wait until the agent has the watch req (so streams[id] is registered), then
+	// cancel the caller ctx so WatchStatus returns BEFORE any progress arrives.
+	<-reqSeen
+	cancel()
+
+	select {
+	case err := <-errc:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchStatus did not return after ctx cancel")
+	}
+
+	// Now — after WatchStatus has returned — let the agent deliver the late
+	// progress frame. deliverProgress must find no registered stream (the deferred
+	// cleanup removed it) and drop it; onSnapshot must not fire and nothing panics.
+	close(deliverLate)
+	select {
+	case <-lateDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent never wrote the late progress frame")
+	}
+	time.Sleep(100 * time.Millisecond) // give the Serve loop time to process+drop it
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 0 {
+		t.Errorf("onSnapshot fired %d times after WatchStatus returned, want 0", calls)
+	}
+}
+
+// TestSessionWatchStatus_SlowConsumerNoHeadOfLineBlock is the regression guard
+// for the head-of-line-blocking half of the fix: a slow onSnapshot must NOT
+// stall the single Serve read goroutine and thereby block unrelated Calls.
+//
+// One watch has a deliberately blocking onSnapshot; while it is blocked on a
+// progress frame, an unrelated get_inventory Call is issued on the same session.
+// In the old model deliverProgress ran the sink inline on the Serve goroutine, so
+// the blocked onSnapshot froze the only reader and the Call's res frame could
+// never be read — a deadlock until a deadline. In the channel model
+// deliverProgress only does a non-blocking buffered send, so the Serve reader
+// stays free and the Call completes promptly. We assert the Call returns well
+// inside its deadline, then release the watch.
+func TestSessionWatchStatus_SlowConsumerNoHeadOfLineBlock(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	blockSnapshot := make(chan struct{}) // released at the end to unblock onSnapshot
+	snapshotEntered := make(chan struct{}, 1)
+
+	// The agent answers a watch req with a single progress frame (no terminal res
+	// — the watch stays open, blocked in onSnapshot), and answers get_inventory
+	// normally. The frame orderings the wire guarantees are preserved by
+	// runAgentMulti's per-req write serialization.
+	tc.runAgentMulti(func(req wsReq) []string {
+		switch req.Op {
+		case opWatchStatus:
+			return []string{progressFrame(req.ID, "modified", `{"found":true,"resource_version":"1","status":{}}`)}
+		case opGetInventory:
+			return []string{resOK(req.ID, `{"vm_count":42}`)}
+		default:
+			return nil
+		}
+	})
+
+	// Start the watch; its onSnapshot blocks (simulating a slow consumer) until the
+	// test releases it.
+	watchErr := make(chan error, 1)
+	watchCtx, watchCancel := context.WithCancel(context.Background())
+	defer watchCancel()
+	go func() {
+		ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "slow"}
+		_, err := tc.sess.WatchStatus(watchCtx, ref, 10, func(string, StatusSnapshot) {
+			select {
+			case snapshotEntered <- struct{}{}:
+			default:
+			}
+			<-blockSnapshot // block the consumer
+		})
+		watchErr <- err
+	}()
+
+	// Wait until onSnapshot is actually blocked, so the watch is mid-consume.
+	select {
+	case <-snapshotEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watch onSnapshot never ran")
+	}
+
+	// With the watch's onSnapshot blocked, an unrelated Call must still complete
+	// quickly — the Serve reader must not be head-of-line-blocked by the slow
+	// consumer. Old model: this deadlocks until the deadline.
+	callDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		res, err := tc.sess.Call(ctx, opGetInventory, nil)
+		if err == nil && string(res) != `{"vm_count":42}` {
+			err = errors.New("unexpected inventory result: " + string(res))
+		}
+		callDone <- err
+	}()
+
+	select {
+	case err := <-callDone:
+		if err != nil {
+			t.Fatalf("unrelated Call failed while a watch consumer was blocked: %v", err)
+		}
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("unrelated Call was head-of-line-blocked by a slow watch consumer")
+	}
+
+	// Release the watch and tear down.
+	close(blockSnapshot)
+	watchCancel()
+	select {
+	case <-watchErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchStatus did not return after release+cancel")
+	}
+}
+
+// TestSessionDeliverProgress_UnknownID guards the stray-progress / old-dc-api
+// compat path: a progress frame whose id no WatchStatus registered is dropped
+// (debug-logged) with no panic and no effect on an unrelated in-flight Call.
+func TestSessionDeliverProgress_UnknownID(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	tc.runAgentMulti(func(req wsReq) []string {
+		// For a normal Call, emit a stray progress frame for an unrelated id
+		// BEFORE the terminal res, then the terminal res. The stray frame must be
+		// dropped and the Call must still succeed.
+		return []string{
+			progressFrame("no-such-id", "modified", `{"found":true,"resource_version":"9","status":{}}`),
+			resOK(req.ID, `{"vm_count":1}`),
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	result, err := tc.sess.Call(ctx, opGetInventory, nil)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if string(result) != `{"vm_count":1}` {
+		t.Errorf("result = %s, want {\"vm_count\":1}", result)
+	}
+}


### PR DESCRIPTION
## What this is

Milestone **M-B** of the agent command channel: the mutating verbs **`apply` / `delete` / `get_status` / `watch_status`**, riding the exact same `req`/`res`/`progress` envelope that `get_inventory` (M-A, #162) already proved out. There are **no new frame types** — only new `op` strings — so protocol v0 and the M-A path stay byte-identical on the wire, and an old agent/new server (and vice-versa) keep interoperating.

This is **dark and non-breaking**: the new surface is internal `Session` methods plus unit tests only. There are **no new public API endpoints and no provider rewiring** — dc-api still talks to its backends directly. Routing real provisioning *through* the agent (the "credentials never leave their region" payoff) is a later milestone; M-B lands the verb plumbing it will use.

## The layers

- **Protocol** (`dc-agent/internal/protocol`) — four new `op` constants and their params/result shapes; one additive `omitempty` field on the existing `progress` frame to carry a status snapshot. `Decode` and the frame switch are unchanged.
- **dc-agent executor** — a dynamic-client implementation: server-side apply (stable field manager, `force`-conflicts flag, server-managed fields stripped before the patch), delete with propagation policy, a single `get_status` read, and a `watch_status` that streams status snapshots up as `progress` frames and **self-terminates after `max_snapshots`** (so a watch is bounded even with no cancel frame). GVK→GVR resolves through a real `RESTMapper`.
- **dc-agent dispatch** — the new ops register alongside `get_inventory` and are advertised in `hello`; `watch_status` emits progress through the single-writer `writeFrame`.
- **dc-api `Session`** — methods driving `apply`/`delete`/`get_status` over the existing `Call`, plus a `WatchStatus` consumer that routes progress frames through a **per-watch buffered channel** so `onSnapshot` runs on the caller's goroutine and a slow consumer can't head-of-line-block the read loop or fire after the watch returns.

## How it was built and verified

Built via a multi-agent workflow (understand → design → per-module implement+test → adversarial review), then the review's findings were addressed and everything was re-verified independently. `go build`, `go vet`, and **`-race` unit tests pass on both modules** — fake dynamic client for the executor, in-memory channel harness for dc-api — including regression guards for the watch lifecycle (no snapshot after return; slow consumer doesn't block the channel) and the SSA pre-strip.

**Status: needs review; not for merge until validated against a live cluster.** Everything here is unit/`-race` verified, but `apply`/`delete`/`watch` have not yet run against a real Harvester cluster — that's the next step once reviewed.

## Known follow-ups (out of scope here, by design)

- **Agent RBAC** — the agent ClusterRole is read-only today (`nodes`/`pods`/`virtualmachines`); `apply`/`delete` (and `get`/`watch` on arbitrary CRDs) need it widened. A `TODO` marks this; it is a separate change.
- **`watch_status` robustness** — no `resourceVersion`/relist on an apiserver-side close, and no explicit cancel frame. `watch_status` is a streaming proof-of-concept here; the `get_status` poll is the path provisioning/reconciliation will actually use. Bounded by `max_snapshots`, so nothing leaks unboundedly.
- **Capability allowlist** on the agent (defense-in-depth once the verbs are wired to real callers).

Design reference: `docs/multi-region-protocol-v1.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
