### PR TITLE
[Fix] Stop dcctl flagging a 202 accept as an edge challenge

### DIFF
--- a/dcctl/internal/client/guard.go
+++ b/dcctl/internal/client/guard.go
@@ -31,35 +31,52 @@ var challengeMarkers = []string{
 	"_cf_chl_opt",
 }
 
-// checkAPIResponse reports an actionable error when resp/body is clearly NOT
-// the JSON API response dcctl expects — i.e. it looks like an edge
-// bot-protection challenge or some other HTML interstitial. It returns nil for
-// any plausible JSON response (success OR a real API JSON error), so normal
-// error handling downstream is unchanged.
+// checkAPIResponse reports an actionable error when the response is clearly NOT
+// something dc-api produced — i.e. it looks like an edge bot-protection
+// challenge or another HTML interstitial. It returns nil for any plausible
+// dc-api response (a success, an async 202/204 accept, or a real API JSON
+// error), so normal handling downstream is unchanged.
 //
-// Triggers when, for a non-2xx-or-not, the response is non-JSON: the
-// Content-Type is not JSON (e.g. text/html), OR the body does not look like
-// JSON, OR the body carries a Cloudflare challenge marker.
+//   - A body that actually looks like a challenge (HTML, or a Cloudflare marker)
+//     is flagged whatever the status code.
+//   - Otherwise a 2xx is a successful dc-api response and is left alone, even if
+//     the body is empty or non-JSON: some endpoints answer 202/204 that way for
+//     asynchronous operations (e.g. a routed delete). A 2xx is never a challenge
+//     — the request reached dc-api.
+//   - For a non-2xx, dc-api answers with JSON; a non-JSON body means something
+//     other than dc-api replied, so we surface the guidance.
 func checkAPIResponse(resp *http.Response, body []byte) error {
 	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
-	jsonContentType := strings.Contains(contentType, "json")
 
-	// A JSON content type with a JSON-shaped body is the normal path — leave it
-	// alone so real API success/error responses flow through as today. A clear
-	// Cloudflare challenge marker overrides even a (spoofed) JSON content type.
-	if jsonContentType && looksLikeJSON(body) && !isChallengeBody(contentType, body) {
+	// A genuine edge challenge (HTML interstitial / Cloudflare marker) is flagged
+	// regardless of status code.
+	if isChallengeBody(contentType, body) {
+		return challengeError(resp.StatusCode)
+	}
+
+	// A 2xx means the request reached dc-api and succeeded. Async endpoints answer
+	// 202/204 with an empty or non-JSON body; that is not a challenge.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
 
-	// Otherwise: a non-JSON content type, a body that plainly isn't JSON, or a
-	// Cloudflare challenge marker — all the same root cause (something other than
-	// dc-api answered) with the same actionable guidance.
+	// Non-2xx: dc-api's error responses are JSON. A JSON-shaped body flows through
+	// to normal error handling; anything else is an interstitial we should flag.
+	if strings.Contains(contentType, "json") && looksLikeJSON(body) {
+		return nil
+	}
+	return challengeError(resp.StatusCode)
+}
+
+// challengeError is the single actionable message for a response that did not
+// come from dc-api (an edge bot-protection challenge or other interstitial).
+func challengeError(status int) error {
 	return fmt.Errorf(
 		"dc-api returned a non-JSON response (HTTP %d) — this looks like an "+
 			"edge bot-protection challenge (Cloudflare). dcctl cannot solve a "+
 			"browser challenge. Check that your `dcapi_url` is correct and that "+
 			"your source network is allowed through the API's edge protection",
-		resp.StatusCode,
+		status,
 	)
 }
 

--- a/dcctl/internal/client/guard_test.go
+++ b/dcctl/internal/client/guard_test.go
@@ -95,3 +95,22 @@ func TestCheckAPIResponse_JSONContentTypeButHTMLBody(t *testing.T) {
 		t.Fatal("expected an error when a challenge marker is present despite a JSON content type, got nil")
 	}
 }
+
+func TestCheckAPIResponse_AcceptedNoContentType(t *testing.T) {
+	// Regression: an async DELETE answered 202 Accepted with no Content-Type and
+	// an empty body. A 2xx reached dc-api, so it is NOT a challenge — the guard
+	// must not turn a successful routed delete into a false Cloudflare error.
+	resp := newResp(http.StatusAccepted, "")
+	if err := checkAPIResponse(resp, nil); err != nil {
+		t.Fatalf("expected no error for a 202 accept with no content type, got: %v", err)
+	}
+}
+
+func TestCheckAPIResponse_AcceptedNonJSONBody(t *testing.T) {
+	// Regression: a 202 Accepted carrying a short non-JSON body (e.g. a plain
+	// status string) is still a successful async accept, not a challenge.
+	resp := newResp(http.StatusAccepted, "text/plain")
+	if err := checkAPIResponse(resp, []byte("accepted")); err != nil {
+		t.Fatalf("expected no error for a 202 accept with a non-JSON body, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What this fixes

When you delete a resource with `dcctl` (for example a network or a virtual machine), dcctl printed an error saying the request looked like a Cloudflare bot-protection challenge — even though the delete actually succeeded. We hit this during live testing: the agent deleted the subnet, the network-attachment-definition, and the VPC, dc-api confirmed they were gone, but dcctl still exited with the edge-challenge error.

## Why it happened

dc-api answers an asynchronous operation, such as a routed delete, with `202 Accepted` and an empty or non-JSON body. dcctl's edge-protection guard treated *any* non-JSON response as a likely Cloudflare challenge and failed the command. A real challenge, though, never returns a 2xx — it comes back as a 4xx or 5xx with an HTML interstitial carrying Cloudflare's markers.

## The fix

The guard now flags a response as a challenge only when the body actually looks like one (HTML, or a Cloudflare marker), or when a non-2xx reply isn't the JSON dc-api would have sent. A 2xx with an empty or non-JSON body is treated as the successful async accept it is. Behaviour for real challenges and for normal JSON success/error responses is unchanged. Regression tests cover a 202 with no content type and with a non-JSON body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
