### PR TITLE
Route provider reads through the agent (M-C read slice)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,20 @@ export DCAPI_BFF_COOKIE_SECURE="false"
 # ignore the parameter.
 # export DCAPI_IDP_USERSTORE_DOMAIN="DEFAULT"
 
+# ── Multi-region (phase 0 + M-C agent routing) ───────────────────────────────
+# This control plane stamps LOCAL_REGION/LOCAL_ZONE on the resources it owns and
+# uses the pair to key its local provider set. Each must name a seeded row:
+# schema.sql seeds region 'lk' and its zone 'zone-1'. Leave at the defaults for a
+# single-region dev stack.
+export DCAPI_LOCAL_REGION="lk"      # region slug this control plane owns (regions table)
+export DCAPI_LOCAL_ZONE="zone-1"    # local zone slug (zones table); pairs with LOCAL_REGION
+#
+# DCAPI_AGENT_ROUTE_READS (M-C) routes provider reads through the per-zone agent
+# instead of the direct Harvester client; default false keeps the direct path.
+# Only takes effect for a zone with a live agent connected — otherwise reads fall
+# back to the direct client regardless. Write toggles land per phase later.
+export DCAPI_AGENT_ROUTE_READS="false"
+
 # ── Server ───────────────────────────────────────────────────────────────────
 export DCAPI_LOG_LEVEL="debug"      # debug for local dev; info for prod
 export DCAPI_LISTEN_ADDR=":8080"

--- a/dc-api/cmd/dc-api/main.go
+++ b/dc-api/cmd/dc-api/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/wso2/dc-api/internal/api"
 	"github.com/wso2/dc-api/internal/api/auth"
+	"github.com/wso2/dc-api/internal/api/handlers"
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/config"
 	"github.com/wso2/dc-api/internal/db"
@@ -87,19 +88,34 @@ func main() {
 	// build on the same regions/zones catalog.
 	repo.SetLocalRegion(cfg.LocalRegion)
 
-	// ── Provider instantiation (Factory Pattern) ──────────────────────────────
-	// The factory reads cfg.VMProvider and returns the right implementation.
-	// If an unknown provider is configured, we exit here — not on first request.
-	computeProvider, err := providers.NewComputeProvider(cfg)
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to initialise compute provider")
-	}
-	log.Info().Str("provider", computeProvider.Name()).Msg("compute provider ready")
+	// ── Agent registry (must exist BEFORE providers) ──────────────────────────
+	// The Registry holds the live per-zone dc-agent Sessions. M-C gives it a
+	// SECOND consumer beyond the WS/inventory handlers: provider read-routing.
+	// We build it here, wrap it once as an agentgw.SessionResolver, and feed that
+	// into providers.NewRegistry. The same *handlers.Registry is handed to
+	// NewRouter (via RouterDeps.AgentRegistry) so there is exactly ONE registry
+	// instance with two consumers — the M-B injection pattern, extended by one.
+	agentRegistry := handlers.NewRegistry()
+	agentGW := handlers.NewAgentGateway(agentRegistry)
 
-	clusterProvider, err := providers.NewClusterProvider(cfg)
+	// ── Provider instantiation (Factory + per-zone Registry) ──────────────────
+	// providers.NewRegistry builds the local-zone ProviderSet from cfg (the same
+	// Direct providers the three factories built pre-M-C) and decides, per call,
+	// whether that zone's READ ops go through the agent (only when
+	// DCAPI_AGENT_ROUTE_READS=true AND a live agent is connected for the zone).
+	// Default is the byte-identical direct path. The existing single-zone wiring
+	// below is unchanged — it just sources the trio from the local set.
+	provReg, err := providers.NewRegistry(cfg, agentGW, log.Logger)
 	if err != nil {
-		log.Fatal().Err(err).Msg("failed to initialise cluster provider")
+		log.Fatal().Err(err).Msg("failed to initialise provider registry")
 	}
+	localSet, err := provReg.For(cfg.LocalRegion, cfg.LocalZone)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to resolve local provider set")
+	}
+	computeProvider := localSet.Compute
+	clusterProvider := localSet.Cluster
+	log.Info().Str("provider", computeProvider.Name()).Msg("compute provider ready")
 	log.Info().Str("provider", clusterProvider.Name()).Msg("cluster provider ready")
 
 	// ── F32: wire cloud-provider SA bootstrap into the cluster provisioner ─────
@@ -113,10 +129,7 @@ func main() {
 		}
 	}
 
-	networkProvider, err := providers.NewNetworkProvider(cfg)
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to initialise network provider")
-	}
+	networkProvider := localSet.Network
 	log.Info().Str("provider", networkProvider.Name()).Msg("network provider ready")
 
 	// ── F15 VPC SNAT + F20 Per-VPC DNS bootstrap ────────────────────────────
@@ -391,7 +404,11 @@ func main() {
 		DirectoryProvider:   directoryProvider,
 		AuthMiddleware:      authMiddleware,
 		AuthService:         bffSvc,
-		Log:                 log.Logger,
+		// Same Registry that feeds provider read-routing (M-C) — so a connected
+		// agent's Session is visible to both the WS/inventory handlers and the
+		// routed compute provider.
+		AgentRegistry: agentRegistry,
+		Log:           log.Logger,
 	})
 
 	// ── HTTP Server ───────────────────────────────────────────────────────────

--- a/dc-api/internal/agentgw/agentgw.go
+++ b/dc-api/internal/agentgw/agentgw.go
@@ -1,0 +1,131 @@
+// Package agentgw is the neutral seam between provider code (which must reach a
+// zone's dc-agent) and the handlers package (which owns the live agent Sessions).
+//
+// It declares interfaces and the agent-channel WIRE STRUCTS only — no
+// implementation, no transport — so BOTH the providers tree and the handlers
+// package can import it without an import cycle. The cycle this resolves is:
+//
+//	handlers → providers → harvester → (would import) handlers     ✗ cycle
+//	handlers → agentgw  ;  harvester → clusteraccess → agentgw      ✓ acyclic
+//
+// *handlers.Session satisfies Session structurally (its Apply/Delete/GetStatus/
+// WatchStatus signatures already match), and *handlers.Registry is adapted to
+// SessionResolver by a 3-line wrapper in package handlers (agentgw_adapter.go).
+//
+// The five wire structs (ResourceRef, ApplyResult, DeleteResult, StatusSnapshot,
+// WatchResult) and the two sentinels (ErrAgentUnavailable, AgentError) are the
+// canonical definitions; handlers/agentchannel.go type-ALIASES them back so the
+// JSON wire contract with dc-agent and every M-B call site are byte-identical.
+package agentgw
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+)
+
+// Session is the subset of *handlers.Session that clusteraccess.AgentBacked
+// needs. *handlers.Session satisfies this by structural match — no change to
+// agentchannel.go's method signatures is required.
+type Session interface {
+	// Apply server-side-applies manifest in the agent's zone cluster.
+	Apply(ctx context.Context, manifest json.RawMessage, fieldManager string, force bool) (ApplyResult, error)
+	// Delete removes the referenced object (a missing object is a successful,
+	// idempotent delete: DeleteResult.Existed == false).
+	Delete(ctx context.Context, ref ResourceRef, propagationPolicy string) (DeleteResult, error)
+	// GetStatus reads the referenced object's status once (Found == false when
+	// the object is absent — not an error).
+	GetStatus(ctx context.Context, ref ResourceRef) (StatusSnapshot, error)
+	// WatchStatus drives the streaming watch_status op.
+	WatchStatus(ctx context.Context, ref ResourceRef, maxSnapshots int, onSnapshot func(stage string, snap StatusSnapshot)) (WatchResult, error)
+}
+
+// SessionResolver hands back the live Session for a zone, or false if no agent
+// is connected. *handlers.Registry is adapted to this in handlers/agentgw_adapter.go.
+type SessionResolver interface {
+	Session(region, zone string) (Session, bool)
+}
+
+// ── Wire structs (canonical home; aliased back in handlers/agentchannel.go) ───
+//
+// These mirror dc-agent's executor structs by JSON tag only (no shared Go
+// package): the field names below ARE the wire contract. dc-api builds the
+// reference from objects it already holds, so it addresses by GVK
+// (api_version + kind), not GVR — the agent owns the GVK→GVR mapping.
+
+// ResourceRef identifies one Kubernetes object by GVK + namespace/name. It is
+// embedded inline (not nested) in delete/get_status/watch_status params.
+type ResourceRef struct {
+	APIVersion string `json:"api_version"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name"`
+}
+
+// ApplyResult is the apply op's result: the applied object's identity and its
+// post-apply version.
+type ApplyResult struct {
+	APIVersion      string `json:"api_version"`
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace,omitempty"`
+	Name            string `json:"name"`
+	UID             string `json:"uid"`
+	ResourceVersion string `json:"resource_version"`
+}
+
+// DeleteResult is the delete op's result. Existed is false when the object was
+// already absent (a 404 is a successful, idempotent delete — not an error).
+type DeleteResult struct {
+	Existed bool `json:"existed"`
+}
+
+// StatusSnapshot is the result of get_status AND the payload of each
+// watch_status progress frame — one shape for both the single read and the
+// stream. Found is false when the object is absent (not an error).
+type StatusSnapshot struct {
+	Found           bool            `json:"found"`
+	ResourceVersion string          `json:"resource_version,omitempty"`
+	Generation      int64           `json:"generation,omitempty"`
+	Status          json.RawMessage `json:"status,omitempty"`
+}
+
+// WatchResult is the terminal summary of a watch_status stream.
+type WatchResult struct {
+	SnapshotsSent int    `json:"snapshots_sent"`
+	Reason        string `json:"reason"`
+}
+
+// ── Sentinels (canonical home; aliased back in handlers/agentchannel.go) ──────
+
+// ErrAgentUnavailable is returned when no live agent session exists for a zone,
+// or the session dies with a request in flight. It is transient — the caller
+// may retry once an agent (re)connects.
+var ErrAgentUnavailable = errors.New("no live agent session for the zone")
+
+// ErrOpNotRoutable is returned by clusteraccess.AgentBacked for an op the agent
+// cannot perform yet (List, Update, full-object Get), or for an unmapped GVR.
+// It is NOT transient — the caller should fall back to the direct path, never
+// retry the agent. clusteraccess.Routed treats it as "use Direct".
+var ErrOpNotRoutable = errors.New("operation not routable through the agent yet")
+
+// Protocol error codes an agent may return in a res frame. These exact strings
+// are the wire contract with dc-agent (a separate Go module). This is the
+// canonical home; handlers/agentchannel.go references CodeOpUnsupported via its
+// own errCodeOpUnsupported alias, and clusteraccess matches on it too — neither
+// can import the other (the import cycle agentgw exists to break), so the shared
+// string lives here, the one package both import.
+const (
+	// CodeOpUnsupported means the agent does not implement the requested op
+	// (e.g. an older agent against a newer dc-api verb). Non-retryable.
+	CodeOpUnsupported = "OP_UNSUPPORTED"
+)
+
+// AgentError is returned when the agent replies with a failure (ok=false). Code
+// is one of the protocol error codes (e.g. OP_UNSUPPORTED, BAD_REQUEST,
+// EXEC_ERROR); callers map it to an HTTP status or a provider error class.
+type AgentError struct {
+	Code    string
+	Message string
+}
+
+func (e *AgentError) Error() string { return e.Code + ": " + e.Message }

--- a/dc-api/internal/api/handlers/agentchannel.go
+++ b/dc-api/internal/api/handlers/agentchannel.go
@@ -27,6 +27,8 @@ import (
 	"github.com/coder/websocket"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+
+	"github.com/wso2/dc-api/internal/agentgw"
 )
 
 // v1 frame type discriminators. Must match dc-agent's protocol package.
@@ -40,7 +42,10 @@ const (
 // issues. These mirror dc-agent's protocol/executor packages — the JSON strings
 // are the shared contract (the two are separate Go modules).
 const (
-	errCodeOpUnsupported = "OP_UNSUPPORTED"
+	// errCodeOpUnsupported aliases the canonical wire string in agentgw so the
+	// "OP_UNSUPPORTED" literal lives in exactly one place (clusteraccess matches
+	// on the same const). BAD_REQUEST/EXEC_ERROR are handler-only today.
+	errCodeOpUnsupported = agentgw.CodeOpUnsupported
 	errCodeBadRequest    = "BAD_REQUEST"
 	errCodeExecError     = "EXEC_ERROR"
 
@@ -95,14 +100,43 @@ type wsProgress struct {
 // reference from objects it already holds, so it addresses by GVK
 // (api_version + kind), not GVR — the agent owns the GVK→GVR mapping.
 
+// The five wire structs and two sentinels below are now defined canonically in
+// package agentgw (so provider-side code can name them without importing
+// handlers — see agentgw.go's package doc on the import cycle). They are
+// type-ALIASED here, not redefined: an alias is the SAME type, so the JSON wire
+// contract with dc-agent is byte-identical and every M-B call site
+// (Session.Apply/Delete/GetStatus/WatchStatus and the inventory handler's
+// *AgentError / ErrAgentUnavailable checks) compiles unchanged.
+
 // ResourceRef identifies one Kubernetes object by GVK + namespace/name. It is
 // embedded inline (not nested) in delete/get_status/watch_status params.
-type ResourceRef struct {
-	APIVersion string `json:"api_version"`
-	Kind       string `json:"kind"`
-	Namespace  string `json:"namespace,omitempty"`
-	Name       string `json:"name"`
-}
+type ResourceRef = agentgw.ResourceRef
+
+// ApplyResult is the apply op's result: the applied object's identity and its
+// post-apply version.
+type ApplyResult = agentgw.ApplyResult
+
+// DeleteResult is the delete op's result. Existed is false when the object was
+// already absent (a 404 is a successful, idempotent delete — not an error).
+type DeleteResult = agentgw.DeleteResult
+
+// StatusSnapshot is the result of get_status AND the payload of each
+// watch_status progress frame — one shape for both the single read and the
+// stream. Found is false when the object is absent (not an error).
+type StatusSnapshot = agentgw.StatusSnapshot
+
+// WatchResult is the terminal summary of a watch_status stream.
+type WatchResult = agentgw.WatchResult
+
+// AgentError is returned by Session.Call when the agent replies with a failure
+// (ok=false). Code is one of the protocol error codes (e.g. OP_UNSUPPORTED,
+// BAD_REQUEST, EXEC_ERROR); callers map it to an HTTP status.
+type AgentError = agentgw.AgentError
+
+// ErrAgentUnavailable is returned when no live agent session exists for a zone,
+// or the session dies with a request in flight. It is transient — the caller
+// may retry once an agent (re)connects.
+var ErrAgentUnavailable = agentgw.ErrAgentUnavailable
 
 // applyParams is the request body for the apply op: a full manifest plus the SSA
 // field manager and force-conflicts flag.
@@ -112,38 +146,11 @@ type applyParams struct {
 	Force        bool            `json:"force,omitempty"`
 }
 
-// ApplyResult is the apply op's result: the applied object's identity and its
-// post-apply version.
-type ApplyResult struct {
-	APIVersion      string `json:"api_version"`
-	Kind            string `json:"kind"`
-	Namespace       string `json:"namespace,omitempty"`
-	Name            string `json:"name"`
-	UID             string `json:"uid"`
-	ResourceVersion string `json:"resource_version"`
-}
-
 // deleteParams is the request body for the delete op: a ResourceRef plus an
 // optional propagation policy.
 type deleteParams struct {
 	ResourceRef
 	PropagationPolicy string `json:"propagation_policy,omitempty"`
-}
-
-// DeleteResult is the delete op's result. Existed is false when the object was
-// already absent (a 404 is a successful, idempotent delete — not an error).
-type DeleteResult struct {
-	Existed bool `json:"existed"`
-}
-
-// StatusSnapshot is the result of get_status AND the payload of each
-// watch_status progress frame — one shape for both the single read and the
-// stream. Found is false when the object is absent (not an error).
-type StatusSnapshot struct {
-	Found           bool            `json:"found"`
-	ResourceVersion string          `json:"resource_version,omitempty"`
-	Generation      int64           `json:"generation,omitempty"`
-	Status          json.RawMessage `json:"status,omitempty"`
 }
 
 // watchStatusParams is the request body for the watch_status op: a ResourceRef
@@ -152,27 +159,6 @@ type watchStatusParams struct {
 	ResourceRef
 	MaxSnapshots int `json:"max_snapshots,omitempty"`
 }
-
-// WatchResult is the terminal summary of a watch_status stream.
-type WatchResult struct {
-	SnapshotsSent int    `json:"snapshots_sent"`
-	Reason        string `json:"reason"`
-}
-
-// ErrAgentUnavailable is returned when no live agent session exists for a zone,
-// or the session dies with a request in flight. It is transient — the caller
-// may retry once an agent (re)connects.
-var ErrAgentUnavailable = errors.New("no live agent session for the zone")
-
-// AgentError is returned by Session.Call when the agent replies with a failure
-// (ok=false). Code is one of the protocol error codes (e.g. OP_UNSUPPORTED,
-// BAD_REQUEST, EXEC_ERROR); callers map it to an HTTP status.
-type AgentError struct {
-	Code    string
-	Message string
-}
-
-func (e *AgentError) Error() string { return e.Code + ": " + e.Message }
 
 // ── Session ─────────────────────────────────────────────────────────────────
 

--- a/dc-api/internal/api/handlers/agentgw_adapter.go
+++ b/dc-api/internal/api/handlers/agentgw_adapter.go
@@ -1,0 +1,32 @@
+// Package handlers — agentgw_adapter.go
+//
+// AgentGateway adapts the concrete *Registry (which owns the live agent
+// Sessions) to the neutral agentgw.SessionResolver interface, so provider-side
+// code (clusteraccess.AgentBacked, wired via providers.Registry) can resolve a
+// zone's session WITHOUT importing package handlers — preserving the acyclic
+// dependency graph (handlers → agentgw ← clusteraccess ← providers).
+//
+// The widening from *Session to agentgw.Session is free: *Session already
+// satisfies agentgw.Session structurally (its Apply/Delete/GetStatus/
+// WatchStatus signatures match). The only work is turning the concrete return
+// of Registry.Session into the interface type.
+package handlers
+
+import "github.com/wso2/dc-api/internal/agentgw"
+
+// AgentGateway adapts *Registry to agentgw.SessionResolver.
+type AgentGateway struct{ reg *Registry }
+
+// NewAgentGateway wraps the shared agent Registry so it can be injected into
+// providers.NewRegistry as an agentgw.SessionResolver.
+func NewAgentGateway(reg *Registry) *AgentGateway { return &AgentGateway{reg: reg} }
+
+// Session returns the live Session for a zone as an agentgw.Session, or false if
+// no agent is connected there.
+func (g *AgentGateway) Session(region, zone string) (agentgw.Session, bool) {
+	s, ok := g.reg.Session(region, zone)
+	if !ok {
+		return nil, false
+	}
+	return s, true // *Session satisfies agentgw.Session
+}

--- a/dc-api/internal/api/router.go
+++ b/dc-api/internal/api/router.go
@@ -100,7 +100,15 @@ type RouterDeps struct {
 	// auth path. When nil, those routes are not registered and the only
 	// auth surface is the Bearer-header /v1/* dcctl uses.
 	AuthService *auth.Service
-	Log         zerolog.Logger
+	// AgentRegistry holds the live per-zone dc-agent Sessions. It is OPTIONAL:
+	// when main.go supplies one (so the SAME registry also feeds provider
+	// read-routing via handlers.NewAgentGateway → providers.NewRegistry), the WS
+	// handler and inventory handler use it. When nil, NewRouter creates its own —
+	// preserving callers (tests, contract harness) that build a router without
+	// wiring providers. Either way it is the single source of agent Sessions for
+	// the routes built here.
+	AgentRegistry *handlers.Registry
+	Log           zerolog.Logger
 }
 
 // NewRouter creates and returns the fully configured Chi router.
@@ -177,9 +185,14 @@ func NewRouter(deps RouterDeps) http.Handler {
 	// an Asgardeo JWT — so it is mounted OUTSIDE the /v1 OIDC group (like
 	// /healthz). The handler validates the bearer before upgrading.
 	// The Registry holds the live agent Sessions. It is shared between the WS
-	// handler (which registers a session per connected agent) and the v1 HTTP
-	// handlers that Call those agents (e.g. zone inventory).
-	agentRegistry := handlers.NewRegistry()
+	// handler (which registers a session per connected agent), the v1 HTTP
+	// handlers that Call those agents (e.g. zone inventory), AND — when main.go
+	// supplies it via deps.AgentRegistry — provider read-routing (M-C). Falling
+	// back to a fresh Registry keeps router-only callers (tests) working.
+	agentRegistry := deps.AgentRegistry
+	if agentRegistry == nil {
+		agentRegistry = handlers.NewRegistry()
+	}
 	agentWSHandler := handlers.NewAgentWSHandler(deps.Repo, agentRegistry, deps.Log)
 	r.Get("/v1/agent/ws", agentWSHandler.ServeHTTP)
 

--- a/dc-api/internal/config/config.go
+++ b/dc-api/internal/config/config.go
@@ -177,9 +177,9 @@ type Config struct {
 	//   deployment with a fallback to "coredns/coredns:1.11.3".
 	// VPCDNSSearchDomain: optional DNS search domain injected into every VPC VM
 	//   (e.g. "lk.dc.internal"). Empty means no extra search domain.
-	VPCDNSForwarders    string `envconfig:"VPC_DNS_FORWARDERS"     default:"1.1.1.1,8.8.8.8"`
-	VPCDNSImage         string `envconfig:"VPC_DNS_IMAGE"          default:""`
-	VPCDNSSearchDomain  string `envconfig:"VPC_DNS_SEARCH_DOMAIN"  default:""`
+	VPCDNSForwarders   string `envconfig:"VPC_DNS_FORWARDERS"     default:"1.1.1.1,8.8.8.8"`
+	VPCDNSImage        string `envconfig:"VPC_DNS_IMAGE"          default:""`
+	VPCDNSSearchDomain string `envconfig:"VPC_DNS_SEARCH_DOMAIN"  default:""`
 
 	// ── F7 BFF (Backend-for-Frontend) — cloud-ui Asgardeo session ────────────
 	// Set BFFClientID to a non-empty value to enable. When enabled, dc-api
@@ -277,6 +277,19 @@ type Config struct {
 	// (resources, key_vaults, databases, private_endpoints rows). It must name
 	// a row in the `regions` table (schema.sql seeds 'lk').
 	LocalRegion string `envconfig:"LOCAL_REGION" default:"lk"`
+
+	// LocalZone is the zone THIS control plane's local providers serve. Pairs
+	// with LocalRegion to key the local provider set in providers.Registry. Must
+	// name a row in the `zones` table (schema.sql seeds 'zone-1' for region 'lk').
+	LocalZone string `envconfig:"LOCAL_ZONE" default:"zone-1"`
+
+	// AgentRouteReads (M-C), when true AND a live agent is connected for a zone,
+	// routes that zone's provider READ ops (VM status reads first) through the
+	// dc-agent command channel instead of the direct dynamic client. Default
+	// false: the direct path is unchanged until an operator explicitly opts in
+	// per zone-with-connected-agent. Write toggles (AgentRouteVMWrites, …) land
+	// per phase as each resource family is cut over.
+	AgentRouteReads bool `envconfig:"AGENT_ROUTE_READS" default:"false"`
 
 	// ── Logging ───────────────────────────────────────────────────────────────
 	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`

--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -1,0 +1,256 @@
+package clusteraccess
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/wso2/dc-api/internal/agentgw"
+)
+
+// agentCallTimeout bounds EVERY agent-channel RPC issued from this accessor,
+// regardless of the context the caller passes in. Without it a caller holding a
+// deadline-less context — notably the reconciler, which calls GetVM with the
+// process-lifetime Run() context — would block forever on a connected-but-slow
+// agent (Session.Call only returns on a reply or ctx done). Mirrors the
+// inventoryCallTimeout precedent in handlers/inventory.go: a hung agent must
+// surface as a prompt timeout error, never an unbounded block.
+const agentCallTimeout = 30 * time.Second
+
+// AgentBacked routes each Kubernetes op to one zone's dc-agent Session. It
+// depends on the neutral agentgw.Session interface, never on package handlers,
+// so there is no import cycle.
+//
+// M-C maps only the status-shaped Get onto an agent op (Session.GetStatus). The
+// mutating verbs (Create/Update/Apply/Delete) and List are stubbed to return
+// ErrOpNotRoutable until their write phase lands AND the matching dc-agent RBAC
+// is widened in the same PR. Routed treats ErrOpNotRoutable as "fall back to
+// Direct", so an un-cut-over verb is never worse than today.
+type AgentBacked struct {
+	sess         agentgw.Session
+	region, zone string
+	fieldManager string
+	mapper       GVRToGVK
+	log          zerolog.Logger
+	// callTimeout bounds each agent RPC. Zero means agentCallTimeout. It is a
+	// field (not a bare const) so tests can inject a tiny value and assert the
+	// deadline fires without waiting the full 30s.
+	callTimeout time.Duration
+}
+
+// NewAgentBacked builds an agent-backed accessor for one zone's session.
+// fieldManager defaults to "dc-api" when empty.
+func NewAgentBacked(sess agentgw.Session, region, zone, fieldManager string, mapper GVRToGVK, log zerolog.Logger) *AgentBacked {
+	if fieldManager == "" {
+		fieldManager = "dc-api"
+	}
+	if mapper == nil {
+		mapper = DefaultGVKMapper()
+	}
+	return &AgentBacked{sess: sess, region: region, zone: zone, fieldManager: fieldManager, mapper: mapper, log: log}
+}
+
+// Ensure AgentBacked satisfies Accessor at compile time.
+var _ Accessor = (*AgentBacked)(nil)
+
+// bound wraps the incoming ctx with the accessor's call timeout so a slow or
+// unresponsive agent always surfaces as a deadline error promptly, even when the
+// caller passed a context with no deadline. The caller MUST defer the returned
+// cancel. If ctx already has an earlier deadline, context.WithTimeout keeps it.
+func (a *AgentBacked) bound(ctx context.Context) (context.Context, context.CancelFunc) {
+	d := a.callTimeout
+	if d <= 0 {
+		d = agentCallTimeout
+	}
+	return context.WithTimeout(ctx, d)
+}
+
+// ref builds the agent ResourceRef for a GVR/ns/name, returning ErrOpNotRoutable
+// (with a loud log) for an unmapped GVR so we never issue a wrong-kind op.
+func (a *AgentBacked) ref(gvr schema.GroupVersionResource, ns, name string) (agentgw.ResourceRef, error) {
+	apiVersion, kind, ok := a.mapper.GVK(gvr)
+	if !ok {
+		a.log.Error().
+			Str("group", gvr.Group).Str("version", gvr.Version).Str("resource", gvr.Resource).
+			Msg("clusteraccess: no GVR→GVK mapping for agent routing — refusing to route (programming error)")
+		return agentgw.ResourceRef{}, fmt.Errorf("clusteraccess: unmapped GVR %s: %w", gvr.String(), agentgw.ErrOpNotRoutable)
+	}
+	return agentgw.ResourceRef{APIVersion: apiVersion, Kind: kind, Namespace: ns, Name: name}, nil
+}
+
+// Get routes a STATUS-only read to Session.GetStatus and synthesizes a partial
+// *unstructured.Unstructured carrying apiVersion, kind, metadata.name/namespace,
+// metadata.resourceVersion, metadata.generation, and status.
+//
+// IMPORTANT: this is sufficient ONLY for callers that read status (e.g. the VM
+// read slice, which reads status.printableStatus). A caller needing spec or
+// metadata beyond name/ns/rv/generation must NOT route via this accessor until a
+// full-object agent read op exists. Found==false is translated to a
+// k8serrors.NewNotFound-shaped error so callers' existing IsNotFound /
+// "not found" string checks fire unchanged on both seams.
+func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	ref, err := a.ref(gvr, ns, name)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := a.bound(ctx)
+	defer cancel()
+
+	snap, err := a.sess.GetStatus(ctx, ref)
+	if err != nil {
+		return nil, a.translateErr(err)
+	}
+
+	// One INFO log per routed read, at the moment the agent path is chosen — the
+	// validation hook described in the design.
+	a.log.Info().
+		Str("seam", "agent").
+		Str("region", a.region).Str("zone", a.zone).
+		Str("api_version", ref.APIVersion).Str("kind", ref.Kind).
+		Str("namespace", ref.Namespace).Str("name", ref.Name).
+		Bool("found", snap.Found).
+		Msg("provider read routed through agent")
+
+	if !snap.Found {
+		// Shape a NotFound so reconciler delete/fail branches and providers'
+		// idempotent-delete checks fire exactly as on the direct path.
+		return nil, k8serrors.NewNotFound(gvr.GroupResource(), name)
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": ref.APIVersion,
+		"kind":       ref.Kind,
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": ns,
+		},
+	}}
+	if snap.ResourceVersion != "" {
+		_ = unstructured.SetNestedField(obj.Object, snap.ResourceVersion, "metadata", "resourceVersion")
+	}
+	if snap.Generation != 0 {
+		_ = unstructured.SetNestedField(obj.Object, snap.Generation, "metadata", "generation")
+	}
+	if len(snap.Status) > 0 {
+		var status map[string]interface{}
+		if err := json.Unmarshal(snap.Status, &status); err != nil {
+			return nil, fmt.Errorf("clusteraccess: decode agent status for %s/%s: %w", ns, name, err)
+		}
+		obj.Object["status"] = status
+	}
+	return obj, nil
+}
+
+// List is not in the M-B agent op set — no list_* op exists yet (M-D). Returns
+// ErrOpNotRoutable so Routed falls back to Direct.
+func (a *AgentBacked) List(ctx context.Context, gvr schema.GroupVersionResource, ns string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return nil, fmt.Errorf("clusteraccess: list of %s not routable: %w", gvr.Resource, agentgw.ErrOpNotRoutable)
+}
+
+// Create / Update / Apply all map to Session.Apply (SSA is create-or-update)
+// once a resource family is cut over in its write phase. Until then they return
+// ErrOpNotRoutable so Routed uses the direct path. The implementation below is
+// the shape the write phases will enable; it is unreachable in M-C because the
+// Routed allow-set does not include any mutating verb.
+func (a *AgentBacked) Create(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	return a.apply(ctx, gvr, ns, obj)
+}
+
+func (a *AgentBacked) Update(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return a.apply(ctx, gvr, ns, obj)
+}
+
+func (a *AgentBacked) Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ string, force bool) (*unstructured.Unstructured, error) {
+	return a.applyForce(ctx, gvr, ns, obj, force)
+}
+
+func (a *AgentBacked) apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	return a.applyForce(ctx, gvr, ns, obj, false)
+}
+
+func (a *AgentBacked) applyForce(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, force bool) (*unstructured.Unstructured, error) {
+	// Verify the GVR is mappable (loud log on a programming error) even though
+	// the manifest carries apiVersion/kind — keeps the not-routable contract
+	// uniform across verbs.
+	if _, _, ok := a.mapper.GVK(gvr); !ok {
+		a.log.Error().
+			Str("group", gvr.Group).Str("version", gvr.Version).Str("resource", gvr.Resource).
+			Msg("clusteraccess: no GVR→GVK mapping for agent apply — refusing to route")
+		return nil, fmt.Errorf("clusteraccess: unmapped GVR %s: %w", gvr.String(), agentgw.ErrOpNotRoutable)
+	}
+	manifest, err := json.Marshal(obj.Object)
+	if err != nil {
+		return nil, fmt.Errorf("clusteraccess: marshal manifest for apply: %w", err)
+	}
+	ctx, cancel := a.bound(ctx)
+	defer cancel()
+	res, err := a.sess.Apply(ctx, manifest, a.fieldManager, force)
+	if err != nil {
+		return nil, a.translateErr(err)
+	}
+	out := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": res.APIVersion,
+		"kind":       res.Kind,
+		"metadata": map[string]interface{}{
+			"name":      res.Name,
+			"namespace": res.Namespace,
+		},
+	}}
+	if res.UID != "" {
+		_ = unstructured.SetNestedField(out.Object, res.UID, "metadata", "uid")
+	}
+	if res.ResourceVersion != "" {
+		_ = unstructured.SetNestedField(out.Object, res.ResourceVersion, "metadata", "resourceVersion")
+	}
+	return out, nil
+}
+
+// Delete routes to Session.Delete. A missing object (Existed==false) is a
+// successful idempotent delete (no error), matching the providers' existing
+// IsNotFound-is-success contract.
+func (a *AgentBacked) Delete(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error {
+	ref, err := a.ref(gvr, ns, name)
+	if err != nil {
+		return err
+	}
+	policy := ""
+	if opts.PropagationPolicy != nil {
+		policy = string(*opts.PropagationPolicy)
+	}
+	ctx, cancel := a.bound(ctx)
+	defer cancel()
+	if _, err := a.sess.Delete(ctx, ref, policy); err != nil {
+		return a.translateErr(err)
+	}
+	return nil
+}
+
+// translateErr maps agent-channel failures into provider-shaped errors so the
+// failure modes stay inside the seam and callers keep their current handling:
+//   - ErrAgentUnavailable → a retryable error whose message contains
+//     "agent unavailable" (reconciler retries next tick; handlers surface 503).
+//   - *AgentError(OP_UNSUPPORTED) → wrapped as ErrOpNotRoutable (non-retryable;
+//     Routed would fall back to Direct on a fresh call).
+//   - anything else → passed through unchanged.
+func (a *AgentBacked) translateErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, agentgw.ErrAgentUnavailable) {
+		return fmt.Errorf("agent unavailable for zone %s/%s: %w", a.region, a.zone, err)
+	}
+	var ae *agentgw.AgentError
+	if errors.As(err, &ae) && ae.Code == agentgw.CodeOpUnsupported {
+		return fmt.Errorf("agent does not support op (%s): %w", ae.Message, agentgw.ErrOpNotRoutable)
+	}
+	return err
+}

--- a/dc-api/internal/providers/clusteraccess/clusteraccess.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess.go
@@ -1,0 +1,90 @@
+// Package clusteraccess defines the seam between a provider and the Kubernetes
+// API of one zone's cluster.
+//
+// Today every provider method reaches Kubernetes by doing
+// c.dynamic.Resource(gvr).Namespace(ns).<verb>(...) directly. This package
+// captures exactly that surface in one narrow interface (Accessor) with two
+// implementations:
+//
+//   - Direct      — a dynamic client on the master kubeconfig (today's behaviour,
+//     byte-identical; see direct.go).
+//   - AgentBacked — each op routed to the zone's dc-agent over the command
+//     channel (see agent.go).
+//   - Routed      — picks Direct or AgentBacked per call from a live decision
+//     function, so a single cached provider can flip seams without
+//     reconstruction (see routed.go).
+//
+// Providers depend ONLY on the Accessor interface, so the Strategy pattern is
+// preserved: a handler never learns whether a provider talks to the cluster
+// directly or through an agent. The public provider interfaces
+// (providers.ComputeProvider, …) are unchanged — no agent concept leaks out.
+package clusteraccess
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Accessor is the per-zone Kubernetes access seam. The method set is the subset
+// of dynamic.Interface that the providers actually use, expressed in terms
+// providers already speak (GVR + ns/name + unstructured). Keeping the seam in
+// GVR-in / unstructured-out terms means the Direct implementation is a one-line
+// passthrough and the provider diff is purely mechanical; the AgentBacked
+// implementation owns the GVR→GVK translation it needs for the wire.
+type Accessor interface {
+	Get(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.GetOptions) (*unstructured.Unstructured, error)
+	List(ctx context.Context, gvr schema.GroupVersionResource, ns string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Create(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error)
+	Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error)
+	Update(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error)
+	Delete(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error
+}
+
+// gvk is the (apiVersion, kind) pair the agent addresses an object by.
+type gvk struct {
+	APIVersion string
+	Kind       string
+}
+
+// GVRToGVK maps a GroupVersionResource to the (apiVersion, kind) the dc-agent
+// wire uses. The AgentBacked accessor has the GVR (providers speak GVR); the
+// agent needs api_version + kind. For the fixed set of GVRs the drivers use this
+// is a static table — an unmapped GVR is a programming error, surfaced as
+// ErrOpNotRoutable with a loud log rather than a silent wrong-kind apply.
+type GVRToGVK interface {
+	GVK(gvr schema.GroupVersionResource) (apiVersion, kind string, ok bool)
+}
+
+// staticGVKMapper is a GVRToGVK backed by a fixed table.
+type staticGVKMapper struct {
+	table map[schema.GroupVersionResource]gvk
+}
+
+func (m staticGVKMapper) GVK(gvr schema.GroupVersionResource) (string, string, bool) {
+	v, ok := m.table[gvr]
+	return v.APIVersion, v.Kind, ok
+}
+
+// DefaultGVKMapper returns the GVR→GVK table seeded from the drivers' own GVR
+// vars and their kinds. It is extended (here, in one place) as each write phase
+// routes a new resource family — never widened ahead of the routed verb.
+//
+// For M-C only the KubeVirt VirtualMachine entry is exercised (the read slice);
+// the rest are pre-seeded because they are the GVRs the existing drivers use and
+// having them present makes the eventual write phases a no-op here. apiVersion is
+// "group/version" (or bare "version" for the core group, which is empty).
+func DefaultGVKMapper() GVRToGVK {
+	return staticGVKMapper{table: map[schema.GroupVersionResource]gvk{
+		// ── harvester driver ───────────────────────────────────────────────────
+		{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}:                    {APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine"},
+		{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstances"}:            {APIVersion: "kubevirt.io/v1", Kind: "VirtualMachineInstance"},
+		{Group: "harvesterhci.io", Version: "v1beta1", Resource: "virtualmachineimages"}:      {APIVersion: "harvesterhci.io/v1beta1", Kind: "VirtualMachineImage"},
+		{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}: {APIVersion: "k8s.cni.cncf.io/v1", Kind: "NetworkAttachmentDefinition"},
+		// ── kubeovn driver (reads first in M-E, then writes) ─────────────────────
+		{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}:    {APIVersion: "kubeovn.io/v1", Kind: "Vpc"},
+		{Group: "kubeovn.io", Version: "v1", Resource: "subnets"}: {APIVersion: "kubeovn.io/v1", Kind: "Subnet"},
+	}}
+}

--- a/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
@@ -1,0 +1,294 @@
+package clusteraccess
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/wso2/dc-api/internal/agentgw"
+)
+
+// vmGVR is the KubeVirt VirtualMachine GVR the read slice routes — the one
+// entry the M-C allow-set + GVK table exercise.
+var vmGVR = schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}
+
+// fakeSession is a hand-written agentgw.Session that returns canned results.
+// Plain interface, no websocket harness needed.
+type fakeSession struct {
+	getStatus func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error)
+	apply     func(manifest json.RawMessage, fm string, force bool) (agentgw.ApplyResult, error)
+	del       func(ref agentgw.ResourceRef, policy string) (agentgw.DeleteResult, error)
+
+	// block, when true, makes GetStatus wait on ctx.Done() and return ctx.Err()
+	// — modelling a connected-but-unresponsive agent (the real Session.Call only
+	// returns on a reply or ctx cancellation). Used to prove the accessor bounds
+	// every call with its own deadline.
+	block bool
+
+	lastRef agentgw.ResourceRef // captured by GetStatus/Delete
+}
+
+func (f *fakeSession) GetStatus(ctx context.Context, ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+	f.lastRef = ref
+	if f.block {
+		<-ctx.Done()
+		return agentgw.StatusSnapshot{}, ctx.Err()
+	}
+	if f.getStatus != nil {
+		return f.getStatus(ref)
+	}
+	return agentgw.StatusSnapshot{}, nil
+}
+
+func (f *fakeSession) Apply(_ context.Context, manifest json.RawMessage, fm string, force bool) (agentgw.ApplyResult, error) {
+	if f.apply != nil {
+		return f.apply(manifest, fm, force)
+	}
+	return agentgw.ApplyResult{}, nil
+}
+
+func (f *fakeSession) Delete(_ context.Context, ref agentgw.ResourceRef, policy string) (agentgw.DeleteResult, error) {
+	f.lastRef = ref
+	if f.del != nil {
+		return f.del(ref, policy)
+	}
+	return agentgw.DeleteResult{}, nil
+}
+
+func (f *fakeSession) WatchStatus(context.Context, agentgw.ResourceRef, int, func(string, agentgw.StatusSnapshot)) (agentgw.WatchResult, error) {
+	return agentgw.WatchResult{}, nil
+}
+
+// ── AgentBacked.Get: status synthesis ─────────────────────────────────────────
+
+func TestAgentBackedGet_SynthesizesStatus(t *testing.T) {
+	sess := &fakeSession{
+		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+			return agentgw.StatusSnapshot{
+				Found:           true,
+				ResourceVersion: "12345",
+				Generation:      7,
+				Status:          json.RawMessage(`{"printableStatus":"Running"}`),
+			}, nil
+		},
+	}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	obj, err := a.Get(context.Background(), vmGVR, "dc-t-p", "vm-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	// The ResourceRef the agent saw must carry the correct GVK + ns/name.
+	if sess.lastRef.APIVersion != "kubevirt.io/v1" || sess.lastRef.Kind != "VirtualMachine" {
+		t.Errorf("agent ref GVK = %s/%s, want kubevirt.io/v1/VirtualMachine", sess.lastRef.APIVersion, sess.lastRef.Kind)
+	}
+	if sess.lastRef.Namespace != "dc-t-p" || sess.lastRef.Name != "vm-1" {
+		t.Errorf("agent ref ns/name = %s/%s, want dc-t-p/vm-1", sess.lastRef.Namespace, sess.lastRef.Name)
+	}
+
+	// The synthesized object must carry the status the harvester driver reads.
+	printable, found, _ := unstructured.NestedString(obj.Object, "status", "printableStatus")
+	if !found || printable != "Running" {
+		t.Errorf("status.printableStatus = %q (found=%v), want Running", printable, found)
+	}
+	if rv := obj.GetResourceVersion(); rv != "12345" {
+		t.Errorf("resourceVersion = %q, want 12345", rv)
+	}
+	if gen := obj.GetGeneration(); gen != 7 {
+		t.Errorf("generation = %d, want 7", gen)
+	}
+	if obj.GetName() != "vm-1" || obj.GetNamespace() != "dc-t-p" {
+		t.Errorf("name/ns = %s/%s, want vm-1/dc-t-p", obj.GetName(), obj.GetNamespace())
+	}
+}
+
+func TestAgentBackedGet_NotFoundIsK8sNotFound(t *testing.T) {
+	sess := &fakeSession{
+		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+			return agentgw.StatusSnapshot{Found: false}, nil
+		},
+	}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	_, err := a.Get(context.Background(), vmGVR, "dc-t-p", "gone", metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected an error for Found=false")
+	}
+	if !k8serrors.IsNotFound(err) {
+		t.Errorf("error is not a k8s NotFound: %v", err)
+	}
+}
+
+func TestAgentBackedGet_AgentUnavailableIsRetryable(t *testing.T) {
+	sess := &fakeSession{
+		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+			return agentgw.StatusSnapshot{}, agentgw.ErrAgentUnavailable
+		},
+	}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	_, err := a.Get(context.Background(), vmGVR, "dc-t-p", "vm-1", metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected an error when agent is unavailable")
+	}
+	// Must surface as agent-unavailable (reconciler retries / handlers 503) and
+	// must NOT be a NotFound (that would wrongly trigger delete/fail branches).
+	if !errors.Is(err, agentgw.ErrAgentUnavailable) {
+		t.Errorf("error does not wrap ErrAgentUnavailable: %v", err)
+	}
+	if k8serrors.IsNotFound(err) {
+		t.Errorf("agent-unavailable must not look like NotFound: %v", err)
+	}
+}
+
+func TestAgentBackedGet_UnmappedGVRNotRoutable(t *testing.T) {
+	sess := &fakeSession{}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	unknown := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	_, err := a.Get(context.Background(), unknown, "ns", "w", metav1.GetOptions{})
+	if !errors.Is(err, agentgw.ErrOpNotRoutable) {
+		t.Errorf("unmapped GVR must yield ErrOpNotRoutable, got %v", err)
+	}
+}
+
+// TestAgentBackedGet_BoundsHangingAgent proves the seam timeout: an agent whose
+// GetStatus never replies must NOT hang Get even when the caller passes a
+// deadline-less context (the reconciler's process-lifetime Run() context). Get
+// must return a DeadlineExceeded-class error promptly from the accessor's own
+// bound. A tiny callTimeout is injected so the test is fast; a watchdog turns a
+// regression (unbounded block) into a test FAIL instead of a hung suite.
+func TestAgentBackedGet_BoundsHangingAgent(t *testing.T) {
+	sess := &fakeSession{block: true} // GetStatus waits on ctx.Done() forever
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+	a.callTimeout = 50 * time.Millisecond // inject a short deadline (default is 30s)
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		// context.Background() has NO deadline — exactly the reconciler case. If
+		// the accessor did not bound the call itself, this would block forever.
+		_, err := a.Get(context.Background(), vmGVR, "dc-t-p", "vm-1", metav1.GetOptions{})
+		done <- result{err: err}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err == nil {
+			t.Fatal("expected a deadline error from the bounded agent call, got nil")
+		}
+		if !errors.Is(res.err, context.DeadlineExceeded) {
+			t.Errorf("error is not DeadlineExceeded-class: %v", res.err)
+		}
+	case <-time.After(5 * time.Second):
+		// 100x the injected timeout — a generous watchdog. Reaching it means the
+		// call was NOT bounded and the reconciler would have hung.
+		t.Fatal("Get did not return within the watchdog window — the agent call was not bounded")
+	}
+}
+
+// ── Routed: chooses Direct vs Agent per the decision function ─────────────────
+
+// recordingAccessor counts which verb was invoked so we can assert which seam
+// Routed selected.
+type recordingAccessor struct {
+	name    string
+	getHits *int
+}
+
+func (r recordingAccessor) Get(_ context.Context, _ schema.GroupVersionResource, _, _ string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	*r.getHits++
+	return &unstructured.Unstructured{Object: map[string]interface{}{"seam": r.name}}, nil
+}
+func (r recordingAccessor) List(context.Context, schema.GroupVersionResource, string, metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return nil, nil
+}
+func (r recordingAccessor) Create(context.Context, schema.GroupVersionResource, string, *unstructured.Unstructured, metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (r recordingAccessor) Apply(context.Context, schema.GroupVersionResource, string, *unstructured.Unstructured, string, bool) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (r recordingAccessor) Update(context.Context, schema.GroupVersionResource, string, *unstructured.Unstructured, metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (r recordingAccessor) Delete(context.Context, schema.GroupVersionResource, string, string, metav1.DeleteOptions) error {
+	return nil
+}
+
+func TestRouted_FallsBackToDirectWhenAgentDeclines(t *testing.T) {
+	var directGets, agentGets int
+	direct := recordingAccessor{name: "direct", getHits: &directGets}
+	agent := recordingAccessor{name: "agent", getHits: &agentGets}
+
+	// agent() always declines → must use Direct.
+	r := NewRouted(direct, func(Verb) (Accessor, bool) { return agent, false })
+
+	obj, err := r.Get(context.Background(), vmGVR, "ns", "n", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if obj.Object["seam"] != "direct" {
+		t.Errorf("expected direct seam, got %v", obj.Object["seam"])
+	}
+	if directGets != 1 || agentGets != 0 {
+		t.Errorf("hits: direct=%d agent=%d, want direct=1 agent=0", directGets, agentGets)
+	}
+}
+
+func TestRouted_UsesAgentWhenDecisionAllows(t *testing.T) {
+	var directGets, agentGets int
+	direct := recordingAccessor{name: "direct", getHits: &directGets}
+	agent := recordingAccessor{name: "agent", getHits: &agentGets}
+
+	// agent() allows ONLY VerbGet — mirrors the M-C read allow-set.
+	r := NewRouted(direct, func(v Verb) (Accessor, bool) {
+		if v == VerbGet {
+			return agent, true
+		}
+		return nil, false
+	})
+
+	obj, err := r.Get(context.Background(), vmGVR, "ns", "n", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if obj.Object["seam"] != "agent" {
+		t.Errorf("expected agent seam, got %v", obj.Object["seam"])
+	}
+	if directGets != 0 || agentGets != 1 {
+		t.Errorf("hits: direct=%d agent=%d, want direct=0 agent=1", directGets, agentGets)
+	}
+
+	// A non-allowed verb (Delete) must still fall back to Direct even though the
+	// agent is "available" — the allow-set gates per verb.
+	if err := r.Delete(context.Background(), vmGVR, "ns", "n", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+}
+
+func TestRouted_NilDecisionAlwaysDirect(t *testing.T) {
+	var directGets int
+	direct := recordingAccessor{name: "direct", getHits: &directGets}
+	r := NewRouted(direct, nil)
+	if _, err := r.Get(context.Background(), vmGVR, "ns", "n", metav1.GetOptions{}); err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if directGets != 1 {
+		t.Errorf("nil decision should use Direct; direct hits=%d", directGets)
+	}
+}
+
+// Compile-time assertion that the fake satisfies the neutral Session interface.
+var _ agentgw.Session = (*fakeSession)(nil)

--- a/dc-api/internal/providers/clusteraccess/direct.go
+++ b/dc-api/internal/providers/clusteraccess/direct.go
@@ -1,0 +1,46 @@
+package clusteraccess
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// Direct is the Accessor backed by a dynamic client on the master kubeconfig.
+// Every method is the exact c.dynamic.Resource(gvr).Namespace(ns).<verb>(...)
+// chain the providers run today, so a provider constructed with a Direct
+// accessor behaves unchanged to the byte.
+type Direct struct{ dyn dynamic.Interface }
+
+// NewDirect wraps a dynamic client as a Direct accessor.
+func NewDirect(dyn dynamic.Interface) *Direct { return &Direct{dyn: dyn} }
+
+// Ensure Direct satisfies Accessor at compile time.
+var _ Accessor = (*Direct)(nil)
+
+func (d *Direct) Get(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.GetOptions) (*unstructured.Unstructured, error) {
+	return d.dyn.Resource(gvr).Namespace(ns).Get(ctx, name, opts)
+}
+
+func (d *Direct) List(ctx context.Context, gvr schema.GroupVersionResource, ns string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return d.dyn.Resource(gvr).Namespace(ns).List(ctx, opts)
+}
+
+func (d *Direct) Create(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	return d.dyn.Resource(gvr).Namespace(ns).Create(ctx, obj, opts)
+}
+
+func (d *Direct) Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error) {
+	return d.dyn.Resource(gvr).Namespace(ns).Apply(ctx, obj.GetName(), obj, metav1.ApplyOptions{FieldManager: fieldManager, Force: force})
+}
+
+func (d *Direct) Update(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return d.dyn.Resource(gvr).Namespace(ns).Update(ctx, obj, opts)
+}
+
+func (d *Direct) Delete(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error {
+	return d.dyn.Resource(gvr).Namespace(ns).Delete(ctx, name, opts)
+}

--- a/dc-api/internal/providers/clusteraccess/routed.go
+++ b/dc-api/internal/providers/clusteraccess/routed.go
@@ -1,0 +1,96 @@
+package clusteraccess
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Verb identifies which Accessor method is being invoked, so the routing
+// decision (Routed.agent) can gate the agent path verb-by-verb. This is how the
+// design's "never widen ahead of the routed verb" is enforced in code: the
+// per-phase allow-set decides which verbs may route.
+type Verb int
+
+const (
+	VerbGet Verb = iota
+	VerbList
+	VerbCreate
+	VerbApply
+	VerbUpdate
+	VerbDelete
+)
+
+// AgentDecision is the live decision function a Routed accessor consults per
+// call. It returns the AgentBacked accessor and true ONLY when the relevant
+// family toggle is on AND a live agent session exists for the zone right now AND
+// the specific verb is in the routed allow-set for the current phase. Otherwise
+// it returns (_, false) and Routed falls through to Direct — so behaviour is
+// never worse than today.
+type AgentDecision func(verb Verb) (Accessor, bool)
+
+// Routed picks Direct or AgentBacked per call from a live decision function.
+// This is what lets a single cached provider flip between seams without
+// reconstruction: agent() re-evaluates the toggle + live-session check + verb
+// allow-set every call. For ops the agent can't do yet, or when agent() says no,
+// it falls through to Direct.
+type Routed struct {
+	direct Accessor
+	agent  AgentDecision
+}
+
+// NewRouted builds a Routed accessor over a Direct fallback and a live decision
+// function. If decide is nil the accessor is always Direct (agent path disabled).
+func NewRouted(direct Accessor, decide AgentDecision) *Routed {
+	if decide == nil {
+		decide = func(Verb) (Accessor, bool) { return nil, false }
+	}
+	return &Routed{direct: direct, agent: decide}
+}
+
+// Ensure Routed satisfies Accessor at compile time.
+var _ Accessor = (*Routed)(nil)
+
+func (r *Routed) Get(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.GetOptions) (*unstructured.Unstructured, error) {
+	if a, ok := r.agent(VerbGet); ok {
+		return a.Get(ctx, gvr, ns, name, opts)
+	}
+	return r.direct.Get(ctx, gvr, ns, name, opts)
+}
+
+func (r *Routed) List(ctx context.Context, gvr schema.GroupVersionResource, ns string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if a, ok := r.agent(VerbList); ok {
+		return a.List(ctx, gvr, ns, opts)
+	}
+	return r.direct.List(ctx, gvr, ns, opts)
+}
+
+func (r *Routed) Create(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	if a, ok := r.agent(VerbCreate); ok {
+		return a.Create(ctx, gvr, ns, obj, opts)
+	}
+	return r.direct.Create(ctx, gvr, ns, obj, opts)
+}
+
+func (r *Routed) Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error) {
+	if a, ok := r.agent(VerbApply); ok {
+		return a.Apply(ctx, gvr, ns, obj, fieldManager, force)
+	}
+	return r.direct.Apply(ctx, gvr, ns, obj, fieldManager, force)
+}
+
+func (r *Routed) Update(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	if a, ok := r.agent(VerbUpdate); ok {
+		return a.Update(ctx, gvr, ns, obj, opts)
+	}
+	return r.direct.Update(ctx, gvr, ns, obj, opts)
+}
+
+func (r *Routed) Delete(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error {
+	if a, ok := r.agent(VerbDelete); ok {
+		return a.Delete(ctx, gvr, ns, name, opts)
+	}
+	return r.direct.Delete(ctx, gvr, ns, name, opts)
+}

--- a/dc-api/internal/providers/harvester/client.go
+++ b/dc-api/internal/providers/harvester/client.go
@@ -2,23 +2,26 @@
 // against the Harvester HCI platform.
 //
 // How Harvester works (important context for SREs):
-//   Harvester is built ON TOP OF Kubernetes. Every VM is a Kubernetes Custom
-//   Resource of kind VirtualMachine (from the KubeVirt API). To create a VM,
-//   you apply a VirtualMachine CRD manifest — exactly like applying a Deployment.
 //
-//   This means our Harvester driver is really a Kubernetes client that manages
-//   VirtualMachine CRDs. We use client-go for this.
+//	Harvester is built ON TOP OF Kubernetes. Every VM is a Kubernetes Custom
+//	Resource of kind VirtualMachine (from the KubeVirt API). To create a VM,
+//	you apply a VirtualMachine CRD manifest — exactly like applying a Deployment.
+//
+//	This means our Harvester driver is really a Kubernetes client that manages
+//	VirtualMachine CRDs. We use client-go for this.
 //
 // BackendUID format:
-//   We store BackendUID as "namespace:vmname" (e.g., "dc-teamalpha:web-01").
-//   This lets GetVM and DeleteVM do a direct O(1) lookup by namespace+name
-//   instead of a slow List+filter by Kubernetes UID. The name is deterministic
-//   (it comes from the spec), making this safe.
+//
+//	We store BackendUID as "namespace:vmname" (e.g., "dc-teamalpha:web-01").
+//	This lets GetVM and DeleteVM do a direct O(1) lookup by namespace+name
+//	instead of a slow List+filter by Kubernetes UID. The name is deterministic
+//	(it comes from the spec), making this safe.
 //
 // Namespace convention:
-//   One Kubernetes namespace per project: "dc-<tenantID>-<projectID>".
-//   The namespace must be created by the project handler (EnsureProjectNamespace)
-//   before any VM can be created. CreateVM does not create or ensure the namespace.
+//
+//	One Kubernetes namespace per project: "dc-<tenantID>-<projectID>".
+//	The namespace must be created by the project handler (EnsureProjectNamespace)
+//	before any VM can be created. CreateVM does not create or ensure the namespace.
 package harvester
 
 import (
@@ -33,6 +36,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
 	"github.com/wso2/dc-api/internal/providers/common"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +92,14 @@ type Client struct {
 	dynamic    dynamic.Interface // Kubernetes dynamic client (handles CRDs and core resources)
 	namespace  string            // fallback namespace (unused now — we derive from tenantID)
 	restConfig *rest.Config      // stored so we can expose server URL + CA for SA kubeconfigs (F32)
+
+	// access is the per-zone cluster-access seam (M-C). It defaults to a
+	// clusteraccess.Direct wrapping `dynamic` (today's behaviour, byte-identical)
+	// unless WithRoutedAccessor injects a routed accessor. Only GetVM's primary
+	// VirtualMachine read goes through it for the M-C read slice; every other
+	// method still calls c.dynamic directly. The seam never leaks an agent
+	// concept past the ComputeProvider interface.
+	access clusteraccess.Accessor
 }
 
 // NewClient creates a Harvester client from a base64-encoded kubeconfig string.
@@ -110,7 +122,40 @@ func NewClient(kubeconfigB64 string, namespace string) (*Client, error) {
 		return nil, fmt.Errorf("create harvester dynamic client: %w", err)
 	}
 
-	return &Client{dynamic: dynClient, namespace: namespace, restConfig: restConfig}, nil
+	return &Client{
+		dynamic:    dynClient,
+		namespace:  namespace,
+		restConfig: restConfig,
+		// Default seam: Direct on the same dynamic client → byte-identical to the
+		// pre-M-C behaviour. providers.NewRegistry replaces this with a Routed
+		// accessor via WithRoutedAccessor when the agent path is wired.
+		access: clusteraccess.NewDirect(dynClient),
+	}, nil
+}
+
+// Dynamic exposes the underlying dynamic client so the provider registry can
+// build the Direct fallback of a Routed accessor over the SAME client every
+// other method uses (no second connection, no kubeconfig re-parse). Mirrors
+// kubeovn.Client.Dynamic().
+func (c *Client) Dynamic() dynamic.Interface { return c.dynamic }
+
+// WithRoutedAccessor replaces the client's cluster-access seam with a routed
+// accessor produced from the client's own dynamic client. build receives a
+// clusteraccess.Direct over c.dynamic (the Direct fallback the routed accessor
+// must use so the off-path is byte-identical) and returns the Accessor to
+// install. Returns the same *Client for chaining.
+//
+// The registry uses this so the Direct fallback and every not-yet-routed method
+// share one dynamic client. A nil build (or a nil result) leaves the default
+// Direct seam in place.
+func (c *Client) WithRoutedAccessor(build func(direct clusteraccess.Accessor) clusteraccess.Accessor) *Client {
+	if build == nil {
+		return c
+	}
+	if a := build(clusteraccess.NewDirect(c.dynamic)); a != nil {
+		c.access = a
+	}
+	return c
 }
 
 // Name satisfies providers.ComputeProvider.
@@ -189,10 +234,13 @@ func (c *Client) GetVM(ctx context.Context, backendUID string) (*models.Resource
 		return nil, err
 	}
 
-	obj, err := c.dynamic.
-		Resource(harvesterVMResource).
-		Namespace(ns).
-		Get(ctx, name, metav1.GetOptions{})
+	// M-C read slice: the primary VirtualMachine read goes through the
+	// cluster-access seam (c.access). With the agent toggle OFF (default) this
+	// resolves to the exact c.dynamic.Resource(...).Get(...) call below; with it
+	// ON and a live agent for the zone, it routes to Session.GetStatus. We read
+	// only status.printableStatus from `obj`, which the agent's status snapshot
+	// fully supplies. The VMI read further down stays on c.dynamic for this slice.
+	obj, err := c.access.Get(ctx, harvesterVMResource, ns, name, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, fmt.Errorf("VM %s not found in Harvester", backendUID)

--- a/dc-api/internal/providers/harvester/getvm_seam_test.go
+++ b/dc-api/internal/providers/harvester/getvm_seam_test.go
@@ -1,0 +1,162 @@
+package harvester
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/wso2/dc-api/internal/agentgw"
+	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+// This test proves the M-C equivalence guarantee: GetVM returns the SAME
+// models.Resource.Status whether its primary VirtualMachine read goes through
+// the Direct seam (fake dynamic object) or the agent seam (Session.GetStatus
+// returning the equivalent status snapshot). The VMI read stays Direct on both
+// paths (no VMI object present → empty IP, which is fine for the status check).
+
+const (
+	testVMNamespace = "dc-tenant-proj"
+	testVMName      = "web-01"
+	testBackendUID  = testVMNamespace + ":" + testVMName
+)
+
+// newFakeDynamicWithVM returns a fake dynamic client holding one KubeVirt
+// VirtualMachine with the given status.printableStatus.
+func newFakeDynamicWithVM(t *testing.T, printableStatus string) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	vm := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubevirt.io/v1",
+		"kind":       "VirtualMachine",
+		"metadata": map[string]interface{}{
+			"name":      testVMName,
+			"namespace": testVMNamespace,
+		},
+		"status": map[string]interface{}{
+			"printableStatus": printableStatus,
+		},
+	}}
+	// Register the GVR→ListKind so the fake's List machinery is satisfied for the
+	// unstructured CRD types the harvester driver uses.
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		harvesterVMResource:  "VirtualMachineList",
+		harvesterVMIResource: "VirtualMachineInstanceList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, vm)
+}
+
+// statusSnapshotFor builds the agent StatusSnapshot equivalent to the fake VM's
+// status — the same printableStatus the Direct path would read off the object.
+func statusSnapshotFor(printableStatus string) agentgw.StatusSnapshot {
+	status, _ := json.Marshal(map[string]interface{}{"printableStatus": printableStatus})
+	return agentgw.StatusSnapshot{Found: true, ResourceVersion: "1", Status: status}
+}
+
+// seamStubSession returns the given snapshot from GetStatus.
+type seamStubSession struct{ snap agentgw.StatusSnapshot }
+
+func (s seamStubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+	return s.snap, nil
+}
+func (s seamStubSession) Apply(context.Context, json.RawMessage, string, bool) (agentgw.ApplyResult, error) {
+	return agentgw.ApplyResult{}, nil
+}
+func (s seamStubSession) Delete(context.Context, agentgw.ResourceRef, string) (agentgw.DeleteResult, error) {
+	return agentgw.DeleteResult{}, nil
+}
+func (s seamStubSession) WatchStatus(context.Context, agentgw.ResourceRef, int, func(string, agentgw.StatusSnapshot)) (agentgw.WatchResult, error) {
+	return agentgw.WatchResult{}, nil
+}
+
+func TestGetVM_DirectAndAgentSeamsAgreeOnStatus(t *testing.T) {
+	cases := []struct {
+		printable string
+		want      models.ResourceStatus
+	}{
+		{"Running", models.StatusActive},
+		{"Starting", models.StatusPending},
+		{"Terminating", models.StatusDeleting},
+		{"CrashLoopBackOff", models.StatusFailed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.printable, func(t *testing.T) {
+			// ── Direct seam ──────────────────────────────────────────────────────
+			dynDirect := newFakeDynamicWithVM(t, tc.printable)
+			directClient := &Client{
+				dynamic: dynDirect,
+				access:  clusteraccess.NewDirect(dynDirect),
+			}
+			directRes, err := directClient.GetVM(context.Background(), testBackendUID)
+			if err != nil {
+				t.Fatalf("Direct GetVM error: %v", err)
+			}
+
+			// ── Agent seam ───────────────────────────────────────────────────────
+			// Same fake dynamic client for the VMI read (kept Direct), but the
+			// primary VM read is routed to a stub agent Session via a Routed
+			// accessor whose decision always allows VerbGet.
+			dynAgent := newFakeDynamicWithVM(t, tc.printable)
+			sess := seamStubSession{snap: statusSnapshotFor(tc.printable)}
+			agentAccessor := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+			routed := clusteraccess.NewRouted(
+				clusteraccess.NewDirect(dynAgent),
+				func(v clusteraccess.Verb) (clusteraccess.Accessor, bool) {
+					if v == clusteraccess.VerbGet {
+						return agentAccessor, true
+					}
+					return nil, false
+				},
+			)
+			agentClient := &Client{
+				dynamic: dynAgent, // VMI read still goes here
+				access:  routed,   // VM read routes to the agent
+			}
+			agentRes, err := agentClient.GetVM(context.Background(), testBackendUID)
+			if err != nil {
+				t.Fatalf("Agent GetVM error: %v", err)
+			}
+
+			// ── Equivalence ──────────────────────────────────────────────────────
+			if directRes.Status != tc.want {
+				t.Errorf("Direct status = %q, want %q", directRes.Status, tc.want)
+			}
+			if agentRes.Status != tc.want {
+				t.Errorf("Agent status = %q, want %q", agentRes.Status, tc.want)
+			}
+			if directRes.Status != agentRes.Status {
+				t.Errorf("seams disagree: Direct=%q Agent=%q", directRes.Status, agentRes.Status)
+			}
+		})
+	}
+}
+
+// TestGetVM_DefaultClientUsesDirect proves the toggle-OFF path: a client built
+// with only a Direct accessor (NewClient's default) reads the VM via the
+// dynamic client — byte-identical to pre-M-C. We assert it equals an explicit
+// dynamic Get.
+func TestGetVM_DefaultClientUsesDirect(t *testing.T) {
+	dyn := newFakeDynamicWithVM(t, "Running")
+	c := &Client{dynamic: dyn, access: clusteraccess.NewDirect(dyn)}
+
+	res, err := c.GetVM(context.Background(), testBackendUID)
+	if err != nil {
+		t.Fatalf("GetVM error: %v", err)
+	}
+	if res.Status != models.StatusActive {
+		t.Errorf("status = %q, want ACTIVE", res.Status)
+	}
+
+	// Sanity: the object is really in the fake store under the direct path.
+	if _, err := dyn.Resource(harvesterVMResource).Namespace(testVMNamespace).Get(context.Background(), testVMName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("direct dynamic Get failed: %v", err)
+	}
+}

--- a/dc-api/internal/providers/registry.go
+++ b/dc-api/internal/providers/registry.go
@@ -1,0 +1,182 @@
+// Package providers — registry.go
+//
+// Registry resolves the provider set for a (region, zone) and decides, per call,
+// whether that zone's provider READ ops go through the direct dynamic client or
+// the zone's dc-agent command channel.
+//
+// ── M-C scope ─────────────────────────────────────────────────────────────────
+// The registry holds exactly ONE zone — the local zone (cfg.LocalRegion /
+// cfg.LocalZone) — built from the process-global DCAPI_* credentials, i.e. the
+// same Direct providers main.go built before M-C. The compute provider for that
+// zone is constructed with a clusteraccess.Routed accessor whose decision
+// closure consults:
+//
+//  1. cfg.AgentRouteReads  (DCAPI_AGENT_ROUTE_READS; default false), AND
+//  2. a non-nil agent gateway, AND
+//  3. a LIVE agent session for the zone right now, AND
+//  4. the verb being in the routed allow-set ({Get} for the read slice).
+//
+// If ANY is false the accessor uses Direct — today's behaviour, byte-identical.
+// Condition 3 is the safety belt: even with the toggle on, a zone with no
+// connected agent silently uses Direct, so flipping the env var can never strand
+// the local zone if the agent is down.
+//
+// cluster/network providers in the set are the plain Direct ones for now —
+// rancher is an HTTP Steve client (does not fit the Accessor seam) and network
+// routing is a later phase (M-E).
+package providers
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/rs/zerolog"
+
+	"github.com/wso2/dc-api/internal/agentgw"
+	"github.com/wso2/dc-api/internal/config"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+	"github.com/wso2/dc-api/internal/providers/harvester"
+)
+
+// ProviderSet is the trio of providers that serve one zone.
+type ProviderSet struct {
+	Compute ComputeProvider
+	Cluster ClusterProvider
+	Network NetworkProvider
+}
+
+// Registry resolves the provider set for a (region, zone). It mirrors
+// handlers.Registry's map+RWMutex+zoneKey shape.
+type Registry struct {
+	mu  sync.RWMutex
+	set map[string]*ProviderSet // key: region "/" zone
+
+	// agentGateway resolves a zone's live agent Session. nil ⇒ the agent path is
+	// disabled entirely (always the Direct seam).
+	agentGateway agentgw.SessionResolver
+
+	// routeReads gates the dark read slice (DCAPI_AGENT_ROUTE_READS).
+	routeReads bool
+
+	localRegion, localZone string
+	log                    zerolog.Logger
+}
+
+func registryKey(region, zone string) string { return region + "/" + zone }
+
+// NewRegistry builds the local-zone ProviderSet from cfg and wires its compute
+// provider's cluster-access seam to the agent gateway behind the read toggle.
+//
+// agentGateway may be nil (agent path disabled). It is the handlers.Registry
+// adapted to agentgw.SessionResolver (handlers.NewAgentGateway), constructed in
+// main.go BEFORE providers so the same registry instance feeds both the WS
+// handler and provider routing.
+func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log zerolog.Logger) (*Registry, error) {
+	r := &Registry{
+		set:          make(map[string]*ProviderSet, 1),
+		agentGateway: agentGateway,
+		routeReads:   cfg.AgentRouteReads,
+		localRegion:  cfg.LocalRegion,
+		localZone:    cfg.LocalZone,
+		log:          log,
+	}
+
+	// ── Compute provider (harvester) with the routed cluster-access seam ───────
+	// Only the harvester path supports the M-C read slice. WithRoutedAccessor
+	// builds the Routed accessor over the client's OWN dynamic client (the Direct
+	// fallback), so the off-path and every not-yet-routed method share one client.
+	var compute ComputeProvider
+	switch cfg.VMProvider {
+	case "harvester":
+		hc, err := harvester.NewClient(cfg.HarvesterKubeconfig, cfg.HarvesterNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("build harvester client for registry: %w", err)
+		}
+		decide := r.agentDecision(cfg)
+		hc.WithRoutedAccessor(func(direct clusteraccess.Accessor) clusteraccess.Accessor {
+			return clusteraccess.NewRouted(direct, decide)
+		})
+		compute = hc
+	default:
+		// Non-harvester compute providers don't have the seam yet — fall back to
+		// the plain factory (Direct behaviour). Nothing routes through the agent.
+		c, err := NewComputeProvider(cfg)
+		if err != nil {
+			return nil, err
+		}
+		compute = c
+	}
+
+	// ── Cluster + Network providers: plain Direct (unchanged) ──────────────────
+	cluster, err := NewClusterProvider(cfg)
+	if err != nil {
+		return nil, err
+	}
+	network, err := NewNetworkProvider(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	r.set[registryKey(cfg.LocalRegion, cfg.LocalZone)] = &ProviderSet{
+		Compute: compute,
+		Cluster: cluster,
+		Network: network,
+	}
+
+	if agentGateway != nil && cfg.AgentRouteReads {
+		log.Info().
+			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
+			Msg("provider registry: agent read-routing ENABLED (DCAPI_AGENT_ROUTE_READS=true) — routes only when a live agent is connected for the zone")
+	} else {
+		log.Info().
+			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
+			Bool("toggle", cfg.AgentRouteReads).Bool("gateway", agentGateway != nil).
+			Msg("provider registry: agent read-routing disabled — using the direct cluster path")
+	}
+	return r, nil
+}
+
+// For returns the cached provider set for a (region, zone). Only the local zone
+// exists in M-C; any other zone is an error (no second zone is provisioned yet).
+func (r *Registry) For(region, zone string) (*ProviderSet, error) {
+	r.mu.RLock()
+	set, ok := r.set[registryKey(region, zone)]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("no provider set for zone %s/%s (only the local zone %s/%s is configured)",
+			region, zone, r.localRegion, r.localZone)
+	}
+	return set, nil
+}
+
+// agentDecision builds the live decision closure for the local zone's Routed
+// accessor. It re-evaluates the toggle + live-session check + verb allow-set on
+// EVERY call, so "toggle on / toggle off" and "agent connected / disconnected"
+// are observable on the very next request with no provider reconstruction.
+//
+// The routed allow-set starts as {VerbGet} for the M-C read slice. Each write
+// phase widens it verb-by-verb IN THE SAME PR as the matching dc-agent RBAC rule
+// — never one without the other. Until a verb is added here it always returns
+// (_, false) → Direct.
+func (r *Registry) agentDecision(cfg *config.Config) clusteraccess.AgentDecision {
+	mapper := clusteraccess.DefaultGVKMapper()
+	fieldManager := "dc-api"
+	region, zone := cfg.LocalRegion, cfg.LocalZone
+
+	return func(verb clusteraccess.Verb) (clusteraccess.Accessor, bool) {
+		// (1) read toggle, (2) gateway present.
+		if !r.routeReads || r.agentGateway == nil {
+			return nil, false
+		}
+		// (4) verb allow-set for the current phase: reads only (Get).
+		if verb != clusteraccess.VerbGet {
+			return nil, false
+		}
+		// (3) a live agent session must exist for the zone RIGHT NOW.
+		sess, ok := r.agentGateway.Session(region, zone)
+		if !ok {
+			return nil, false
+		}
+		return clusteraccess.NewAgentBacked(sess, region, zone, fieldManager, mapper, r.log), true
+	}
+}

--- a/dc-api/internal/providers/registry_test.go
+++ b/dc-api/internal/providers/registry_test.go
@@ -1,0 +1,97 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/wso2/dc-api/internal/agentgw"
+	"github.com/wso2/dc-api/internal/config"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+// fakeResolver is an agentgw.SessionResolver that returns a fixed presence
+// answer. The decision closure only checks the boolean (presence); it never
+// calls the Session, but a non-nil one is returned so the contract holds.
+type fakeResolver struct{ connected bool }
+
+func (f fakeResolver) Session(region, zone string) (agentgw.Session, bool) {
+	if !f.connected {
+		return nil, false
+	}
+	return stubSession{}, true
+}
+
+// stubSession is a no-op agentgw.Session (the decision path never invokes it).
+type stubSession struct{}
+
+func (stubSession) Apply(context.Context, json.RawMessage, string, bool) (agentgw.ApplyResult, error) {
+	return agentgw.ApplyResult{}, nil
+}
+func (stubSession) Delete(context.Context, agentgw.ResourceRef, string) (agentgw.DeleteResult, error) {
+	return agentgw.DeleteResult{}, nil
+}
+func (stubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+	return agentgw.StatusSnapshot{}, nil
+}
+func (stubSession) WatchStatus(context.Context, agentgw.ResourceRef, int, func(string, agentgw.StatusSnapshot)) (agentgw.WatchResult, error) {
+	return agentgw.WatchResult{}, nil
+}
+
+// decisionRegistry builds a *Registry wired only with the fields agentDecision
+// reads (no kubeconfig parsing), so we can unit-test the gating logic directly.
+func decisionRegistry(routeReads bool, gw agentgw.SessionResolver) *Registry {
+	return &Registry{
+		agentGateway: gw,
+		routeReads:   routeReads,
+		localRegion:  "lk",
+		localZone:    "zone-1",
+		log:          zerolog.Nop(),
+	}
+}
+
+func cfgWith(routeReads bool) *config.Config {
+	return &config.Config{LocalRegion: "lk", LocalZone: "zone-1", AgentRouteReads: routeReads}
+}
+
+func TestAgentDecision_ToggleOff_AlwaysDirect(t *testing.T) {
+	r := decisionRegistry(false, fakeResolver{connected: true})
+	decide := r.agentDecision(cfgWith(false))
+	if _, ok := decide(clusteraccess.VerbGet); ok {
+		t.Error("toggle off must NOT route to the agent (Get)")
+	}
+}
+
+func TestAgentDecision_NoGateway_AlwaysDirect(t *testing.T) {
+	r := decisionRegistry(true, nil)
+	decide := r.agentDecision(cfgWith(true))
+	if _, ok := decide(clusteraccess.VerbGet); ok {
+		t.Error("nil gateway must NOT route to the agent")
+	}
+}
+
+func TestAgentDecision_ToggleOn_NoLiveAgent_Direct(t *testing.T) {
+	r := decisionRegistry(true, fakeResolver{connected: false})
+	decide := r.agentDecision(cfgWith(true))
+	if _, ok := decide(clusteraccess.VerbGet); ok {
+		t.Error("toggle on but no connected agent must fall back to Direct")
+	}
+}
+
+func TestAgentDecision_ToggleOn_LiveAgent_RoutesGetOnly(t *testing.T) {
+	r := decisionRegistry(true, fakeResolver{connected: true})
+	decide := r.agentDecision(cfgWith(true))
+
+	if _, ok := decide(clusteraccess.VerbGet); !ok {
+		t.Error("toggle on + live agent must route Get through the agent")
+	}
+	// Write verbs are NOT in the M-C allow-set — must stay Direct even with a
+	// live agent and the read toggle on.
+	for _, v := range []clusteraccess.Verb{clusteraccess.VerbList, clusteraccess.VerbCreate, clusteraccess.VerbApply, clusteraccess.VerbUpdate, clusteraccess.VerbDelete} {
+		if _, ok := decide(v); ok {
+			t.Errorf("verb %v must NOT route in M-C (read-only allow-set)", v)
+		}
+	}
+}


### PR DESCRIPTION
## What this changes

dc-api manages VMs and networks by talking to the datacenter's Kubernetes (Harvester) directly, with a master credential it holds. This adds the plumbing for an alternative path: handing an operation to the small **agent** that runs inside the datacenter, over the connection that agent already keeps open to the control plane — so the work runs locally with the datacenter's own credentials, and the control plane never needs that cluster's keys. (This is also what will let a *second* datacenter, which the control plane can't reach into directly, be managed the same way as the local one.)

This PR wires that path for **one read only — looking up a VM's status** — and it is **turned off by default**, behind a new setting `DCAPI_AGENT_ROUTE_READS` (default `false`). With the setting off, dc-api behaves exactly as it does today. Nothing else is routed through the agent yet.

## Why it's safe to merge

- **Off by default.** With the new setting unchanged, every operation still uses the existing direct path, byte-for-byte. Turning it on is a deliberate, reversible config change — and even then it only engages when an agent is actually connected for that zone.
- **No interface change.** The provider interfaces the request handlers use are unchanged; a handler can't tell whether a call went direct or through the agent.
- **Can't stall the system.** Every agent-routed call has a 30-second timeout, so a slow or unresponsive agent returns an error instead of blocking the background reconciler. There's a test that proves a hung agent surfaces as a timeout, not a hang.

## How it's structured (for code reviewers)

- `internal/agentgw/` — a small new package holding the agent's message types and a lookup interface. It exists so the provider code can use the agent **without** importing the API-handlers package, which would create an import cycle. The existing agent message structs move here and are aliased back, so the agent's wire format is unchanged.
- `internal/providers/clusteraccess/` — an `Accessor` with two implementations: `Direct` (the current Kubernetes-client path, untouched) and `AgentBacked` (sends the call to the agent). A `Routed` wrapper chooses between them per call.
- `internal/providers/registry.go` — resolves the right providers for a given region/zone.
- The Harvester provider now routes only its VM-status read through this, and only when the setting is on.

## How to verify

- In `dc-api/`: `go build ./... && go vet ./... && go test ./...` — all green (race-tested on the changed packages); no import cycle (the build proves it).
- With the setting off (the default), behavior is identical to before this PR.
- Intended end-to-end check, after this merges and deploys: set `DCAPI_AGENT_ROUTE_READS=true` in a dev environment and confirm a VM-status lookup is served by the in-datacenter agent. The agent's current read-only permissions already allow reading VMs, so this needs no permission changes.

## Not in this PR

Creating or deleting VMs and networks through the agent — and the matching agent permission grants — come in later, separate PRs, one resource type at a time. This change is read-only and purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
