### PR TITLE
[Refactor] Make region and zone a declarative resource property

### DIFF
--- a/dc-api/internal/api/handlers/bastion.go
+++ b/dc-api/internal/api/handlers/bastion.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/rbac"
 )
@@ -218,6 +219,9 @@ func (h *BastionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// phase-0 zone inheritance from the (always present) parent VNet.
+	_, bastionZone := inheritPlacement(placement.Bastion, vnet.Region, vnet.Zone, true)
+
 	// SSH key (same flow as VM — private key returned once, never stored).
 	publicKey, privateKeyPEM, err := generateSSHKeyPair()
 	if err != nil {
@@ -250,7 +254,9 @@ func (h *BastionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ProviderType: h.provider.Name(),
 		VNetID:       &vnet.ID,
 		SubnetID:     &subnet.ID,
-		Zone:         vnet.Zone, // phase-0 zone inheritance: bastion is always a VPC child
+		// phase-0 zone inheritance: bastion is always a VPC child, so it adopts
+		// the parent VNet's zone via the table-driven helper (placement.Bastion).
+		Zone: bastionZone,
 	})
 	if err != nil {
 		h.log.Error().Err(err).Str("tenant", tenantID).Msg("create bastion resource in DB")

--- a/dc-api/internal/api/handlers/cluster.go
+++ b/dc-api/internal/api/handlers/cluster.go
@@ -32,6 +32,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/providers/common"
 	"github.com/wso2/dc-api/internal/rbac"
@@ -406,8 +407,10 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		subnetBackendUID = subnet.BackendUID
 		vnetUUIDPtr = &vnetUUID
 		subnetUUIDPtr = &subnetUUID
-		// Phase-0 zone inheritance: the cluster adopts its parent VNet's zone.
-		clusterZone = vnet.Zone
+		// Phase-0 zone inheritance: the cluster adopts its parent VNet's zone,
+		// resolved through the table-driven helper (placement.Cluster is a Child
+		// of VNET).
+		_, clusterZone = inheritPlacement(placement.Cluster, vnet.Region, vnet.Zone, true)
 	}
 
 	// Create PENDING record

--- a/dc-api/internal/api/handlers/peering.go
+++ b/dc-api/internal/api/handlers/peering.go
@@ -29,6 +29,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/rbac"
 )
@@ -170,23 +171,13 @@ func (h *PeeringHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Same region check (multi-region peering deferred).
-	if vnet.Region != peerVNet.Region {
-		writeError(w, http.StatusBadRequest,
-			fmt.Sprintf("cross-region peering is not supported in M2 (VNet region: %s, peer VNet region: %s)",
-				vnet.Region, peerVNet.Region))
-		return
-	}
-
-	// Phase-0 same-zone check (mirrors the cross-region guard above for the
-	// sibling case; a 422 because zone disagreement is an unprocessable
-	// containment violation, not a malformed request). With the single seeded
-	// zone both VNets are 'zone-1', so this never fires today. The parent-child
-	// families rely on the existing FK containment instead of an explicit guard.
-	if vnet.Zone != peerVNet.Zone {
-		writeError(w, http.StatusUnprocessableEntity,
-			fmt.Sprintf("cross-zone peering is not supported (VNet zone: %s, peer VNet zone: %s)",
-				vnet.Zone, peerVNet.Zone))
+	// Cross-region (400) / cross-zone (422) sibling guards, routed through the
+	// shared table-driven check so the conditions are declared once. Operand
+	// order (vnet, peerVNet) is load-bearing — it sets the rendered message text.
+	// With the single seeded zone both VNets are 'zone-1', so the zone branch
+	// never fires today; the parent-child families rely on FK containment.
+	if e := placement.SamePlacement(vnet.Region, vnet.Zone, peerVNet.Region, peerVNet.Zone); e != nil {
+		writeError(w, e.Status, e.Msg)
 		return
 	}
 

--- a/dc-api/internal/api/handlers/placement.go
+++ b/dc-api/internal/api/handlers/placement.go
@@ -1,0 +1,34 @@
+// Package handlers — placement.go
+//
+// Shared, table-driven region/zone inheritance for handlers. Before this file
+// each of vm.go / cluster.go / bastion.go open-coded `childZone = vnet.Zone` on
+// the VPC path; the rule (a Child family inherits its parent's region/zone) is
+// now read from the placement registry instead of repeated per handler.
+//
+// The helper takes the ALREADY-FETCHED parent region/zone — the handlers fetch
+// the parent VNet anyway for the ACTIVE / subnet-belongs-to checks, so there is
+// exactly one GetVNet per request, identical to before.
+package handlers
+
+import "github.com/wso2/dc-api/internal/placement"
+
+// inheritPlacement returns the (region, zone) a Child family seeds onto its row
+// before repo.Create, given its already-resolved parent's region/zone.
+//
+//   - present=false (the legacy non-VPC VM/Cluster path, where there is no
+//     parent) → returns ("", "") so repo.Create falls back to the local
+//     default, identical to the old empty `vmZone`.
+//   - a Root or non-regional family → ("", "") (never inherits).
+//   - a Child family with a present parent → the parent's (region, zone).
+//
+// Region is returned for completeness but the resources table never writes
+// res.Region today (Create always stamps the local region), so VM/Cluster/
+// Bastion callers use only the zone — preserving exact current behaviour. The
+// region return is reserved for a future child family whose Create binds an
+// inherited region.
+func inheritPlacement(f placement.Family, parentRegion, parentZone string, present bool) (region, zone string) {
+	if !f.Regional || f.Mode != placement.Child || !present {
+		return "", ""
+	}
+	return parentRegion, parentZone
+}

--- a/dc-api/internal/api/handlers/placement_test.go
+++ b/dc-api/internal/api/handlers/placement_test.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/wso2/dc-api/internal/placement"
+)
+
+// TestInheritPlacement_ChildPresent pins that a Child family with a present
+// parent inherits the parent's zone (region returned but unused by callers).
+func TestInheritPlacement_ChildPresent(t *testing.T) {
+	for _, f := range []placement.Family{placement.VM, placement.Cluster, placement.Bastion} {
+		region, zone := inheritPlacement(f, "lk", "zone-3", true)
+		if zone != "zone-3" {
+			t.Errorf("inheritPlacement(%s) zone = %q, want inherited zone-3", f.Kind, zone)
+		}
+		if region != "lk" {
+			t.Errorf("inheritPlacement(%s) region = %q, want lk", f.Kind, region)
+		}
+	}
+}
+
+// TestInheritPlacement_ChildAbsent pins the legacy non-VPC path: no parent →
+// ("", "") so repo.Create falls back to the local default.
+func TestInheritPlacement_ChildAbsent(t *testing.T) {
+	region, zone := inheritPlacement(placement.VM, "lk", "zone-3", false)
+	if region != "" || zone != "" {
+		t.Errorf("inheritPlacement(absent parent) = (%q,%q), want empty", region, zone)
+	}
+}
+
+// TestInheritPlacement_NonChild pins that Root / non-regional families never
+// inherit, even with a present parent.
+func TestInheritPlacement_NonChild(t *testing.T) {
+	for _, f := range []placement.Family{placement.VNet, placement.KeyVault, placement.Subnet} {
+		region, zone := inheritPlacement(f, "lk", "zone-3", true)
+		if region != "" || zone != "" {
+			t.Errorf("inheritPlacement(%s) = (%q,%q), want empty (not a Child)", f.Kind, region, zone)
+		}
+	}
+}

--- a/dc-api/internal/api/handlers/vm.go
+++ b/dc-api/internal/api/handlers/vm.go
@@ -41,6 +41,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/middleware"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/rbac"
 	"golang.org/x/crypto/ssh"
@@ -317,10 +318,11 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 		subnetBackendUID = subnet.BackendUID
 		vnetUUIDPtr = &vnetUUID
 		subnetUUIDPtr = &subnetUUID
-		// Phase-0 zone inheritance: the VM adopts its parent VNet's zone. The
+		// Phase-0 zone inheritance: the VM adopts its parent VNet's zone, resolved
+		// through the table-driven helper (placement.VM is a Child of VNET). The
 		// subnet was already verified to belong to this VNet (single-parent
 		// containment above), so there is no independent zone to mismatch.
-		vmZone = vnet.Zone
+		_, vmZone = inheritPlacement(placement.VM, vnet.Region, vnet.Zone, true)
 	}
 
 	// ── Step 4a: read VPC DNS server IP (F20) ────────────────────────────────

--- a/dc-api/internal/db/database.go
+++ b/dc-api/internal/db/database.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 )
 
 // ErrDatabaseNotFound is returned by GetDatabase/DeleteDatabase when the
@@ -50,11 +51,17 @@ func (r *Repository) CreateDatabase(ctx context.Context, d *models.Database) (*m
 		)
 		RETURNING id, created_at, updated_at`
 
+	// Field-less family declared Root (see placement.Database): region/zone are
+	// default-stamped via the table-driven Stamp helper (empty inputs →
+	// regionStamp(), zoneStamp()), value-identical to the prior unconditional
+	// binds. True parent-zone inheritance for the VPC path is wired when 3b
+	// flips the declaration to Child.
+	region, zone := r.Stamp(placement.Database, "", "")
 	if err := r.pool.QueryRow(ctx, q,
 		d.TenantID, d.TenantUUID, d.ProjectID, d.ProjectUUID,
 		d.Name, string(d.Engine), nilIfEmpty(d.EngineVersion), d.InstanceClass, d.AllocatedStorageGB,
 		string(d.NetworkMode), d.VNetID, d.SubnetID, nilIfEmpty(d.NadRef),
-		string(d.Status), nilIfEmpty(d.Message), r.regionStamp(), r.zoneStamp(),
+		string(d.Status), nilIfEmpty(d.Message), region, zone,
 	).Scan(&d.ID, &d.CreatedAt, &d.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create database: %w", err)
 	}

--- a/dc-api/internal/db/db.go
+++ b/dc-api/internal/db/db.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 )
 
 // Repository encapsulates all PostgreSQL operations for DC-API.
@@ -157,11 +158,10 @@ func (r *Repository) Create(ctx context.Context, res *models.Resource) (*models.
 
 	// Zone (phase 0): VPC children pass the parent VNet's zone via res.Zone;
 	// root/standalone resources leave it empty and fall back to zoneStamp()
-	// (DCAPI_LOCAL_ZONE). Mirrors how region is always regionStamp() today.
-	zone := res.Zone
-	if zone == "" {
-		zone = r.zoneStamp()
-	}
+	// (DCAPI_LOCAL_ZONE). Region is always-local. Both are now resolved by the
+	// table-driven Stamp helper (placement.VM == Cluster == Bastion here — all
+	// Child/VNET/HasModelField, so the Family value is interchangeable).
+	region, zone := r.Stamp(placement.VM, "", res.Zone)
 	row := tx.QueryRow(ctx, q,
 		res.TenantID,
 		res.TenantUUID,
@@ -177,7 +177,7 @@ func (r *Repository) Create(ctx context.Context, res *models.Resource) (*models.
 		res.VNetID,
 		res.SubnetID,
 		nilIfEmpty(res.Message),
-		r.regionStamp(),
+		region,
 		zone,
 	)
 	if err := row.Scan(&res.ID, &res.CreatedAt, &res.UpdatedAt); err != nil {

--- a/dc-api/internal/db/keyvault.go
+++ b/dc-api/internal/db/keyvault.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 )
 
 // ErrKeyVaultNotFound is returned by GetKeyVault / DeleteKeyVault when the
@@ -39,10 +40,14 @@ func (r *Repository) CreateKeyVault(ctx context.Context, kv *models.KeyVault) (*
 	if kv.Message != "" {
 		message = &kv.Message
 	}
+	// Field-less root: region/zone default-stamped via the table-driven Stamp
+	// helper (empty inputs → regionStamp(), zoneStamp()). Nothing is written to
+	// the model — KeyVault has no Region/Zone field.
+	region, zone := r.Stamp(placement.KeyVault, "", "")
 	if err := r.pool.QueryRow(ctx, q,
 		kv.TenantID, kv.TenantUUID,
 		nilIfEmpty(kv.ProjectID), nilIfNilUUID(kv.ProjectUUID),
-		kv.Name, kv.SoftDeleteDays, string(kv.Status), message, r.regionStamp(), r.zoneStamp(),
+		kv.Name, kv.SoftDeleteDays, string(kv.Status), message, region, zone,
 	).Scan(&kv.ID, &kv.CreatedAt, &kv.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create key_vault: %w", err)
 	}

--- a/dc-api/internal/db/network.go
+++ b/dc-api/internal/db/network.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 )
 
 
@@ -46,9 +47,11 @@ func (r *Repository) CreateVNet(ctx context.Context, v *models.VNet) (*models.VN
 
 	// Zone (phase 0): the VNet is a root resource, so its zone is stamped from
 	// DCAPI_LOCAL_ZONE when the handler leaves it empty. Children inherit this.
-	if v.Zone == "" {
-		v.Zone = r.zoneStamp()
-	}
+	// Region passes through unchanged (placement.VNet is RegionFromModel) — the
+	// validated request region in v.Region is authoritative, never the local
+	// stamp. Resolved by the table-driven Stamp helper; v.Zone is written back so
+	// callers that read the returned VNet see the resolved zone (tests rely on it).
+	v.Region, v.Zone = r.Stamp(placement.VNet, v.Region, v.Zone)
 	row := r.pool.QueryRow(ctx, q,
 		v.TenantID,
 		v.TenantUUID,

--- a/dc-api/internal/db/placement.go
+++ b/dc-api/internal/db/placement.go
@@ -1,0 +1,55 @@
+// Package db — placement.go
+//
+// The shared region/zone stamping primitive. Before this file every Create*
+// method open-coded its own region/zone binding (regionStamp()/zoneStamp(), or
+// the v.Zone-default-then-bind for VNet, or the res.Zone-or-default for VPC
+// children). Those five shapes are now ALL produced by one helper, Stamp,
+// driven by a placement.Family declaration — so a new regional resource needs
+// no per-Create hand-wiring, only a Family row.
+//
+// Stamp returns VALUES rather than mutating a model, deliberately: field-less
+// families (KeyVault/Database/PrivateEndpoint have no Region/Zone struct field)
+// pass the returned values straight to their INSERT and write nothing back to
+// the struct, while field-bearing families assign them onto the model. One
+// mechanism, both heterogeneous classes, no invented fields.
+package db
+
+import "github.com/wso2/dc-api/internal/placement"
+
+// Stamp returns the (region, zone) to write for a row of family f.
+//
+// inRegion/inZone are caller-supplied hints:
+//   - inZone: a child's inherited zone (the parent VNet's zone), or "" when the
+//     caller has none — Stamp then falls back to the local zone (zoneStamp).
+//   - inRegion: used ONLY by VNet (RegionFromModel) where region comes from the
+//     validated model value; every other family always stamps the local region.
+//
+// This single function reproduces all five legacy stamp shapes:
+//   - VPC child (VM/Cluster/Bastion): Stamp(VM, "", res.Zone)
+//     → (regionStamp(), res.Zone-or-zoneStamp()).
+//   - VNet root:                       Stamp(VNet, v.Region, v.Zone)
+//     → (v.Region, v.Zone-or-zoneStamp()).
+//   - field-less root (KV/DB/PE):      Stamp(KeyVault, "", "")
+//     → (regionStamp(), zoneStamp()).
+//
+// For a non-regional family it returns ("", ""); such families never bind these
+// columns and must not call Stamp.
+func (r *Repository) Stamp(f placement.Family, inRegion, inZone string) (region, zone string) {
+	if !f.Regional {
+		return "", ""
+	}
+	// Region: VNet trusts the model value (RegionFromModel); everyone else is
+	// always-local — identical to every non-VNet region binding today.
+	if f.RegionFromModel {
+		region = inRegion
+	} else {
+		region = r.regionStamp()
+	}
+	// Zone: an inherited value wins, else the local-zone default — identical to
+	// the two legacy patterns (child res.Zone-or-default, root empty-or-default).
+	zone = inZone
+	if zone == "" {
+		zone = r.zoneStamp()
+	}
+	return region, zone
+}

--- a/dc-api/internal/db/placement_test.go
+++ b/dc-api/internal/db/placement_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/wso2/dc-api/internal/placement"
+)
+
+// TestStamp_RootFieldlessDefaults pins that a field-less Root family (KeyVault/
+// Database/PrivateEndpoint) is stamped with the local region+zone defaults from
+// empty inputs — byte-identical to the prior `r.regionStamp(), r.zoneStamp()`
+// unconditional binds. No DB needed: Stamp only reads localRegion/localZone.
+func TestStamp_RootFieldlessDefaults(t *testing.T) {
+	// (a) unset locals → seeded fallbacks "lk"/"zone-1".
+	r := &Repository{}
+	for _, f := range []placement.Family{placement.KeyVault, placement.Database, placement.PrivateEndpoint} {
+		region, zone := r.Stamp(f, "", "")
+		if region != "lk" || zone != "zone-1" {
+			t.Errorf("Stamp(%s) defaults = (%q,%q), want (lk,zone-1)", f.Kind, region, zone)
+		}
+	}
+
+	// (b) configured locals → those values.
+	r2 := &Repository{localRegion: "us", localZone: "zone-7"}
+	region, zone := r2.Stamp(placement.KeyVault, "", "")
+	if region != "us" || zone != "zone-7" {
+		t.Errorf("Stamp(KeyVault) with locals = (%q,%q), want (us,zone-7)", region, zone)
+	}
+}
+
+// TestStamp_ChildInheritsZoneRegionLocal pins the VPC-child behaviour shared by
+// VM/Cluster/Bastion through resources.Create: region is ALWAYS the local stamp
+// (never the parent's), zone is the inherited value when present, else the local
+// default. Mirrors the legacy `r.regionStamp()` + `zone := res.Zone; if ""...`.
+func TestStamp_ChildInheritsZoneRegionLocal(t *testing.T) {
+	r := &Repository{localRegion: "lk", localZone: "zone-1"}
+
+	// Inherited (VPC path): zone comes from the parent, region stays local.
+	for _, f := range []placement.Family{placement.VM, placement.Cluster, placement.Bastion} {
+		region, zone := r.Stamp(f, "", "zone-3")
+		if region != "lk" {
+			t.Errorf("Stamp(%s) region = %q, want lk (always-local)", f.Kind, region)
+		}
+		if zone != "zone-3" {
+			t.Errorf("Stamp(%s) zone = %q, want inherited zone-3", f.Kind, zone)
+		}
+	}
+
+	// Legacy non-VPC path: no inherited zone → falls back to the local default.
+	region, zone := r.Stamp(placement.VM, "", "")
+	if region != "lk" || zone != "zone-1" {
+		t.Errorf("Stamp(VM) legacy path = (%q,%q), want (lk,zone-1)", region, zone)
+	}
+}
+
+// TestStamp_VNetRegionFromModel pins VNet's lone exception: region passes through
+// from the model unchanged (RegionFromModel), never the local stamp; zone defaults
+// only when empty. Mirrors the legacy raw `v.Region` bind + `if v.Zone==""...`.
+func TestStamp_VNetRegionFromModel(t *testing.T) {
+	r := &Repository{localRegion: "lk", localZone: "zone-1"}
+
+	// Model region passes through (not "lk"); model zone passes through.
+	region, zone := r.Stamp(placement.VNet, "eu", "zone-5")
+	if region != "eu" {
+		t.Errorf("Stamp(VNet) region = %q, want model value eu (RegionFromModel)", region)
+	}
+	if zone != "zone-5" {
+		t.Errorf("Stamp(VNet) zone = %q, want model value zone-5", zone)
+	}
+
+	// Empty model zone → local default; region still from model.
+	region, zone = r.Stamp(placement.VNet, "eu", "")
+	if region != "eu" || zone != "zone-1" {
+		t.Errorf("Stamp(VNet) empty-zone = (%q,%q), want (eu,zone-1)", region, zone)
+	}
+}
+
+// TestStamp_NonRegionalReturnsEmpty pins that non-regional families never get a
+// region/zone (their INSERTs have no such columns).
+func TestStamp_NonRegionalReturnsEmpty(t *testing.T) {
+	r := &Repository{localRegion: "lk", localZone: "zone-1"}
+	region, zone := r.Stamp(placement.Subnet, "", "")
+	if region != "" || zone != "" {
+		t.Errorf("Stamp(Subnet) = (%q,%q), want empty (non-regional)", region, zone)
+	}
+}

--- a/dc-api/internal/db/private_endpoint.go
+++ b/dc-api/internal/db/private_endpoint.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/wso2/dc-api/internal/audit"
 	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/placement"
 )
 
 // ErrPrivateEndpointNotFound is returned when a lookup misses.
@@ -50,11 +51,15 @@ func (r *Repository) CreatePrivateEndpoint(ctx context.Context, ep *models.Priva
 	if ep.Message != "" {
 		messagePtr = &ep.Message
 	}
+	// Field-less family declared Root (see placement.PrivateEndpoint): region/zone
+	// are default-stamped via the table-driven Stamp helper, value-identical to
+	// the prior unconditional binds. No handler inheritance today, none added.
+	region, zone := r.Stamp(placement.PrivateEndpoint, "", "")
 	if err := r.pool.QueryRow(ctx, q,
 		ep.TenantID, ep.TenantUUID,
 		nilIfEmpty(ep.ProjectID), nilIfNilUUID(ep.ProjectUUID),
 		string(ep.TargetType), ep.TargetID, ep.VNetID, ep.SubnetID, ep.Name,
-		ipPtr, hostnamePtr, ep.BackendAddr, proxyPodPtr, string(ep.Status), messagePtr, r.regionStamp(), r.zoneStamp(),
+		ipPtr, hostnamePtr, ep.BackendAddr, proxyPodPtr, string(ep.Status), messagePtr, region, zone,
 	).Scan(&ep.ID, &ep.CreatedAt, &ep.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("db create private_endpoint: %w", err)
 	}

--- a/dc-api/internal/placement/registry.go
+++ b/dc-api/internal/placement/registry.go
@@ -1,0 +1,134 @@
+// Package placement is the single declarative source of truth for how each
+// resource family acquires its (region, zone) pair — the "regional" property
+// made declarative, the same way the capability registry made
+// "agent-manageable" declarative.
+//
+// ── THE CONTRACT FOR NEW REGIONAL RESOURCE FAMILIES ──────────────────────────
+//
+// Before this package, the fact that a resource carries a region and a zone was
+// hand-wired across ~11 files: the db layer stamped region/zone inline in every
+// Create* method, the handlers copied region/zone from a parent VNet by hand,
+// and the cross-region/cross-zone mismatch guard was open-coded in peering.go.
+//
+// Now a family's regional shape is ONE row in the var block below, consumed by
+// shared code:
+//
+//   - db.Repository.Stamp(f, inRegion, inZone) resolves the (region, zone) to
+//     write for any family, driven entirely by the Family's flags.
+//   - placement.SamePlacement(...) reproduces the cross-region (400) /
+//     cross-zone (422) guard.
+//
+// To make a new resource family regional: append one Family var here (and, if a
+// child, name its ParentKind). No per-handler or per-db hand-wiring.
+//
+// This package is a LEAF — it imports nothing from the project (only std-lib
+// behaviour via fmt) so both db and handlers can import it without an import
+// cycle (db must never import handlers).
+package placement
+
+import "fmt"
+
+// PlacementMode is how a family acquires its (region, zone).
+type PlacementMode int
+
+const (
+	// Root families choose their own region/zone — they are default-stamped
+	// from the control plane's local region/zone.
+	Root PlacementMode = iota
+	// Child families inherit region/zone from a named parent family.
+	Child
+)
+
+// Family declares the regional shape of one resource family. The Kind matches
+// the kind string used by the audit framework (auditedTable.kind).
+type Family struct {
+	// Kind is the family identifier, e.g. "VM", "VNET", "KEYVAULT".
+	Kind string
+	// Regional is whether this family carries/stamps region+zone at all.
+	// Non-regional families have no region/zone columns and are never stamped.
+	Regional bool
+	// Mode is Root or Child. Ignored when !Regional.
+	Mode PlacementMode
+	// ParentKind, for Child families, is the Family.Kind it inherits from.
+	ParentKind string
+	// HasModelField is true when region/zone live on the Go model and round-trip;
+	// false for write-only DB columns (KeyVault/Database/PrivateEndpoint have no
+	// Region/Zone struct field).
+	HasModelField bool
+	// RegionFromModel is true ONLY for VNET: its region is taken from the model
+	// (the validated request region), never from the local region stamp.
+	RegionFromModel bool
+}
+
+// The per-family declarations. Adding a regional resource is appending one row.
+//
+// NOTE on Stamp keying: the shared Stamp helper keys on the flags below
+// (RegionFromModel, Mode/inputs), NOT on Kind. VM/Cluster/Bastion share a single
+// db Create, so any of those Family values is interchangeable there precisely
+// because all three are Child/VNET/HasModelField/!RegionFromModel.
+var (
+	// ── Roots (choose their own placement) ───────────────────────────────────
+	VNet     = Family{Kind: "VNET", Regional: true, Mode: Root, HasModelField: true, RegionFromModel: true}
+	KeyVault = Family{Kind: "KEYVAULT", Regional: true, Mode: Root, HasModelField: false}
+	// Database and PrivateEndpoint are conceptually VPC children, but TODAY they
+	// unconditionally default-stamp region/zone and do NOT inherit from a parent
+	// VNet. They are declared Root to preserve that exact behaviour. The
+	// aspirational §13.1 parent-zone inheritance is deferred to step 3b; flipping
+	// these to Child would silently change stamping from zoneStamp() to the
+	// parent VNet's zone — do not do that here.
+	Database        = Family{Kind: "DATABASE", Regional: true, Mode: Root, HasModelField: false}
+	PrivateEndpoint = Family{Kind: "PRIVATE_ENDPOINT", Regional: true, Mode: Root, HasModelField: false}
+
+	// ── Children (inherit region/zone from VNET) — resources-table families ──
+	VM      = Family{Kind: "VM", Regional: true, Mode: Child, ParentKind: "VNET", HasModelField: true}
+	Cluster = Family{Kind: "CLUSTER", Regional: true, Mode: Child, ParentKind: "VNET", HasModelField: true}
+	Bastion = Family{Kind: "BASTION", Regional: true, Mode: Child, ParentKind: "VNET", HasModelField: true}
+
+	// ── Non-regional families (no region/zone column) ───────────────────────
+	// Declared for completeness/clarity. They inherit by FK containment and are
+	// never stamped — their Create methods do not call Stamp.
+	Subnet          = Family{Kind: "SUBNET", Regional: false}
+	RouteTable      = Family{Kind: "ROUTE_TABLE", Regional: false}
+	NSG             = Family{Kind: "NSG", Regional: false}
+	NSGAttachment   = Family{Kind: "NSG_ATTACHMENT", Regional: false}
+	Peering         = Family{Kind: "PEERING", Regional: false}
+	PrivateDnsZone  = Family{Kind: "PRIVATE_DNS_ZONE", Regional: false}
+	DnsRecord       = Family{Kind: "DNS_RECORD", Regional: false}
+	RouteTableAssoc = Family{Kind: "ROUTE_TABLE_ASSOC", Regional: false}
+)
+
+// PlacementError carries the HTTP status and message for a placement mismatch,
+// so callers (handlers) write the exact status/message the open-coded guard did.
+type PlacementError struct {
+	Status int
+	Msg    string
+}
+
+func (e *PlacementError) Error() string { return e.Msg }
+
+// SamePlacement reproduces the peering handler's two consecutive guards as one
+// shared check, byte-identical in status and message:
+//
+//   - regions differ          → 400 "cross-region peering is not supported in M2 (...)"
+//   - regions equal, zones differ → 422 "cross-zone peering is not supported (...)"
+//   - otherwise               → nil
+//
+// Operand order matters: the messages list (a, b) — keep (vnet, peerVNet) at the
+// call site or the rendered text flips.
+func SamePlacement(aRegion, aZone, bRegion, bZone string) *PlacementError {
+	if aRegion != bRegion {
+		return &PlacementError{
+			Status: 400,
+			Msg: fmt.Sprintf("cross-region peering is not supported in M2 (VNet region: %s, peer VNet region: %s)",
+				aRegion, bRegion),
+		}
+	}
+	if aZone != bZone {
+		return &PlacementError{
+			Status: 422,
+			Msg: fmt.Sprintf("cross-zone peering is not supported (VNet zone: %s, peer VNet zone: %s)",
+				aZone, bZone),
+		}
+	}
+	return nil
+}

--- a/dc-api/internal/placement/registry_test.go
+++ b/dc-api/internal/placement/registry_test.go
@@ -1,0 +1,83 @@
+package placement
+
+import "testing"
+
+// TestSamePlacement_Identical pins that equal region+zone yields no error so a
+// peering proceeds — the common single-zone production case.
+func TestSamePlacement_Identical(t *testing.T) {
+	if e := SamePlacement("lk", "zone-1", "lk", "zone-1"); e != nil {
+		t.Errorf("SamePlacement(equal) = %v, want nil", e)
+	}
+}
+
+// TestSamePlacement_CrossRegion pins the cross-region branch: 400 with the exact
+// legacy message and operand order (a, b) == (vnet, peerVNet).
+func TestSamePlacement_CrossRegion(t *testing.T) {
+	e := SamePlacement("lk", "zone-1", "eu", "zone-1")
+	if e == nil {
+		t.Fatal("SamePlacement(cross-region) = nil, want error")
+	}
+	if e.Status != 400 {
+		t.Errorf("status = %d, want 400", e.Status)
+	}
+	want := "cross-region peering is not supported in M2 (VNet region: lk, peer VNet region: eu)"
+	if e.Msg != want {
+		t.Errorf("msg = %q, want %q", e.Msg, want)
+	}
+}
+
+// TestSamePlacement_CrossZone pins the cross-zone branch: equal region, differing
+// zone → 422 with the exact legacy message and operand order.
+func TestSamePlacement_CrossZone(t *testing.T) {
+	e := SamePlacement("lk", "zone-1", "lk", "zone-2")
+	if e == nil {
+		t.Fatal("SamePlacement(cross-zone) = nil, want error")
+	}
+	if e.Status != 422 {
+		t.Errorf("status = %d, want 422", e.Status)
+	}
+	want := "cross-zone peering is not supported (VNet zone: zone-1, peer VNet zone: zone-2)"
+	if e.Msg != want {
+		t.Errorf("msg = %q, want %q", e.Msg, want)
+	}
+}
+
+// TestSamePlacement_RegionWinsOverZone pins precedence: when BOTH region and zone
+// differ, the region (400) guard fires first, exactly as the two consecutive
+// legacy if-blocks ordered them.
+func TestSamePlacement_RegionWinsOverZone(t *testing.T) {
+	e := SamePlacement("lk", "zone-1", "eu", "zone-2")
+	if e == nil || e.Status != 400 {
+		t.Fatalf("SamePlacement(both differ) = %v, want status 400 (region first)", e)
+	}
+}
+
+// TestFamilyDeclarations pins the declared shape of each family so an accidental
+// flip (e.g. Database → Child, which would change stamping) is caught.
+func TestFamilyDeclarations(t *testing.T) {
+	// Roots that default-stamp.
+	for _, f := range []Family{VNet, KeyVault, Database, PrivateEndpoint} {
+		if !f.Regional || f.Mode != Root {
+			t.Errorf("%s should be Regional Root, got Regional=%v Mode=%v", f.Kind, f.Regional, f.Mode)
+		}
+	}
+	// VNet alone takes region from the model.
+	if !VNet.RegionFromModel {
+		t.Error("VNet must be RegionFromModel")
+	}
+	if KeyVault.RegionFromModel || Database.RegionFromModel || PrivateEndpoint.RegionFromModel {
+		t.Error("field-less roots must NOT be RegionFromModel")
+	}
+	// VM/Cluster/Bastion are Children of VNET.
+	for _, f := range []Family{VM, Cluster, Bastion} {
+		if !f.Regional || f.Mode != Child || f.ParentKind != "VNET" || f.RegionFromModel {
+			t.Errorf("%s should be Regional Child of VNET, !RegionFromModel; got %+v", f.Kind, f)
+		}
+	}
+	// Non-regional families.
+	for _, f := range []Family{Subnet, RouteTable, NSG, NSGAttachment, Peering, PrivateDnsZone, DnsRecord, RouteTableAssoc} {
+		if f.Regional {
+			t.Errorf("%s should be non-regional", f.Kind)
+		}
+	}
+}


### PR DESCRIPTION
## What this changes

Until now, the fact that a resource carries a region and a zone was hand-copied across about eleven files: the database layer stamped the values inline in every create method, the handlers copied them from a parent network by hand, and the cross-region and cross-zone mismatch checks were written out in the peering handler. Making a new resource regional meant touching all of those places and keeping them consistent.

This introduces a single declaration per resource family — in a new `internal/placement` package — that says whether the family is regional and whether it is a "root" (picks its own region and zone) or a "child" (inherits them from a named parent). Shared helpers then do the stamping, the parent-inheritance, and the mismatch validation by reading that declaration. Making a resource regional becomes one row in that table rather than edits spread across the codebase. It's the same idea as the agent capability registry, applied to the "regional" property.

## Why it's safe

It's a pure refactor — behaviour is unchanged for every resource family. The same region and zone are stamped, children inherit from the same parent networks, and a cross-region or cross-zone mismatch returns the same status and message as before. The change is deliberately faithful to *current* behaviour: databases and private endpoints are declared as roots (not children), because today they default-stamp their region and zone rather than inheriting from a parent — the declaration encodes what the code does now, and the future inherited form stays deferred.

## What's untouched

The region and zone database columns, the public API and `openapi.yaml`, cloud-ui, and dcctl are all unchanged, and routing is not affected — which agent a resource's operations are sent to is a separate, later change.

## How to verify

`go build`, `go vet`, and race-enabled unit tests all pass, including the new `placement` package tests. The Postgres-backed zone integration tests from the earlier zone work pass against the refactored create paths with no edits to the tests themselves — that is the behaviour-preservation check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
