### PR TITLE
[Refactor] Derive agent RBAC and routing from a capability registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help bootstrap check up down db-reset build-api build-cli build run dev
+.PHONY: help bootstrap check up down db-reset build-api build-cli build run dev gen-agent-rbac
 
 # Default target — print help
 help:
@@ -47,6 +47,14 @@ build-cli:
 	@echo "Built: ~/bin/dcctl"
 
 build: build-api build-cli
+
+# ── Code generation ───────────────────────────────────────────────────────────
+# Regenerate the dc-agent RBAC manifest from the capability registry
+# (dc-api/internal/providers/clusteraccess/capabilities.go). Run this after
+# editing any AgentCapability.AgentVerbs; the drift-check unit test fails CI if
+# the committed file is stale.
+gen-agent-rbac:
+	cd dc-api && go run ./cmd/gen-agent-rbac -out ../flux/platform/dc-agent/base/rbac.yaml
 
 # ── Run ───────────────────────────────────────────────────────────────────────
 run:

--- a/dc-api/cmd/gen-agent-rbac/main.go
+++ b/dc-api/cmd/gen-agent-rbac/main.go
@@ -1,0 +1,57 @@
+// Command gen-agent-rbac renders the dc-agent Kubernetes RBAC manifest from the
+// capability registry and writes it to the flux base. It is the generator behind
+// the //go:generate directive in
+// internal/providers/clusteraccess/capabilities.go and `make gen-agent-rbac`.
+//
+// The output is byte-stable: re-running it without a registry change yields an
+// identical file (a drift-check unit test enforces this). Edit the registry, not
+// the YAML.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2/dc-api/internal/agentrbac"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+func main() {
+	out := flag.String("out", "", "path to write the generated rbac.yaml")
+	flag.Parse()
+
+	if *out == "" {
+		fmt.Fprintln(os.Stderr, "gen-agent-rbac: -out is required")
+		os.Exit(2)
+	}
+
+	data := agentrbac.RenderAgentRBAC(clusteraccess.AgentCapabilities)
+
+	// Atomic write: temp file in the same dir, then rename.
+	dir := filepath.Dir(*out)
+	tmp, err := os.CreateTemp(dir, ".rbac-*.yaml.tmp")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gen-agent-rbac: create temp: %v\n", err)
+		os.Exit(1)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		fmt.Fprintf(os.Stderr, "gen-agent-rbac: write temp: %v\n", err)
+		os.Exit(1)
+	}
+	if err := tmp.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "gen-agent-rbac: close temp: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.Rename(tmpName, *out); err != nil {
+		fmt.Fprintf(os.Stderr, "gen-agent-rbac: rename to %s: %v\n", *out, err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "gen-agent-rbac: wrote %s\n", *out)
+}

--- a/dc-api/internal/agentrbac/render.go
+++ b/dc-api/internal/agentrbac/render.go
@@ -1,0 +1,161 @@
+// Package agentrbac renders the dc-agent Kubernetes RBAC manifest from the
+// capability registry (clusteraccess.AgentCapabilities). It is the single
+// rendering function shared by the cmd/gen-agent-rbac generator and the drift
+// test, so "what the generator writes" and "what the test compares against" can
+// never diverge.
+package agentrbac
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+// header is the fixed DO-NOT-EDIT banner. Editing the YAML by hand is a no-op:
+// regeneration (and the drift test) overwrite it.
+const header = `# GENERATED FILE — DO NOT EDIT.
+#
+# Produced by dc-api/cmd/gen-agent-rbac from the capability registry
+# (dc-api/internal/providers/clusteraccess/capabilities.go). To change the
+# agent's permissions, edit the relevant AgentCapability.AgentVerbs and run
+# 'make gen-agent-rbac', then commit the regenerated file. A drift-check unit
+# test fails CI if this file is out of sync with the registry.
+#
+# The agent runs in-cluster and reads THIS datacenter's inventory (at the
+# control plane's request) via this ServiceAccount — no kubeconfig travels
+# (DCAGENT_KUBECONFIG is empty, so the executor uses in-cluster config). Tenant
+# VMs live in dc-<id> namespaces not predictable at deploy time, so the grant is
+# cluster-scoped (ClusterRole), exactly as dc-webhook does for NADs.
+`
+
+// preamble emits the ServiceAccount; binding emits the ClusterRoleBinding. Both
+// are generator constants — onboarding/removing capabilities never disturbs them.
+const serviceAccount = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dc-agent
+  namespace: dc-agent-system
+`
+
+const clusterRoleBinding = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dc-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dc-agent
+subjects:
+  - kind: ServiceAccount
+    name: dc-agent
+    namespace: dc-agent-system
+`
+
+// rule is one ClusterRole policy rule, ready to render deterministically.
+type rule struct {
+	apiGroup  string
+	resources []string
+	verbs     []string
+}
+
+// RenderAgentRBAC renders the full RBAC manifest (ServiceAccount + ClusterRole +
+// ClusterRoleBinding) for the given capabilities. Output is deterministic and
+// byte-stable across runs regardless of map iteration order: rules are sorted by
+// apiGroup then resource, and verbs follow the canonical k8s order.
+func RenderAgentRBAC(caps []clusteraccess.AgentCapability) []byte {
+	rules := capabilityRules(caps)
+
+	var b bytes.Buffer
+	b.WriteString(header)
+	b.WriteString("---\n")
+	b.WriteString(serviceAccount)
+	b.WriteString("---\n")
+	b.WriteString("apiVersion: rbac.authorization.k8s.io/v1\n")
+	b.WriteString("kind: ClusterRole\n")
+	b.WriteString("metadata:\n")
+	b.WriteString("  name: dc-agent\n")
+	b.WriteString("rules:\n")
+	for _, r := range rules {
+		b.WriteString("  - apiGroups: [" + quoteList([]string{r.apiGroup}) + "]\n")
+		b.WriteString("    resources: [" + quoteList(r.resources) + "]\n")
+		b.WriteString("    verbs: [" + quoteList(r.verbs) + "]\n")
+	}
+	b.WriteString("---\n")
+	b.WriteString(clusterRoleBinding)
+	return b.Bytes()
+}
+
+// capabilityRules builds the ordered ClusterRole rules: the fixed base inventory
+// rule (nodes/pods get,list,watch — serves the agent's hard-coded get_inventory
+// op) followed by one rule per capability that grants RBAC (non-empty
+// AgentVerbs), grouped by apiGroup and sorted deterministically.
+func capabilityRules(caps []clusteraccess.AgentCapability) []rule {
+	// Base inventory rule is a generator constant, NOT registry-driven: the
+	// agent's get_inventory reads nodes/pods via the typed clientset.
+	rules := []rule{
+		{apiGroup: "", resources: []string{"nodes", "pods"}, verbs: []string{"get", "list", "watch"}},
+	}
+
+	// Merge capability verbs per (apiGroup, resource).
+	type key struct{ group, resource string }
+	verbsByKey := map[key]map[string]bool{}
+	for _, c := range caps {
+		if len(c.AgentVerbs) == 0 {
+			continue
+		}
+		k := key{group: c.GVR.Group, resource: c.GVR.Resource}
+		if verbsByKey[k] == nil {
+			verbsByKey[k] = map[string]bool{}
+		}
+		for _, v := range c.AgentVerbs {
+			kv, ok := clusteraccess.K8sVerb(v)
+			if !ok {
+				continue
+			}
+			verbsByKey[k][kv] = true
+		}
+	}
+
+	keys := make([]key, 0, len(verbsByKey))
+	for k := range verbsByKey {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].group != keys[j].group {
+			return keys[i].group < keys[j].group
+		}
+		return keys[i].resource < keys[j].resource
+	})
+
+	for _, k := range keys {
+		rules = append(rules, rule{
+			apiGroup:  k.group,
+			resources: []string{k.resource},
+			verbs:     canonicalVerbs(verbsByKey[k]),
+		})
+	}
+	return rules
+}
+
+// canonicalVerbs returns the present verbs in canonical k8s order.
+func canonicalVerbs(present map[string]bool) []string {
+	out := make([]string, 0, len(present))
+	for _, v := range clusteraccess.K8sVerbOrder() {
+		if present[v] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// quoteList renders a YAML inline array body like `"a", "b"` (the caller wraps
+// it in [ ]). Empty group renders as "" to match k8s core-group convention.
+func quoteList(items []string) string {
+	qs := make([]string, len(items))
+	for i, s := range items {
+		qs[i] = "\"" + s + "\""
+	}
+	return strings.Join(qs, ", ")
+}

--- a/dc-api/internal/agentrbac/render_test.go
+++ b/dc-api/internal/agentrbac/render_test.go
@@ -1,0 +1,52 @@
+package agentrbac
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+// repoRoot resolves the repository root from this test file's location so the
+// drift test works under `go test ./...` in CI with no env setup. This file is
+// dc-api/internal/agentrbac/render_test.go, so the repo root is four dirs up.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// .../dc-api/internal/agentrbac/render_test.go → repo root
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+}
+
+// TestRBACDrift fails if the committed flux rbac.yaml is out of sync with the
+// registry — i.e. someone edited capabilities.go without regenerating. The
+// message tells the dev exactly how to fix it.
+func TestRBACDrift(t *testing.T) {
+	got := RenderAgentRBAC(clusteraccess.AgentCapabilities)
+
+	path := filepath.Join(repoRoot(t), "flux", "platform", "dc-agent", "base", "rbac.yaml")
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read committed rbac.yaml at %s: %v", path, err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("flux/platform/dc-agent/base/rbac.yaml is STALE — run `make gen-agent-rbac` and commit.\n\n--- want (committed) ---\n%s\n--- got (regenerated) ---\n%s", want, got)
+	}
+}
+
+// TestRBACByteStable proves the generator is deterministic: rendering twice from
+// the same registry yields identical bytes (guards against nondeterministic map
+// iteration leaking into the output).
+func TestRBACByteStable(t *testing.T) {
+	a := RenderAgentRBAC(clusteraccess.AgentCapabilities)
+	b := RenderAgentRBAC(clusteraccess.AgentCapabilities)
+	if !bytes.Equal(a, b) {
+		t.Fatalf("RenderAgentRBAC is not byte-stable:\n--- run 1 ---\n%s\n--- run 2 ---\n%s", a, b)
+	}
+}

--- a/dc-api/internal/providers/clusteraccess/capabilities.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities.go
@@ -1,0 +1,247 @@
+package clusteraccess
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+//go:generate go run github.com/wso2/dc-api/cmd/gen-agent-rbac -out ../../../../flux/platform/dc-agent/base/rbac.yaml
+
+// AgentCapability is the ONE declaration per agent-manageable resource family.
+//
+// From this single struct we derive three things that used to be maintained by
+// hand in three separate places:
+//
+//  1. the GVR→GVK wire mapping (clusteraccess.DefaultGVKMapper) the AgentBacked
+//     accessor needs to address an object on the dc-agent wire;
+//  2. the dc-api routing allow-set (which seam Verbs MAY route to the agent),
+//     consulted by providers.Registry.agentDecision; and
+//  3. the agent's Kubernetes RBAC ClusterRole rule, emitted by the
+//     cmd/gen-agent-rbac generator.
+//
+// Adding a new agent-managed resource family is a single new struct in
+// AgentCapabilities — never a hand-edit of the mapper, the routing switch, or
+// the RBAC YAML.
+type AgentCapability struct {
+	// GVR is the resource as providers speak it (the seam is GVR-in).
+	GVR schema.GroupVersionResource
+	// APIVersion is how the dc-agent wire (ResourceRef) addresses the group/
+	// version, e.g. "kubevirt.io/v1" (bare "v1" for the core group).
+	APIVersion string
+	// Kind is how the dc-agent wire addresses the object, e.g. "VirtualMachine".
+	Kind string
+	// Namespaced records whether the resource is namespaced. It controls nothing
+	// in dc-api today (the agent resolves scope via its RESTMapper) but is kept
+	// for completeness and future scoping. VirtualMachine is namespaced.
+	Namespaced bool
+	// RouteVerbs is the set of seam Verbs that MAY route to the agent for this
+	// family. Membership here, AND-ed with the per-family env toggle and a live
+	// session, is what providers.Registry.agentDecision consults. A capability
+	// that is GVK-mapped but not yet routed (pre-seeded) leaves this nil.
+	RouteVerbs []Verb
+	// AgentVerbs is the set of seam Verbs whose Kubernetes verb the agent's
+	// ServiceAccount MAY perform on-cluster for this family. It drives the RBAC
+	// generator and is deliberately SEPARATE from RouteVerbs: the VM family
+	// routes only {Get,Create,Delete} from dc-api, yet the agent's SA needs
+	// get/list/watch/create/patch/delete because get_inventory lists VMs,
+	// get_status/watch_status read+watch, and SSA-create needs create+patch. A
+	// capability that grants no RBAC (pre-seeded GVK-only) leaves this nil.
+	AgentVerbs []Verb
+}
+
+// vmCapability is the one truly onboarded capability in phase 1.
+//
+// RouteVerbs reproduces today's dc-api allow-set EXACTLY: reads={VerbGet},
+// writes={VerbCreate, VerbDelete}. AgentVerbs reproduces today's hand-written
+// ClusterRole verb list for kubevirt.io/virtualmachines EXACTLY — it maps to
+// the k8s verbs get,list,watch,create,patch,delete (VerbApply→patch via SSA;
+// VerbCreate→create are both present, reproducing the old {create,patch} grant).
+var vmCapability = AgentCapability{
+	GVR:        schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"},
+	APIVersion: "kubevirt.io/v1",
+	Kind:       "VirtualMachine",
+	Namespaced: true,
+	// What dc-api MAY route to the agent (drives the allow-set + must be
+	// GVK-mapped): the VM read slice (Get) and the VM write slice (Create/Delete).
+	RouteVerbs: []Verb{VerbGet, VerbCreate, VerbDelete},
+	// What the agent's SA MAY do on-cluster (drives RBAC). Superset of RouteVerbs:
+	// get_inventory lists VMs, get_status/watch_status read+watch, and SSA-create
+	// needs create+patch. Reproduces the old rule verbatim:
+	// get,list,watch,create,patch,delete.
+	AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
+}
+
+// The pre-seeded, GVK-only capabilities. These exist so DefaultGVKMapper keeps
+// resolving the GVRs the existing drivers use (the table stays a 6-entry
+// superset, unchanged from the pre-refactor literal), but they are NOT yet
+// onboarded to the agent: RouteVerbs=nil means they contribute nothing to the
+// routing allow-set, and AgentVerbs=nil means they emit no RBAC rule. They are
+// NOT agent-managed today — onboarding any of them is a later phase that fills
+// in RouteVerbs/AgentVerbs.
+var (
+	vmiCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstances"},
+		APIVersion: "kubevirt.io/v1",
+		Kind:       "VirtualMachineInstance",
+		Namespaced: true,
+	}
+	vmImageCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "harvesterhci.io", Version: "v1beta1", Resource: "virtualmachineimages"},
+		APIVersion: "harvesterhci.io/v1beta1",
+		Kind:       "VirtualMachineImage",
+		Namespaced: true,
+	}
+	nadCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"},
+		APIVersion: "k8s.cni.cncf.io/v1",
+		Kind:       "NetworkAttachmentDefinition",
+		Namespaced: true,
+	}
+	vpcCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"},
+		APIVersion: "kubeovn.io/v1",
+		Kind:       "Vpc",
+		Namespaced: false,
+	}
+	subnetCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "subnets"},
+		APIVersion: "kubeovn.io/v1",
+		Kind:       "Subnet",
+		Namespaced: false,
+	}
+)
+
+// AgentCapabilities is THE registry: one declaration per resource family.
+//
+// Phase 1 has exactly one truly onboarded entry (vmCapability) plus five
+// GVK-only pre-seeded entries that keep the wire mapper a superset without
+// granting any routing or RBAC. New families are added here (one struct each)
+// in later phases — never by editing the mapper, the allow-set switch, or the
+// RBAC YAML by hand.
+var AgentCapabilities = []AgentCapability{
+	vmCapability,
+	vmiCapability,
+	vmImageCapability,
+	nadCapability,
+	vpcCapability,
+	subnetCapability,
+}
+
+// Registry returns the declared capabilities.
+func Registry() []AgentCapability { return AgentCapabilities }
+
+// Derived lookups, built once.
+var (
+	derivedOnce       sync.Once
+	derivedGVKTable   map[schema.GroupVersionResource]gvk
+	derivedRouteSet   map[schema.GroupVersionResource]map[Verb]bool
+	derivedUnionRoute map[Verb]bool
+)
+
+func buildDerived() {
+	derivedOnce.Do(func() {
+		derivedGVKTable = make(map[schema.GroupVersionResource]gvk, len(AgentCapabilities))
+		derivedRouteSet = make(map[schema.GroupVersionResource]map[Verb]bool, len(AgentCapabilities))
+		derivedUnionRoute = make(map[Verb]bool)
+		for _, c := range AgentCapabilities {
+			derivedGVKTable[c.GVR] = gvk{APIVersion: c.APIVersion, Kind: c.Kind}
+			if len(c.RouteVerbs) > 0 {
+				set := make(map[Verb]bool, len(c.RouteVerbs))
+				for _, v := range c.RouteVerbs {
+					set[v] = true
+					derivedUnionRoute[v] = true
+				}
+				derivedRouteSet[c.GVR] = set
+			}
+		}
+	})
+}
+
+// UnionRouteVerbs returns the union of RouteVerbs across all capabilities — the
+// set of seam Verbs that MAY route to the agent for ANY family. With one
+// onboarded family today this equals {VerbGet, VerbCreate, VerbDelete}, exactly
+// the pre-refactor hand-maintained allow-set. agentDecision consults this for
+// membership, then gates reads vs writes by the per-family env toggles.
+//
+// PHASE-1 SIMPLIFICATION: agentDecision is verb-only (it does not receive a
+// GVR), so the union is the correct membership test while there is a single
+// onboarded family. When a second family with DIFFERENT RouteVerbs is onboarded,
+// the GVR must be threaded into agentDecision and RoutableVerbs(gvr) used
+// instead of the union.
+func UnionRouteVerbs() map[Verb]bool {
+	buildDerived()
+	out := make(map[Verb]bool, len(derivedUnionRoute))
+	for v := range derivedUnionRoute {
+		out[v] = true
+	}
+	return out
+}
+
+// RoutableVerbs returns the per-family routable verb set for a GVR (from its
+// RouteVerbs), and whether the GVR is an onboarded routable family at all.
+func RoutableVerbs(gvr schema.GroupVersionResource) (map[Verb]bool, bool) {
+	buildDerived()
+	set, ok := derivedRouteSet[gvr]
+	if !ok {
+		return nil, false
+	}
+	out := make(map[Verb]bool, len(set))
+	for v := range set {
+		out[v] = true
+	}
+	return out, true
+}
+
+// IsReadVerb classifies a seam Verb as a read for the reads/writes toggle split.
+// VerbList is included so it falls on the read side once it becomes routable.
+func IsReadVerb(v Verb) bool {
+	switch v {
+	case VerbGet, VerbList:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsWriteVerb classifies a seam Verb as a write for the reads/writes toggle split.
+func IsWriteVerb(v Verb) bool {
+	switch v {
+	case VerbCreate, VerbApply, VerbUpdate, VerbDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// verbToK8s is the canonical seam-Verb → Kubernetes-RBAC-verb mapping. VerbApply
+// maps to "patch" because server-side apply is an HTTP PATCH with
+// application/apply-patch+yaml. This table is the RBAC vocabulary the generator
+// uses to turn AgentVerbs into a ClusterRole rule's verbs.
+var verbToK8s = map[Verb]string{
+	VerbGet:    "get",
+	VerbList:   "list",
+	VerbWatch:  "watch",
+	VerbCreate: "create",
+	VerbApply:  "patch",
+	VerbUpdate: "update",
+	VerbDelete: "delete",
+}
+
+// k8sVerbOrder is the canonical ordering of Kubernetes RBAC verbs used to make
+// generated rule output deterministic (and to match kubectl/API conventions).
+var k8sVerbOrder = []string{"get", "list", "watch", "create", "update", "patch", "delete"}
+
+// K8sVerb returns the Kubernetes RBAC verb for a seam Verb.
+func K8sVerb(v Verb) (string, bool) {
+	s, ok := verbToK8s[v]
+	return s, ok
+}
+
+// K8sVerbOrder returns the canonical ordering of Kubernetes RBAC verbs, used by
+// the RBAC generator to emit deterministic, byte-stable verb lists.
+func K8sVerbOrder() []string {
+	out := make([]string, len(k8sVerbOrder))
+	copy(out, k8sVerbOrder)
+	return out
+}

--- a/dc-api/internal/providers/clusteraccess/capabilities_test.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities_test.go
@@ -1,0 +1,63 @@
+package clusteraccess
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestUnionRouteVerbs pins the registry-derived routing allow-set to today's
+// hand-maintained set EXACTLY: {VerbGet, VerbCreate, VerbDelete}. Any drift
+// (e.g. accidentally giving a pre-seeded capability RouteVerbs) fails here.
+func TestUnionRouteVerbs(t *testing.T) {
+	got := UnionRouteVerbs()
+	want := map[Verb]bool{VerbGet: true, VerbCreate: true, VerbDelete: true}
+
+	if len(got) != len(want) {
+		t.Fatalf("union route verbs size = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for v := range want {
+		if !got[v] {
+			t.Errorf("union route verbs missing %v", v)
+		}
+	}
+	// Explicitly assert the verbs that must NOT be routable.
+	for _, v := range []Verb{VerbList, VerbApply, VerbUpdate, VerbWatch} {
+		if got[v] {
+			t.Errorf("verb %v must NOT be routable but is in the union", v)
+		}
+	}
+}
+
+// TestDefaultGVKMapperResolvesKnownGVRs pins the derived GVK table to the same
+// six entries (and same APIVersion/Kind) the pre-refactor literal had.
+func TestDefaultGVKMapperResolvesKnownGVRs(t *testing.T) {
+	m := DefaultGVKMapper()
+	cases := []struct {
+		gvr        schema.GroupVersionResource
+		apiVersion string
+		kind       string
+	}{
+		{schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}, "kubevirt.io/v1", "VirtualMachine"},
+		{schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstances"}, "kubevirt.io/v1", "VirtualMachineInstance"},
+		{schema.GroupVersionResource{Group: "harvesterhci.io", Version: "v1beta1", Resource: "virtualmachineimages"}, "harvesterhci.io/v1beta1", "VirtualMachineImage"},
+		{schema.GroupVersionResource{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}, "k8s.cni.cncf.io/v1", "NetworkAttachmentDefinition"},
+		{schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}, "kubeovn.io/v1", "Vpc"},
+		{schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "subnets"}, "kubeovn.io/v1", "Subnet"},
+	}
+	for _, c := range cases {
+		av, k, ok := m.GVK(c.gvr)
+		if !ok {
+			t.Errorf("GVR %v not resolved", c.gvr)
+			continue
+		}
+		if av != c.apiVersion || k != c.kind {
+			t.Errorf("GVR %v → %s/%s, want %s/%s", c.gvr, av, k, c.apiVersion, c.kind)
+		}
+	}
+
+	// An unknown GVR must not resolve.
+	if _, _, ok := m.GVK(schema.GroupVersionResource{Group: "x", Version: "v1", Resource: "widgets"}); ok {
+		t.Error("unknown GVR unexpectedly resolved")
+	}
+}

--- a/dc-api/internal/providers/clusteraccess/clusteraccess.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess.go
@@ -68,23 +68,20 @@ func (m staticGVKMapper) GVK(gvr schema.GroupVersionResource) (string, string, b
 	return v.APIVersion, v.Kind, ok
 }
 
-// DefaultGVKMapper returns the GVR→GVK table seeded from the drivers' own GVR
-// vars and their kinds. It is extended (here, in one place) as each write phase
-// routes a new resource family — never widened ahead of the routed verb.
+// DefaultGVKMapper returns the GVR→GVK table DERIVED from the capability
+// registry (AgentCapabilities). Every capability — onboarded or pre-seeded
+// GVK-only — contributes one table entry, so the table is the same 6-entry
+// superset it has always been, now built from the single source of truth
+// instead of a hand-written literal. An unmapped GVR is a programming error,
+// surfaced as ErrOpNotRoutable by the AgentBacked accessor.
 //
-// For M-C only the KubeVirt VirtualMachine entry is exercised (the read slice);
-// the rest are pre-seeded because they are the GVRs the existing drivers use and
-// having them present makes the eventual write phases a no-op here. apiVersion is
-// "group/version" (or bare "version" for the core group, which is empty).
+// A new resource family is GVK-mapped by adding it to AgentCapabilities — never
+// by editing this function.
 func DefaultGVKMapper() GVRToGVK {
-	return staticGVKMapper{table: map[schema.GroupVersionResource]gvk{
-		// ── harvester driver ───────────────────────────────────────────────────
-		{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}:                    {APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine"},
-		{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstances"}:            {APIVersion: "kubevirt.io/v1", Kind: "VirtualMachineInstance"},
-		{Group: "harvesterhci.io", Version: "v1beta1", Resource: "virtualmachineimages"}:      {APIVersion: "harvesterhci.io/v1beta1", Kind: "VirtualMachineImage"},
-		{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}: {APIVersion: "k8s.cni.cncf.io/v1", Kind: "NetworkAttachmentDefinition"},
-		// ── kubeovn driver (reads first in M-E, then writes) ─────────────────────
-		{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}:    {APIVersion: "kubeovn.io/v1", Kind: "Vpc"},
-		{Group: "kubeovn.io", Version: "v1", Resource: "subnets"}: {APIVersion: "kubeovn.io/v1", Kind: "Subnet"},
-	}}
+	buildDerived()
+	table := make(map[schema.GroupVersionResource]gvk, len(derivedGVKTable))
+	for k, v := range derivedGVKTable {
+		table[k] = v
+	}
+	return staticGVKMapper{table: table}
 }

--- a/dc-api/internal/providers/clusteraccess/routed.go
+++ b/dc-api/internal/providers/clusteraccess/routed.go
@@ -21,6 +21,13 @@ const (
 	VerbApply
 	VerbUpdate
 	VerbDelete
+	// VerbWatch is appended LAST so the iota values of the existing verbs are
+	// unchanged. It is an RBAC-vocabulary token ONLY — it is NOT in any
+	// RouteVerbs set, the Accessor interface gains no Watch method, and Routed
+	// gains no Watch path. It exists purely so AgentCapability.AgentVerbs can
+	// express the agent's watch grant (get_status/watch_status) for the RBAC
+	// generator. Routing behaviour is therefore unchanged by its addition.
+	VerbWatch
 )
 
 // AgentDecision is the live decision function a Routed accessor consults per

--- a/dc-api/internal/providers/registry.go
+++ b/dc-api/internal/providers/registry.go
@@ -192,21 +192,31 @@ func (r *Registry) agentDecision(cfg *config.Config) clusteraccess.AgentDecision
 	fieldManager := "dc-api"
 	region, zone := cfg.LocalRegion, cfg.LocalZone
 
+	// routable is the union of every capability's RouteVerbs — the registry-
+	// derived membership test that REPLACES the old hand-written switch. With one
+	// onboarded family today it equals {VerbGet, VerbCreate, VerbDelete}, exactly
+	// the pre-refactor allow-set, so decisions are byte-identical. The reads vs
+	// writes split (which toggle gates which verb) stays here.
+	routable := clusteraccess.UnionRouteVerbs()
+
 	return func(verb clusteraccess.Verb) (clusteraccess.Accessor, bool) {
 		// (2) gateway present — shared precondition for any routing.
 		if r.agentGateway == nil {
 			return nil, false
 		}
-		// (1)+(4) per-family toggle AND verb allow-set, together.
-		//   reads  → AgentRouteReads  gates {VerbGet}
-		//   writes → AgentRouteWrites gates {VerbCreate, VerbDelete} (VM write slice)
-		// A verb not listed here always falls through to Direct.
-		switch verb {
-		case clusteraccess.VerbGet:
+		// (1)+(4) registry membership AND per-family toggle, together.
+		//   reads  → AgentRouteReads  gates read verbs  (VerbGet today)
+		//   writes → AgentRouteWrites gates write verbs (VerbCreate, VerbDelete today)
+		// A verb not in the registry's routable union always falls through to Direct.
+		if !routable[verb] {
+			return nil, false
+		}
+		switch {
+		case clusteraccess.IsReadVerb(verb):
 			if !r.routeReads {
 				return nil, false
 			}
-		case clusteraccess.VerbCreate, clusteraccess.VerbDelete:
+		case clusteraccess.IsWriteVerb(verb):
 			if !r.routeWrites {
 				return nil, false
 			}

--- a/flux/platform/dc-agent/base/rbac.yaml
+++ b/flux/platform/dc-agent/base/rbac.yaml
@@ -1,11 +1,17 @@
+# GENERATED FILE — DO NOT EDIT.
+#
+# Produced by dc-api/cmd/gen-agent-rbac from the capability registry
+# (dc-api/internal/providers/clusteraccess/capabilities.go). To change the
+# agent's permissions, edit the relevant AgentCapability.AgentVerbs and run
+# 'make gen-agent-rbac', then commit the regenerated file. A drift-check unit
+# test fails CI if this file is out of sync with the registry.
+#
 # The agent runs in-cluster and reads THIS datacenter's inventory (at the
 # control plane's request) via this ServiceAccount — no kubeconfig travels
-# (DCAGENT_KUBECONFIG is empty, so the executor uses in-cluster config). The
-# executor (dc-agent/internal/executor/kube.go GetInventory) reads exactly three
-# things, all read-only and cluster-wide: Nodes, Pods (all namespaces, to sum
-# allocated CPU/memory), and KubeVirt VirtualMachines (all namespaces, counted).
-# Tenant VMs live in dc-<id> namespaces not predictable at deploy time, so the
-# grant is cluster-scoped (ClusterRole), exactly as dc-webhook does for NADs.
+# (DCAGENT_KUBECONFIG is empty, so the executor uses in-cluster config). Tenant
+# VMs live in dc-<id> namespaces not predictable at deploy time, so the grant is
+# cluster-scoped (ClusterRole), exactly as dc-webhook does for NADs.
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -22,9 +28,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["kubevirt.io"]
     resources: ["virtualmachines"]
-    # create+patch = server-side apply (VM create); delete = VM delete.
-    # Widened for the agent VM write slice (DCAPI_AGENT_ROUTE_WRITES). Nothing
-    # broader: still scoped to virtualmachines only.
     verbs: ["get", "list", "watch", "create", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What this changes

dc-api decides which Kubernetes resources the in-datacenter agent is allowed to manage, and the agent is granted matching permissions on its own cluster. Until now that information lived in three separate places that had to be kept in lockstep by hand: the routing allow-set in dc-api, a resource-to-Kind mapping table, and the agent's RBAC ClusterRole YAML. This PR replaces that with a single source of truth — a capability registry — from which all three are derived. Making a resource agent-manageable becomes one registry entry instead of three hand-synced edits.

## Why it's safe

This is a pure refactor with no behavior change. The routing decisions are identical (the same operations route to the agent under the same conditions), and the generated RBAC ClusterRole grants byte-identical permissions to the previous hand-written file. Neither what the agent is permitted to do nor what dc-api routes to it changes.

## How it's structured

- A capability registry (`internal/providers/clusteraccess/capabilities.go`): one `AgentCapability` per resource family, recording its identity (group/version/resource and kind), which operations dc-api may route to the agent, and which Kubernetes verbs the agent's ServiceAccount needs.
- The routing allow-set and the resource-to-Kind mapping now derive from the registry instead of hand-written literals.
- The agent's RBAC manifest (`flux/platform/dc-agent/base/rbac.yaml`) is now a generated file with a DO-NOT-EDIT header, produced by `make gen-agent-rbac`.
- A drift-check unit test fails CI if that manifest is hand-edited or left out of sync with the registry — the same guardrail the project already uses for its OpenAPI client codegen.

## How to verify

- `go build ./... && go vet ./...` are clean; unit tests pass, including race-enabled runs on the provider packages.
- The generated `rbac.yaml` grants exactly the same permissions as before this PR (rule-for-rule identical); only the file's header and formatting differ because it is now generated rather than hand-written.
- `make gen-agent-rbac` is idempotent (regenerating produces no diff), and the drift-check test catches a registry change that wasn't regenerated.

## Not in this PR

No new resources are onboarded and no permissions change — the only resource the agent manages remains the VM, exactly as today. This is the foundation; follow-up changes use the registry to make the agent's zone configuration single-sourced and to onboard further resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
