### PR TITLE
Route VM create and delete through the agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,19 @@ export DCAPI_LOCAL_ZONE="zone-1"    # local zone slug (zones table); pairs with 
 # Only takes effect for a zone with a live agent connected — otherwise reads fall
 # back to the direct client regardless. Write toggles land per phase later.
 export DCAPI_AGENT_ROUTE_READS="false"
+#
+# DCAPI_AGENT_ROUTE_WRITES routes provider WRITE ops (VM create + VM delete first)
+# through the per-zone agent instead of the direct Harvester client; default false
+# keeps writes on the direct path. With this OFF, VM create is the unchanged
+# dynamic POST and delete the unchanged dynamic delete (byte-identical). With it
+# ON for a zone with a live agent, create routes as a server-side apply (the
+# agent's only create mechanism) and delete to the agent's delete. Independent of
+# DCAPI_AGENT_ROUTE_READS — reads can be on while writes stay off. Only takes
+# effect for a zone with a live agent connected. The agent's RBAC must already
+# permit the verb (create/patch/delete on virtualmachines) BEFORE flipping this
+# on — a routed write to an under-permissioned agent fails the op (it does NOT
+# fall back to the direct path).
+export DCAPI_AGENT_ROUTE_WRITES="false"
 
 # ── Server ───────────────────────────────────────────────────────────────────
 export DCAPI_LOG_LEVEL="debug"      # debug for local dev; info for prod

--- a/dc-api/internal/config/config.go
+++ b/dc-api/internal/config/config.go
@@ -287,9 +287,17 @@ type Config struct {
 	// routes that zone's provider READ ops (VM status reads first) through the
 	// dc-agent command channel instead of the direct dynamic client. Default
 	// false: the direct path is unchanged until an operator explicitly opts in
-	// per zone-with-connected-agent. Write toggles (AgentRouteVMWrites, …) land
-	// per phase as each resource family is cut over.
+	// per zone-with-connected-agent. Write toggles (AgentRouteWrites) land per
+	// phase as each resource family is cut over.
 	AgentRouteReads bool `envconfig:"AGENT_ROUTE_READS" default:"false"`
+
+	// AgentRouteWrites, when true AND a live agent is connected for a zone, routes
+	// that zone's provider WRITE ops in the routed allow-set (VM create/delete
+	// first) through the dc-agent command channel. Independent of AgentRouteReads:
+	// reads can be on while writes stay off. Default false so writes stay on the
+	// direct path even after the write seam merges, until an operator opts in for a
+	// zone with a connected agent whose RBAC already permits the op.
+	AgentRouteWrites bool `envconfig:"AGENT_ROUTE_WRITES" default:"false"`
 
 	// ── Logging ───────────────────────────────────────────────────────────────
 	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`

--- a/dc-api/internal/config/config_test.go
+++ b/dc-api/internal/config/config_test.go
@@ -1,0 +1,76 @@
+package config
+
+import "testing"
+
+// setRequiredEnv sets the minimum DCAPI_* variables marked required:"true" so
+// config.Load() succeeds. The toggle tests then layer the AGENT_ROUTE_* vars on
+// top. t.Setenv auto-restores every key at the end of the test.
+func setRequiredEnv(t *testing.T) {
+	t.Helper()
+	required := map[string]string{
+		"DCAPI_DB_URL":                       "postgres://u:p@localhost:5432/db?sslmode=disable",
+		"DCAPI_OIDC_ISSUER":                  "https://issuer.example.com",
+		"DCAPI_OIDC_AUDIENCE":                "test-client",
+		"DCAPI_HARVESTER_KUBECONFIG":         "ZHVtbXk=", // base64("dummy")
+		"DCAPI_RANCHER_URL":                  "https://rancher.example.com",
+		"DCAPI_RANCHER_TOKEN":                "token-xyz",
+		"DCAPI_RANCHER_HARVESTER_CREDENTIAL": "cattle-global-data:cc-xxxxx",
+		"DCAPI_VPC_EXTERNAL_BRIDGE":          "mgmt-br",
+		"DCAPI_VPC_EXTERNAL_CIDR":            "192.168.10.0/24",
+		"DCAPI_VPC_EXTERNAL_GATEWAY":         "192.168.10.254",
+	}
+	for k, v := range required {
+		t.Setenv(k, v)
+	}
+}
+
+// TestAgentRouteWrites_DefaultFalse asserts the write toggle defaults to false
+// when the env var is unset — writes stay on the direct path until an operator
+// opts in.
+func TestAgentRouteWrites_DefaultFalse(t *testing.T) {
+	setRequiredEnv(t)
+	// Intentionally do NOT set DCAPI_AGENT_ROUTE_WRITES.
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.AgentRouteWrites {
+		t.Error("AgentRouteWrites = true by default, want false")
+	}
+}
+
+// TestAgentRouteToggles_Independent asserts the read and write toggles are wired
+// to distinct env vars and move independently — reads can be on while writes stay
+// off, and vice versa.
+func TestAgentRouteToggles_Independent(t *testing.T) {
+	cases := []struct {
+		name                  string
+		reads, writes         string
+		wantReads, wantWrites bool
+	}{
+		{"both off", "false", "false", false, false},
+		{"reads on, writes off", "true", "false", true, false},
+		{"reads off, writes on", "false", "true", false, true},
+		{"both on", "true", "true", true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setRequiredEnv(t)
+			t.Setenv("DCAPI_AGENT_ROUTE_READS", tc.reads)
+			t.Setenv("DCAPI_AGENT_ROUTE_WRITES", tc.writes)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+			if cfg.AgentRouteReads != tc.wantReads {
+				t.Errorf("AgentRouteReads = %v, want %v", cfg.AgentRouteReads, tc.wantReads)
+			}
+			if cfg.AgentRouteWrites != tc.wantWrites {
+				t.Errorf("AgentRouteWrites = %v, want %v", cfg.AgentRouteWrites, tc.wantWrites)
+			}
+		})
+	}
+}

--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -29,11 +29,33 @@ const agentCallTimeout = 30 * time.Second
 // depends on the neutral agentgw.Session interface, never on package handlers,
 // so there is no import cycle.
 //
-// M-C maps only the status-shaped Get onto an agent op (Session.GetStatus). The
-// mutating verbs (Create/Update/Apply/Delete) and List are stubbed to return
-// ErrOpNotRoutable until their write phase lands AND the matching dc-agent RBAC
-// is widened in the same PR. Routed treats ErrOpNotRoutable as "fall back to
-// Direct", so an un-cut-over verb is never worse than today.
+// Op coverage: the status-shaped Get maps onto Session.GetStatus (read slice);
+// Create/Update/Apply all map onto Session.Apply and Delete onto Session.Delete
+// (write slice 1 — VM create/delete). These verbs are IMPLEMENTED, not stubbed.
+// List has no agent op yet (M-D) and still returns ErrOpNotRoutable so Routed
+// falls back to Direct.
+//
+// NOTE on Create: the agent exposes only server-side apply (Session.Apply) as its
+// create mechanism, so AgentBacked.Create is an SSA, NOT a POST. This is the one
+// intentional asymmetry with the Direct seam, whose Create is a plain dynamic POST
+// (byte-identical to the pre-seam behaviour). It is acceptable because it lives
+// solely on the opt-in agent path (DCAPI_AGENT_ROUTE_WRITES); the default
+// toggle-OFF create stays a POST.
+//
+// Activation is NOT decided here — it is gated by the Routed allow-set (which the
+// per-family DCAPI_AGENT_ROUTE_{READS,WRITES} toggles drive). A verb the allow-set
+// does not include is chosen as Direct BEFORE any method here is called, so no
+// agent op runs. CRITICALLY, for a verb the allow-set DOES activate, this
+// accessor's return value — success OR error — is TERMINAL in Routed: there is no
+// mid-call fallback to Direct (see routed.go). The load-bearing invariant that
+// keeps that safe: for a mapped, supported resource an activated write verb must
+// never return ErrOpNotRoutable. ErrOpNotRoutable is produced only for an
+// unmapped GVR (a programming error — VMs are mapped) or an OP_UNSUPPORTED reply
+// (gone once the agent's op handler + RBAC ship in the activating PR). A genuine
+// write failure — RBAC 403, timeout, dropped channel — surfaces as a real error
+// (403 passes through translateErr unchanged; a dropped channel becomes a
+// retryable "agent unavailable"), so a misconfigured routed write fails LOUDLY
+// rather than silently double-running on Direct.
 type AgentBacked struct {
 	sess         agentgw.Session
 	region, zone string
@@ -156,11 +178,15 @@ func (a *AgentBacked) List(ctx context.Context, gvr schema.GroupVersionResource,
 	return nil, fmt.Errorf("clusteraccess: list of %s not routable: %w", gvr.Resource, agentgw.ErrOpNotRoutable)
 }
 
-// Create / Update / Apply all map to Session.Apply (SSA is create-or-update)
-// once a resource family is cut over in its write phase. Until then they return
-// ErrOpNotRoutable so Routed uses the direct path. The implementation below is
-// the shape the write phases will enable; it is unreachable in M-C because the
-// Routed allow-set does not include any mutating verb.
+// Create / Update / Apply all map to Session.Apply (SSA is create-or-update) —
+// server-side apply is the only mutating mechanism the agent exposes. They are
+// LIVE for the VM write slice: the Routed allow-set activates VerbCreate (and
+// VerbDelete) behind DCAPI_AGENT_ROUTE_WRITES, so the CreateVM call site's
+// c.access.Create(...) reaches Session.Apply here when the toggle is on and a live
+// agent serves the zone. The create therefore becomes an SSA on the agent path
+// (vs a plain POST on the Direct path) — the intentional asymmetry documented on
+// the type above. For a mapped GVR (VMs are mapped) these never return
+// ErrOpNotRoutable — only a real apply failure or, transiently, agent-unavailable.
 func (a *AgentBacked) Create(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
 	return a.apply(ctx, gvr, ns, obj)
 }
@@ -169,6 +195,10 @@ func (a *AgentBacked) Update(ctx context.Context, gvr schema.GroupVersionResourc
 	return a.apply(ctx, gvr, ns, obj)
 }
 
+// Apply deliberately IGNORES the caller's fieldManager argument and uses
+// a.fieldManager instead: the agent owns the field-manager identity for every op
+// it applies (it is fixed at the agent boundary, not chosen per call site), so the
+// caller's value is intentionally not forwarded. This is by design, not a bug.
 func (a *AgentBacked) Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ string, force bool) (*unstructured.Unstructured, error) {
 	return a.applyForce(ctx, gvr, ns, obj, force)
 }

--- a/dc-api/internal/providers/clusteraccess/routed.go
+++ b/dc-api/internal/providers/clusteraccess/routed.go
@@ -69,6 +69,14 @@ func (r *Routed) List(ctx context.Context, gvr schema.GroupVersionResource, ns s
 
 func (r *Routed) Create(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error) {
 	if a, ok := r.agent(VerbCreate); ok {
+		// TERMINAL on activation: once the agent is chosen its result — success OR
+		// error — is returned directly; there is NO re-check and NO retry on
+		// r.direct. This is the no-double-execution boundary for the routed VM
+		// create: an activated create that fails (RBAC 403, timeout, dropped
+		// channel) propagates as an error and must NOT also run on Direct. NOTE the
+		// asymmetry: the agent path is a server-side apply (the agent's only create
+		// mechanism), while the Direct fallback below is a plain dynamic POST — see
+		// agent.go for why that is safe and intended.
 		return a.Create(ctx, gvr, ns, obj, opts)
 	}
 	return r.direct.Create(ctx, gvr, ns, obj, opts)
@@ -76,6 +84,12 @@ func (r *Routed) Create(ctx context.Context, gvr schema.GroupVersionResource, ns
 
 func (r *Routed) Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error) {
 	if a, ok := r.agent(VerbApply); ok {
+		// TERMINAL on activation: once the agent is chosen, its result — success OR
+		// error — is returned directly. There is NO errors.Is(err, ErrOpNotRoutable)
+		// re-check and NO retry on r.direct here. This is the no-double-execution
+		// boundary: an activated apply that fails (RBAC 403, timeout, dropped
+		// channel) propagates as an error and must NOT also run on Direct. Do not
+		// add a fallback here — see agent.go for the invariant that keeps it safe.
 		return a.Apply(ctx, gvr, ns, obj, fieldManager, force)
 	}
 	return r.direct.Apply(ctx, gvr, ns, obj, fieldManager, force)
@@ -90,6 +104,10 @@ func (r *Routed) Update(ctx context.Context, gvr schema.GroupVersionResource, ns
 
 func (r *Routed) Delete(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error {
 	if a, ok := r.agent(VerbDelete); ok {
+		// TERMINAL on activation: the agent's result is returned directly — no
+		// re-check, no retry on r.direct. The no-double-execution boundary: an
+		// activated delete that fails must NOT also run on Direct. Do not add a
+		// fallback here — see agent.go for the invariant that keeps it safe.
 		return a.Delete(ctx, gvr, ns, name, opts)
 	}
 	return r.direct.Delete(ctx, gvr, ns, name, opts)

--- a/dc-api/internal/providers/harvester/client.go
+++ b/dc-api/internal/providers/harvester/client.go
@@ -95,10 +95,12 @@ type Client struct {
 
 	// access is the per-zone cluster-access seam (M-C). It defaults to a
 	// clusteraccess.Direct wrapping `dynamic` (today's behaviour, byte-identical)
-	// unless WithRoutedAccessor injects a routed accessor. Only GetVM's primary
-	// VirtualMachine read goes through it for the M-C read slice; every other
-	// method still calls c.dynamic directly. The seam never leaks an agent
-	// concept past the ComputeProvider interface.
+	// unless WithRoutedAccessor injects a routed accessor. The VM-object ops route
+	// through it: GetVM's primary VirtualMachine read (read slice), and CreateVM's
+	// create + DeleteVM's delete (write slice 1). Image resolution, the cloud-
+	// provider SA bootstrap, ListVMs, and the VMI read inside GetVM all still call
+	// c.dynamic directly — those GVRs are not in the agent's mapper/RBAC. The seam
+	// never leaks an agent concept past the ComputeProvider interface.
 	access clusteraccess.Accessor
 }
 
@@ -192,10 +194,16 @@ func (c *Client) CreateVM(ctx context.Context, tenantID, projectID string, spec 
 
 	vmManifest := buildVMManifest(spec, ns, imageID, storageClass, mac)
 
-	_, err = c.dynamic.
-		Resource(harvesterVMResource).
-		Namespace(ns).
-		Create(ctx, vmManifest, metav1.CreateOptions{})
+	// VM-object create goes through the cluster-access seam (c.access). With the
+	// write toggle OFF (default) this is clusteraccess.Direct.Create — the exact
+	// dynamic-client POST (.Resource(gvr).Namespace(ns).Create(...)) this method ran
+	// before the write slice, so it is byte-identical. With the toggle ON and a live
+	// agent for the zone, this routes to the agent's create, which is a server-side
+	// apply (the only create mechanism the agent exposes); the agent error is
+	// terminal (no silent Direct fallback). The asymmetry (direct=POST, agent=SSA)
+	// lives only on the opt-in agent path. Image resolution above stays on
+	// c.dynamic.
+	_, err = c.access.Create(ctx, harvesterVMResource, ns, vmManifest, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("harvester create VM %q in %s: %w", spec.Name, ns, err)
 	}
@@ -297,13 +305,18 @@ func (c *Client) DeleteVM(ctx context.Context, backendUID string) error {
 		return err
 	}
 
+	// VM-object delete goes through the cluster-access seam (c.access). With the
+	// write toggle OFF (default) this is clusteraccess.Direct.Delete — the exact
+	// dynamic-client delete with PropagationPolicy=Background as before, byte-
+	// identical. With the toggle ON and a live agent for the zone, this routes to
+	// Session.Delete; the agent error is terminal (no silent Direct fallback). On
+	// both seams a missing object is a successful idempotent delete: Direct surfaces
+	// a NotFound that IsNotFound swallows here; the agent maps Existed==false to a
+	// nil error.
 	propagation := metav1.DeletePropagationBackground
-	err = c.dynamic.
-		Resource(harvesterVMResource).
-		Namespace(ns).
-		Delete(ctx, name, metav1.DeleteOptions{
-			PropagationPolicy: &propagation,
-		})
+	err = c.access.Delete(ctx, harvesterVMResource, ns, name, metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+	})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		// IsNotFound is fine — the VM is already gone, deletion goal is achieved.
 		return fmt.Errorf("harvester delete VM %s: %w", backendUID, err)

--- a/dc-api/internal/providers/harvester/vmwrite_seam_test.go
+++ b/dc-api/internal/providers/harvester/vmwrite_seam_test.go
@@ -1,0 +1,538 @@
+package harvester
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/wso2/dc-api/internal/agentgw"
+	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+// This file proves the VM write slice (write slice 1):
+//
+//   - Toggle OFF  → CreateVM uses the DIRECT create (a plain dynamic POST, NOT
+//     Direct.Apply/SSA) and DeleteVM uses the DIRECT delete; the agent is never
+//     touched (byte-identical to pre-write-slice behaviour). The explicit
+//     direct.applyCount()==0 assertions are the regression guard for the bug this
+//     slice fixes — toggle-OFF create must stay a POST, not silently become SSA.
+//   - Toggle ON + live session → CreateVM routes to the agent's create (which is
+//     Session.Apply — the agent's only create mechanism) and DeleteVM routes to
+//     Session.Delete, and the result is mapped correctly.
+//   - Toggle ON + agent write ERROR → the error SURFACES and the DIRECT seam is
+//     NOT called (the no-double-execution guard). Covered for BOTH a plain
+//     transport error AND an *agentgw.AgentError{Code: OP_UNSUPPORTED}.
+//   - No connected agent (decision returns false) → DIRECT seam, as the registry
+//     does when r.agentGateway.Session(...) returns !ok.
+//
+// It complements getvm_seam_test.go (the read slice). To avoid redeclaring the
+// helpers that file already owns (seamStubSession, newFakeDynamicWithVM, the
+// testVM* consts), this file defines its own call-counting stub session and a
+// call-counting Direct decorator.
+
+// ── A configurable, call-counting agent Session stub ─────────────────────────
+
+// writeStubSession records Apply/Delete invocations and returns a programmable
+// result/error for each. It satisfies agentgw.Session (the read methods are
+// inert — this slice exercises writes).
+type writeStubSession struct {
+	mu sync.Mutex
+
+	applyCalls  int
+	deleteCalls int
+
+	applyResult agentgw.ApplyResult
+	applyErr    error
+
+	deleteResult agentgw.DeleteResult
+	deleteErr    error
+}
+
+func (s *writeStubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+	return agentgw.StatusSnapshot{}, nil
+}
+
+func (s *writeStubSession) Apply(_ context.Context, _ json.RawMessage, _ string, _ bool) (agentgw.ApplyResult, error) {
+	s.mu.Lock()
+	s.applyCalls++
+	s.mu.Unlock()
+	return s.applyResult, s.applyErr
+}
+
+func (s *writeStubSession) Delete(_ context.Context, _ agentgw.ResourceRef, _ string) (agentgw.DeleteResult, error) {
+	s.mu.Lock()
+	s.deleteCalls++
+	s.mu.Unlock()
+	return s.deleteResult, s.deleteErr
+}
+
+func (s *writeStubSession) WatchStatus(context.Context, agentgw.ResourceRef, int, func(string, agentgw.StatusSnapshot)) (agentgw.WatchResult, error) {
+	return agentgw.WatchResult{}, nil
+}
+
+func (s *writeStubSession) applyCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.applyCalls
+}
+
+func (s *writeStubSession) deleteCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deleteCalls
+}
+
+// ── A call-counting Direct decorator ─────────────────────────────────────────
+
+// countingAccessor is a fully synthetic Accessor that counts the write verbs so a
+// test can assert the DIRECT path was — or was NOT — taken, and WHICH verb it
+// took (createCalls vs applyCalls matters: toggle-OFF create must be a POST →
+// Create, never Apply/SSA). This is also how the no-double-execution guard is
+// proven: when the agent errors, createCalls / deleteCalls here must stay 0 (a
+// fallback would increment them).
+//
+// It is deliberately synthetic rather than wrapping a real clusteraccess.Direct
+// over a fake dynamic client, for two unavoidable client-go fake limitations:
+//
+//   - The dynamicfake Create reactor deep-copies the stored object as JSON and
+//     panics on a plain Go int ("cannot deep copy int"); buildVMManifest puts
+//     spec.CPU (an int) into the manifest. A live apiserver serializes over the
+//     wire so ints are fine — this is purely a fake-store artifact, so a real
+//     Direct.Create over the fake cannot be exercised here.
+//   - The dynamicfake SSA reactor does NOT support unstructured objects
+//     (apply-on-absent 404s; apply-on-existing errors "unable to find api field
+//     in struct Unstructured"), so Direct.Apply over the fake is equally
+//     off-limits.
+//
+// Production Direct.Create/Delete against a real apiserver is exercised by the
+// integration suite. Here the contract under test is the ROUTING decision and the
+// no-fallback guarantee, both of which are about which accessor (and which verb)
+// is invoked — the call counters capture that precisely without persisting.
+type countingAccessor struct {
+	mu          sync.Mutex
+	createCalls int
+	applyCalls  int
+	deleteCalls int
+}
+
+var _ clusteraccess.Accessor = (*countingAccessor)(nil)
+
+func (c *countingAccessor) Get(_ context.Context, _ schema.GroupVersionResource, ns, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubevirt.io/v1", "kind": "VirtualMachine",
+		"metadata": map[string]interface{}{"name": name, "namespace": ns},
+	}}, nil
+}
+
+func (c *countingAccessor) List(_ context.Context, _ schema.GroupVersionResource, _ string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+
+func (c *countingAccessor) Create(_ context.Context, _ schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	c.mu.Lock()
+	c.createCalls++
+	c.mu.Unlock()
+	// Synthetic success mirroring a dynamic POST (the created object echoes back).
+	// The toggle-OFF / no-agent CreateVM tests assert routing via this counter; no
+	// persistence is needed.
+	_ = ns
+	return obj, nil
+}
+
+func (c *countingAccessor) Apply(_ context.Context, _ schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ string, _ bool) (*unstructured.Unstructured, error) {
+	c.mu.Lock()
+	c.applyCalls++
+	c.mu.Unlock()
+	// Synthetic success mirroring a server-side apply (the object identity echoes
+	// back). Not on the CreateVM path any more — CreateVM uses Create — but kept so
+	// the decorator stays a full Accessor and any stray Apply is still counted.
+	_ = ns
+	return obj, nil
+}
+
+func (c *countingAccessor) Update(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (c *countingAccessor) Delete(_ context.Context, _ schema.GroupVersionResource, _, _ string, _ metav1.DeleteOptions) error {
+	c.mu.Lock()
+	c.deleteCalls++
+	c.mu.Unlock()
+	// Synthetic successful delete — mirrors Direct's IsNotFound-is-success
+	// observable. Routing is proven by the counter.
+	return nil
+}
+
+func (c *countingAccessor) createCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.createCalls
+}
+
+func (c *countingAccessor) applyCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.applyCalls
+}
+
+func (c *countingAccessor) deleteCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.deleteCalls
+}
+
+// ── Fake-dynamic helpers + a representative VMSpec ───────────────────────────
+
+// newEmptyFakeDynamic returns a fake dynamic client with NO objects, so a DeleteVM
+// sees no object (and CreateVM, when it reaches a real store, would be a fresh
+// create). resolveImage does NOT go through the seam, so CreateVM tests pre-seed
+// an image object via newFakeDynamicWithImage instead.
+func newEmptyFakeDynamic() *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		harvesterVMResource:  "VirtualMachineList",
+		harvesterVMIResource: "VirtualMachineInstanceList",
+		vmImageGVR:           "VirtualMachineImageList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+}
+
+// newFakeDynamicWithImage seeds a ready VirtualMachineImage (status.storageClassName
+// populated) so resolveImage — which always runs on c.dynamic — succeeds. The VM
+// store itself stays empty.
+func newFakeDynamicWithImage(imageName, storageClass string) *dynamicfake.FakeDynamicClient {
+	img := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "harvesterhci.io/v1beta1",
+		"kind":       "VirtualMachineImage",
+		"metadata": map[string]interface{}{
+			"name":      "image-abc123",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"displayName": imageName,
+		},
+		"status": map[string]interface{}{
+			"storageClassName": storageClass,
+		},
+	}}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		harvesterVMResource:  "VirtualMachineList",
+		harvesterVMIResource: "VirtualMachineInstanceList",
+		vmImageGVR:           "VirtualMachineImageList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, img)
+}
+
+func sampleVMSpec() models.VMSpec {
+	return models.VMSpec{
+		Name:       testVMName,
+		ResourceID: "11111111-2222-3333-4444-555555555555",
+		ImageName:  "ubuntu-22.04",
+		CPU:        2,
+		MemoryGB:   4,
+		DiskGB:     20,
+		// Legacy bridge path (no VNet/Subnet) keeps the manifest simple; the seam
+		// routing under test is identical regardless of the network shape.
+		NetworkName: "default/vm-network",
+	}
+}
+
+// writeRouted builds a Routed accessor whose decision allows ONLY VerbCreate and
+// VerbDelete (mirroring the registry's write allow-set) and returns the supplied
+// agent accessor for them. direct is the call-counting Direct decorator so a test
+// can assert whether the direct path ran. allow=false models the toggle-off /
+// no-connected-agent case (always Direct).
+func writeRouted(direct clusteraccess.Accessor, agent clusteraccess.Accessor, allow bool) *clusteraccess.Routed {
+	return clusteraccess.NewRouted(direct, func(v clusteraccess.Verb) (clusteraccess.Accessor, bool) {
+		if !allow {
+			return nil, false
+		}
+		switch v {
+		case clusteraccess.VerbCreate, clusteraccess.VerbDelete:
+			return agent, true
+		default:
+			return nil, false
+		}
+	})
+}
+
+// ── Toggle OFF: CreateVM/DeleteVM use Direct; agent untouched ────────────────
+
+func TestCreateVM_ToggleOff_UsesDirect_AgentUntouched(t *testing.T) {
+	dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
+	direct := &countingAccessor{}
+	sess := &writeStubSession{}
+	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+	c := &Client{
+		dynamic: dyn,
+		access:  writeRouted(direct, agent, false), // toggle OFF → never routes
+	}
+
+	res, err := c.CreateVM(context.Background(), "tenant", "proj", sampleVMSpec())
+	if err != nil {
+		t.Fatalf("CreateVM error: %v", err)
+	}
+	if res.Status != models.StatusPending {
+		t.Errorf("status = %q, want PENDING", res.Status)
+	}
+
+	// CreateVM must take the DIRECT create path (a plain POST) — NOT the agent, and
+	// NOT Direct.Apply (the bug this slice fixes: toggle-OFF create must stay POST).
+	if got := sess.applyCount(); got != 0 {
+		t.Errorf("agent Apply called %d times with toggle OFF, want 0", got)
+	}
+	if got := direct.createCount(); got != 1 {
+		t.Errorf("direct Create called %d times, want 1", got)
+	}
+	if got := direct.applyCount(); got != 0 {
+		t.Errorf("direct Apply called %d times with toggle OFF, want 0 (create must be a POST, not SSA)", got)
+	}
+}
+
+func TestDeleteVM_ToggleOff_UsesDirect_AgentUntouched(t *testing.T) {
+	dyn := newEmptyFakeDynamic()
+	direct := &countingAccessor{}
+	sess := &writeStubSession{}
+	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+	c := &Client{
+		dynamic: dyn,
+		access:  writeRouted(direct, agent, false),
+	}
+
+	// No object present → Direct returns NotFound, which DeleteVM swallows as a
+	// successful idempotent delete. The point is the DIRECT seam ran, not the agent.
+	if err := c.DeleteVM(context.Background(), testBackendUID); err != nil {
+		t.Fatalf("DeleteVM error: %v", err)
+	}
+	if got := sess.deleteCount(); got != 0 {
+		t.Errorf("agent Delete called %d times with toggle OFF, want 0", got)
+	}
+	if got := direct.deleteCount(); got != 1 {
+		t.Errorf("direct Delete called %d times, want 1", got)
+	}
+}
+
+// ── Toggle ON + live session: routes to the agent ───────────────────────────
+
+func TestCreateVM_ToggleOn_RoutesToAgentApply(t *testing.T) {
+	dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
+	direct := &countingAccessor{}
+	sess := &writeStubSession{
+		applyResult: agentgw.ApplyResult{
+			APIVersion:      "kubevirt.io/v1",
+			Kind:            "VirtualMachine",
+			Namespace:       "dc-tenant-proj",
+			Name:            testVMName,
+			UID:             "uid-1",
+			ResourceVersion: "42",
+		},
+	}
+	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+	c := &Client{
+		dynamic: dyn,
+		access:  writeRouted(direct, agent, true), // toggle ON
+	}
+
+	res, err := c.CreateVM(context.Background(), "tenant", "proj", sampleVMSpec())
+	if err != nil {
+		t.Fatalf("CreateVM error: %v", err)
+	}
+
+	// Agent create is a server-side apply (Session.Apply) — the agent's only create
+	// mechanism — so the agent's apply counter is what increments here.
+	if got := sess.applyCount(); got != 1 {
+		t.Errorf("agent Apply called %d times, want 1", got)
+	}
+	if got := direct.createCount(); got != 0 {
+		t.Errorf("direct Create called %d times with toggle ON, want 0", got)
+	}
+	if got := direct.applyCount(); got != 0 {
+		t.Errorf("direct Apply called %d times with toggle ON, want 0", got)
+	}
+	// BackendUID is built from ns:name regardless of seam — verify the mapping.
+	if want := "dc-tenant-proj:" + testVMName; res.BackendUID != want {
+		t.Errorf("BackendUID = %q, want %q", res.BackendUID, want)
+	}
+	if res.Status != models.StatusPending {
+		t.Errorf("status = %q, want PENDING", res.Status)
+	}
+
+	// The agent path must NOT have written to the local fake dynamic store.
+	if _, err := dyn.Resource(harvesterVMResource).Namespace("dc-tenant-proj").Get(context.Background(), testVMName, metav1.GetOptions{}); err == nil {
+		t.Error("VM unexpectedly present in the direct store — agent path should not touch it")
+	}
+}
+
+func TestDeleteVM_ToggleOn_RoutesToAgentDelete(t *testing.T) {
+	dyn := newEmptyFakeDynamic()
+	direct := &countingAccessor{}
+	sess := &writeStubSession{deleteResult: agentgw.DeleteResult{Existed: true}}
+	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+	c := &Client{
+		dynamic: dyn,
+		access:  writeRouted(direct, agent, true),
+	}
+
+	if err := c.DeleteVM(context.Background(), testBackendUID); err != nil {
+		t.Fatalf("DeleteVM error: %v", err)
+	}
+	if got := sess.deleteCount(); got != 1 {
+		t.Errorf("agent Delete called %d times, want 1", got)
+	}
+	if got := direct.deleteCount(); got != 0 {
+		t.Errorf("direct Delete called %d times with toggle ON, want 0", got)
+	}
+}
+
+// TestDeleteVM_ToggleOn_AgentMissingObjectIsSuccess proves the idempotent-delete
+// contract on the agent seam: Existed==false maps to a nil error (no double-run,
+// no spurious failure), matching Direct's IsNotFound-is-success behaviour.
+func TestDeleteVM_ToggleOn_AgentMissingObjectIsSuccess(t *testing.T) {
+	dyn := newEmptyFakeDynamic()
+	direct := &countingAccessor{}
+	sess := &writeStubSession{deleteResult: agentgw.DeleteResult{Existed: false}}
+	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+	c := &Client{dynamic: dyn, access: writeRouted(direct, agent, true)}
+
+	if err := c.DeleteVM(context.Background(), testBackendUID); err != nil {
+		t.Fatalf("DeleteVM error on absent object: %v", err)
+	}
+	if got := sess.deleteCount(); got != 1 {
+		t.Errorf("agent Delete called %d times, want 1", got)
+	}
+	if got := direct.deleteCount(); got != 0 {
+		t.Errorf("direct Delete called %d times, want 0 (no fallback on idempotent delete)", got)
+	}
+}
+
+// ── The load-bearing test: agent write error surfaces, NO direct fallback ────
+
+func TestCreateVM_ToggleOn_AgentError_SurfacesNoDirectFallback(t *testing.T) {
+	cases := []struct {
+		name     string
+		applyErr error
+	}{
+		{"plain transport error", errors.New("connection reset by peer")},
+		{"op unsupported", &agentgw.AgentError{Code: agentgw.CodeOpUnsupported, Message: "apply not implemented"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
+			direct := &countingAccessor{}
+			sess := &writeStubSession{applyErr: tc.applyErr}
+			agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+			c := &Client{dynamic: dyn, access: writeRouted(direct, agent, true)}
+
+			_, err := c.CreateVM(context.Background(), "tenant", "proj", sampleVMSpec())
+			if err == nil {
+				t.Fatal("CreateVM returned nil error; the agent write failure must surface")
+			}
+
+			// The agent was attempted exactly once (via Session.Apply, its only
+			// create mechanism)...
+			if got := sess.applyCount(); got != 1 {
+				t.Errorf("agent Apply called %d times, want 1", got)
+			}
+			// ...and the DIRECT seam was NEVER called — no double-execution. Both the
+			// POST create path and the (unused) Apply path must stay at 0.
+			if got := direct.createCount(); got != 0 {
+				t.Errorf("direct Create called %d times after agent error, want 0 (no fallback / no double-execution)", got)
+			}
+			if got := direct.applyCount(); got != 0 {
+				t.Errorf("direct Apply called %d times after agent error, want 0 (no fallback / no double-execution)", got)
+			}
+			// And nothing landed in the direct store.
+			if _, gerr := dyn.Resource(harvesterVMResource).Namespace("dc-tenant-proj").Get(context.Background(), testVMName, metav1.GetOptions{}); gerr == nil {
+				t.Error("VM present in direct store after agent error — Direct must not have run")
+			}
+		})
+	}
+}
+
+func TestDeleteVM_ToggleOn_AgentError_SurfacesNoDirectFallback(t *testing.T) {
+	cases := []struct {
+		name      string
+		deleteErr error
+	}{
+		{"plain transport error", errors.New("connection reset by peer")},
+		{"op unsupported", &agentgw.AgentError{Code: agentgw.CodeOpUnsupported, Message: "delete not implemented"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dyn := newEmptyFakeDynamic()
+			direct := &countingAccessor{}
+			sess := &writeStubSession{deleteErr: tc.deleteErr}
+			agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+			c := &Client{dynamic: dyn, access: writeRouted(direct, agent, true)}
+
+			err := c.DeleteVM(context.Background(), testBackendUID)
+			if err == nil {
+				t.Fatal("DeleteVM returned nil error; the agent write failure must surface")
+			}
+			if got := sess.deleteCount(); got != 1 {
+				t.Errorf("agent Delete called %d times, want 1", got)
+			}
+			if got := direct.deleteCount(); got != 0 {
+				t.Errorf("direct Delete called %d times after agent error, want 0 (no fallback / no double-execution)", got)
+			}
+		})
+	}
+}
+
+// ── No connected agent: decision returns false → Direct ──────────────────────
+
+// TestCreateVM_NoConnectedAgent_UsesDirect models the registry's behaviour when
+// the toggle is ON but agentGateway.Session(...) returns !ok (no live agent): the
+// decision returns (_, false) and Routed uses Direct. We model that exactly with
+// allow=false (the closure short-circuits identically). This is the safety belt:
+// flipping the env var can never strand the zone when the agent is down.
+func TestCreateVM_NoConnectedAgent_UsesDirect(t *testing.T) {
+	dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
+	direct := &countingAccessor{}
+	sess := &writeStubSession{}
+	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
+
+	// decision returns false (no live session) → Direct, even though "writes" are
+	// conceptually enabled.
+	c := &Client{dynamic: dyn, access: writeRouted(direct, agent, false)}
+
+	if _, err := c.CreateVM(context.Background(), "tenant", "proj", sampleVMSpec()); err != nil {
+		t.Fatalf("CreateVM error: %v", err)
+	}
+	if got := sess.applyCount(); got != 0 {
+		t.Errorf("agent Apply called %d times with no live agent, want 0", got)
+	}
+	if got := direct.createCount(); got != 1 {
+		t.Errorf("direct Create called %d times, want 1", got)
+	}
+	if got := direct.applyCount(); got != 0 {
+		t.Errorf("direct Apply called %d times with no live agent, want 0 (create must be a POST)", got)
+	}
+}
+
+// Compile-time assertion that the stub really satisfies the neutral Session
+// interface the seam depends on (catches a signature drift early).
+var _ agentgw.Session = (*writeStubSession)(nil)
+
+// Silence the unused-import linter for dynamic in case a future refactor drops
+// the only typed use; harmless and explicit.
+var _ dynamic.Interface = (*dynamicfake.FakeDynamicClient)(nil)

--- a/dc-api/internal/providers/registry.go
+++ b/dc-api/internal/providers/registry.go
@@ -1,8 +1,8 @@
 // Package providers — registry.go
 //
 // Registry resolves the provider set for a (region, zone) and decides, per call,
-// whether that zone's provider READ ops go through the direct dynamic client or
-// the zone's dc-agent command channel.
+// whether that zone's provider ops go through the direct dynamic client or the
+// zone's dc-agent command channel.
 //
 // ── M-C scope ─────────────────────────────────────────────────────────────────
 // The registry holds exactly ONE zone — the local zone (cfg.LocalRegion /
@@ -11,15 +11,19 @@
 // zone is constructed with a clusteraccess.Routed accessor whose decision
 // closure consults:
 //
-//  1. cfg.AgentRouteReads  (DCAPI_AGENT_ROUTE_READS; default false), AND
+//  1. the per-family toggle for the verb — AgentRouteReads (DCAPI_AGENT_ROUTE_READS,
+//     default false) for reads, AgentRouteWrites (DCAPI_AGENT_ROUTE_WRITES, default
+//     false) for the VM write slice — AND
 //  2. a non-nil agent gateway, AND
 //  3. a LIVE agent session for the zone right now, AND
-//  4. the verb being in the routed allow-set ({Get} for the read slice).
+//  4. the verb being in the routed allow-set ({Get} for reads; {Create, Delete}
+//     for the VM create/delete write slice).
 //
 // If ANY is false the accessor uses Direct — today's behaviour, byte-identical.
-// Condition 3 is the safety belt: even with the toggle on, a zone with no
+// Condition 3 is the safety belt: even with a toggle on, a zone with no
 // connected agent silently uses Direct, so flipping the env var can never strand
-// the local zone if the agent is down.
+// the local zone if the agent is down. The toggles are independent: reads can
+// route while writes stay on the direct path.
 //
 // cluster/network providers in the set are the plain Direct ones for now —
 // rancher is an HTTP Steve client (does not fit the Accessor seam) and network
@@ -58,6 +62,10 @@ type Registry struct {
 	// routeReads gates the dark read slice (DCAPI_AGENT_ROUTE_READS).
 	routeReads bool
 
+	// routeWrites gates the write slice (DCAPI_AGENT_ROUTE_WRITES): VM
+	// create (SSA apply) + delete first. Independent of routeReads.
+	routeWrites bool
+
 	localRegion, localZone string
 	log                    zerolog.Logger
 }
@@ -76,6 +84,7 @@ func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log z
 		set:          make(map[string]*ProviderSet, 1),
 		agentGateway: agentGateway,
 		routeReads:   cfg.AgentRouteReads,
+		routeWrites:  cfg.AgentRouteWrites,
 		localRegion:  cfg.LocalRegion,
 		localZone:    cfg.LocalZone,
 		log:          log,
@@ -123,6 +132,9 @@ func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log z
 		Network: network,
 	}
 
+	// One log line covering BOTH toggles so an operator can tell from the logs
+	// whether reads and/or writes route. Each only ever engages when a live agent
+	// is connected for the zone; with the gateway absent both are forced off.
 	if agentGateway != nil && cfg.AgentRouteReads {
 		log.Info().
 			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
@@ -132,6 +144,16 @@ func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log z
 			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
 			Bool("toggle", cfg.AgentRouteReads).Bool("gateway", agentGateway != nil).
 			Msg("provider registry: agent read-routing disabled — using the direct cluster path")
+	}
+	if agentGateway != nil && cfg.AgentRouteWrites {
+		log.Info().
+			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
+			Msg("provider registry: agent write-routing ENABLED (DCAPI_AGENT_ROUTE_WRITES=true) — VM create/delete route only when a live agent is connected for the zone and its RBAC permits the verb")
+	} else {
+		log.Info().
+			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
+			Bool("toggle", cfg.AgentRouteWrites).Bool("gateway", agentGateway != nil).
+			Msg("provider registry: agent write-routing disabled — VM writes use the direct cluster path")
 	}
 	return r, nil
 }
@@ -150,26 +172,45 @@ func (r *Registry) For(region, zone string) (*ProviderSet, error) {
 }
 
 // agentDecision builds the live decision closure for the local zone's Routed
-// accessor. It re-evaluates the toggle + live-session check + verb allow-set on
+// accessor. It re-evaluates the toggles + live-session check + verb allow-set on
 // EVERY call, so "toggle on / toggle off" and "agent connected / disconnected"
 // are observable on the very next request with no provider reconstruction.
 //
-// The routed allow-set starts as {VerbGet} for the M-C read slice. Each write
-// phase widens it verb-by-verb IN THE SAME PR as the matching dc-agent RBAC rule
-// — never one without the other. Until a verb is added here it always returns
-// (_, false) → Direct.
+// The routed allow-set is gated per family: reads (VerbGet) by AgentRouteReads,
+// writes (VerbCreate, VerbDelete — the VM create/delete slice) by AgentRouteWrites.
+// Each verb is added here IN THE SAME PR as the matching dc-agent RBAC rule —
+// never one without the other. Any verb not listed always returns (_, false) →
+// Direct.
+//
+// NOTE: the write allow-set uses VerbCreate (not VerbApply) because CreateVM
+// calls c.access.Create(...). On the Direct path that is a byte-identical POST;
+// only the AgentBacked path turns VerbCreate into a server-side apply, since SSA
+// is the agent's only create mechanism. VerbApply/VerbUpdate stay out until a
+// later phase needs them.
 func (r *Registry) agentDecision(cfg *config.Config) clusteraccess.AgentDecision {
 	mapper := clusteraccess.DefaultGVKMapper()
 	fieldManager := "dc-api"
 	region, zone := cfg.LocalRegion, cfg.LocalZone
 
 	return func(verb clusteraccess.Verb) (clusteraccess.Accessor, bool) {
-		// (1) read toggle, (2) gateway present.
-		if !r.routeReads || r.agentGateway == nil {
+		// (2) gateway present — shared precondition for any routing.
+		if r.agentGateway == nil {
 			return nil, false
 		}
-		// (4) verb allow-set for the current phase: reads only (Get).
-		if verb != clusteraccess.VerbGet {
+		// (1)+(4) per-family toggle AND verb allow-set, together.
+		//   reads  → AgentRouteReads  gates {VerbGet}
+		//   writes → AgentRouteWrites gates {VerbCreate, VerbDelete} (VM write slice)
+		// A verb not listed here always falls through to Direct.
+		switch verb {
+		case clusteraccess.VerbGet:
+			if !r.routeReads {
+				return nil, false
+			}
+		case clusteraccess.VerbCreate, clusteraccess.VerbDelete:
+			if !r.routeWrites {
+				return nil, false
+			}
+		default:
 			return nil, false
 		}
 		// (3) a live agent session must exist for the zone RIGHT NOW.

--- a/dc-api/internal/providers/registry_test.go
+++ b/dc-api/internal/providers/registry_test.go
@@ -42,18 +42,41 @@ func (stubSession) WatchStatus(context.Context, agentgw.ResourceRef, int, func(s
 
 // decisionRegistry builds a *Registry wired only with the fields agentDecision
 // reads (no kubeconfig parsing), so we can unit-test the gating logic directly.
+// It sets only the read toggle; tests that exercise write routing use
+// decisionRegistryToggles to set both.
 func decisionRegistry(routeReads bool, gw agentgw.SessionResolver) *Registry {
+	return decisionRegistryToggles(routeReads, false, gw)
+}
+
+// decisionRegistryToggles is decisionRegistry with both per-family toggles
+// (reads + writes) settable, so the write-routing cases can drive routeWrites
+// independently of routeReads.
+func decisionRegistryToggles(routeReads, routeWrites bool, gw agentgw.SessionResolver) *Registry {
 	return &Registry{
 		agentGateway: gw,
 		routeReads:   routeReads,
+		routeWrites:  routeWrites,
 		localRegion:  "lk",
 		localZone:    "zone-1",
 		log:          zerolog.Nop(),
 	}
 }
 
+// cfgWith builds a config with only the read toggle set (write toggle off).
 func cfgWith(routeReads bool) *config.Config {
-	return &config.Config{LocalRegion: "lk", LocalZone: "zone-1", AgentRouteReads: routeReads}
+	return cfgWithToggles(routeReads, false)
+}
+
+// cfgWithToggles builds a config with both per-family agent-routing toggles set.
+// agentDecision reads LocalRegion/LocalZone off cfg, so they are populated to
+// match decisionRegistry's zone.
+func cfgWithToggles(routeReads, routeWrites bool) *config.Config {
+	return &config.Config{
+		LocalRegion:      "lk",
+		LocalZone:        "zone-1",
+		AgentRouteReads:  routeReads,
+		AgentRouteWrites: routeWrites,
+	}
 }
 
 func TestAgentDecision_ToggleOff_AlwaysDirect(t *testing.T) {
@@ -81,17 +104,76 @@ func TestAgentDecision_ToggleOn_NoLiveAgent_Direct(t *testing.T) {
 }
 
 func TestAgentDecision_ToggleOn_LiveAgent_RoutesGetOnly(t *testing.T) {
-	r := decisionRegistry(true, fakeResolver{connected: true})
-	decide := r.agentDecision(cfgWith(true))
+	// Reads-only configuration: read toggle on, WRITE toggle off.
+	r := decisionRegistryToggles(true, false, fakeResolver{connected: true})
+	decide := r.agentDecision(cfgWithToggles(true, false))
 
 	if _, ok := decide(clusteraccess.VerbGet); !ok {
 		t.Error("toggle on + live agent must route Get through the agent")
 	}
-	// Write verbs are NOT in the M-C allow-set — must stay Direct even with a
-	// live agent and the read toggle on.
+	// With ONLY the read toggle on, no write verb may route — Create/Delete are
+	// gated by the (off) write toggle; List/Apply/Update are not in any allow-set.
 	for _, v := range []clusteraccess.Verb{clusteraccess.VerbList, clusteraccess.VerbCreate, clusteraccess.VerbApply, clusteraccess.VerbUpdate, clusteraccess.VerbDelete} {
 		if _, ok := decide(v); ok {
-			t.Errorf("verb %v must NOT route in M-C (read-only allow-set)", v)
+			t.Errorf("verb %v must NOT route with only the read toggle on", v)
+		}
+	}
+}
+
+// TestAgentDecision_WritesOn_LiveAgent_RoutesCreateAndDelete asserts the write
+// allow-set: with the write toggle on + a live agent, VerbCreate AND VerbDelete
+// route to the agent. Get follows the read toggle (off here → Direct), and the
+// non-allow-set verbs (List/Apply/Update) never route.
+func TestAgentDecision_WritesOn_LiveAgent_RoutesCreateAndDelete(t *testing.T) {
+	// writes on, reads off — proves the toggles are independent.
+	r := decisionRegistryToggles(false, true, fakeResolver{connected: true})
+	decide := r.agentDecision(cfgWithToggles(false, true))
+
+	for _, v := range []clusteraccess.Verb{clusteraccess.VerbCreate, clusteraccess.VerbDelete} {
+		if _, ok := decide(v); !ok {
+			t.Errorf("write toggle on + live agent must route verb %v through the agent", v)
+		}
+	}
+	// Read toggle is OFF here → Get must stay Direct.
+	if _, ok := decide(clusteraccess.VerbGet); ok {
+		t.Error("read toggle off must keep Get on Direct even when writes route")
+	}
+	// VerbApply/VerbUpdate are NOT in the write allow-set (create is VerbCreate, a
+	// POST on Direct); they must never route. VerbList has no agent op.
+	for _, v := range []clusteraccess.Verb{clusteraccess.VerbList, clusteraccess.VerbApply, clusteraccess.VerbUpdate} {
+		if _, ok := decide(v); ok {
+			t.Errorf("verb %v is not in the write allow-set and must NOT route", v)
+		}
+	}
+}
+
+// TestAgentDecision_WritesOff_CreateDeleteStayDirect asserts that with the write
+// toggle OFF, VerbCreate and VerbDelete fall through to Direct — even with a live
+// agent and the read toggle on. This is the load-bearing guard for "toggle-OFF
+// create stays the byte-identical POST on Direct".
+func TestAgentDecision_WritesOff_CreateDeleteStayDirect(t *testing.T) {
+	// reads on, writes off.
+	r := decisionRegistryToggles(true, false, fakeResolver{connected: true})
+	decide := r.agentDecision(cfgWithToggles(true, false))
+
+	for _, v := range []clusteraccess.Verb{clusteraccess.VerbCreate, clusteraccess.VerbDelete} {
+		if _, ok := decide(v); ok {
+			t.Errorf("write toggle off must keep verb %v on Direct", v)
+		}
+	}
+}
+
+// TestAgentDecision_WritesOn_NoLiveAgent_StayDirect asserts the safety belt for
+// writes: even with the write toggle on, a zone with no connected agent never
+// routes a write — Create/Delete fall through to Direct. Flipping the env var can
+// never strand the zone when the agent is down.
+func TestAgentDecision_WritesOn_NoLiveAgent_StayDirect(t *testing.T) {
+	r := decisionRegistryToggles(true, true, fakeResolver{connected: false})
+	decide := r.agentDecision(cfgWithToggles(true, true))
+
+	for _, v := range []clusteraccess.Verb{clusteraccess.VerbGet, clusteraccess.VerbCreate, clusteraccess.VerbDelete} {
+		if _, ok := decide(v); ok {
+			t.Errorf("no connected agent must keep verb %v on Direct even with the toggle on", v)
 		}
 	}
 }

--- a/flux/platform/dc-agent/base/rbac.yaml
+++ b/flux/platform/dc-agent/base/rbac.yaml
@@ -22,7 +22,10 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["kubevirt.io"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list", "watch"]
+    # create+patch = server-side apply (VM create); delete = VM delete.
+    # Widened for the agent VM write slice (DCAPI_AGENT_ROUTE_WRITES). Nothing
+    # broader: still scoped to virtualmachines only.
+    verbs: ["get", "list", "watch", "create", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What this changes

dc-api creates and deletes VMs by talking to the datacenter's Kubernetes (Harvester) directly. This adds the ability to instead hand those two operations to the **agent** running inside the datacenter, over the connection it already holds — so they run locally with the datacenter's own credentials. It's behind a new setting, **`DCAPI_AGENT_ROUTE_WRITES`, off by default**: with it off, creating and deleting VMs works exactly as it does today. This follows the earlier change that let the agent serve VM *reads*; this one adds *writes*, for VMs only.

## Why it's safe to merge

- **Off by default → no change.** With the setting off, VM create still uses the original direct create call (a normal POST) and delete still uses the original direct delete — byte-for-byte identical. There are tests asserting the agent is never touched when the setting is off. Only when the setting is on **and** an agent is connected for the zone do create/delete route through the agent.
- **No double-execution.** When a write is routed to the agent and the agent reports it as failed, that error is surfaced to the caller — it is **not** then retried on the direct path. That guarantees a VM is never created or deleted twice. (Covered by a test.)
- The provider interfaces are unchanged; no import cycle.

## How it's structured (for reviewers)

- A new `DCAPI_AGENT_ROUTE_WRITES` setting (default `false`), separate from the read setting so reads and writes can be enabled independently.
- The cluster-access seam's per-operation allow-set now permits VM create + delete to route to the agent when the write setting is on. The Harvester provider's `CreateVM`/`DeleteVM` call the seam (which chooses direct-vs-agent per call); everything else — image lookup, the cloud-provider ServiceAccount bootstrap — stays on the direct path.
- **Create semantics note:** the direct path creates a VM with a normal create (POST), unchanged. The agent path creates via *server-side apply*, because that's the only create mechanism the agent exposes — so a VM create becomes a server-side apply **only** when routed through the agent (the opt-in path).
- The agent's permission set (`flux/platform/dc-agent/base/rbac.yaml`) gains exactly `create, patch, delete` on `virtualmachines` (create+patch are what server-side apply needs; delete for delete) — nothing else widened.

## Deploy ordering (important for whoever enables this)

The agent's new VM-write permission (on the Harvester cluster) must be in effect **before** `DCAPI_AGENT_ROUTE_WRITES` is turned on, or Kubernetes will deny the routed writes. Because the setting is off by default, the two changes are safe to merge in any order — just don't flip the setting on until the agent's permission has rolled out.

## How to verify

- In `dc-api/`: `go build ./... && go vet ./... && go test ./...` — green (race-tested on the changed packages); no import cycle.
- Setting off (the default): VM create/delete behavior is identical to before this PR (tests assert the direct path is used and the agent is not touched).
- Intended end-to-end check, later: with the agent permission rolled out, set `DCAPI_AGENT_ROUTE_WRITES=true` in a dev environment and confirm a VM create and delete are carried out by the in-datacenter agent.

## Not in this PR

Routing other operations (networks, the cloud-provider ServiceAccount bootstrap, etc.) through the agent — those come later, each with their own matching permission grant. This change is limited to VM create/delete and is off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
