### PR TITLE
[Feature] Route each resource to its own zone's provider

### DIFF
--- a/dc-api/cmd/dc-api/main.go
+++ b/dc-api/cmd/dc-api/main.go
@@ -113,6 +113,12 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialise provider registry")
 	}
+	// Per-resource zone routing: the registry resolves the provider set for each
+	// resource's (region, zone). The regions/zones catalog gates building a set
+	// for a REMOTE zone (fail closed → an unknown zone never falls back to the
+	// local cluster). In the single-cluster default no remote zone is ever asked
+	// for, so this is inert there. The LOCAL set below stays the eager cache hit.
+	provReg.WithZoneCatalog(repo)
 	localSet, err := provReg.For(cfg.LocalRegion, cfg.LocalZone)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to resolve local provider set")
@@ -222,14 +228,14 @@ func main() {
 		// kube-ovn-controller hiccup must not prevent the API from starting.
 		{
 			bfCtx, bfCancel := context.WithTimeout(ctx, 10*time.Minute)
-			runNATBackfill(bfCtx, repo, kvClient)
+			runNATBackfill(bfCtx, repo, kvClient, cfg.LocalRegion, cfg.LocalZone)
 			bfCancel()
 		}
 
 		// ── Step 4: F20 backfill (10 min budget) ──────────────────────────────
 		{
 			bfCtx, bfCancel := context.WithTimeout(ctx, 10*time.Minute)
-			runDNSBackfill(bfCtx, repo, kvClient)
+			runDNSBackfill(bfCtx, repo, kvClient, cfg.LocalRegion, cfg.LocalZone)
 			bfCancel()
 		}
 	}
@@ -313,7 +319,11 @@ func main() {
 	// Polls PENDING/DELETING resources every 60s and syncs their status from
 	// the provider back into PostgreSQL. Runs as a background goroutine and
 	// exits cleanly when ctx is cancelled (SIGTERM).
-	go reconciler.New(repo, computeProvider, clusterProvider, log.Logger).Run(ctx)
+	// The reconciler resolves the provider per-resource by the resource's zone
+	// (provReg), so a resource in a remote zone reconciles against that zone's
+	// agent and one unreachable zone never stalls the others. In the single-zone
+	// case every resource resolves to the same local set (the cache hit).
+	go reconciler.New(repo, provReg, log.Logger).Run(ctx)
 
 	// ── F21: build infra-reserved-NAD set + sanity-check operator config ─────
 	// Build a set from DCAPI_INFRA_RESERVED_NADS, then assert that the
@@ -387,10 +397,17 @@ func main() {
 	// ── Router ────────────────────────────────────────────────────────────────
 	// All wiring happens in NewRouter. main.go does not know about individual routes.
 	router := api.NewRouter(api.RouterDeps{
-		Repo:                repo,
-		ComputeProvider:     computeProvider,
-		ClusterProvider:     clusterProvider,
-		NetworkProvider:     networkProvider,
+		Repo: repo,
+		// Per-resource provider resolver. Handlers call Providers.For(region, zone)
+		// per resource so a resource in a remote zone reaches that zone's agent. In
+		// the single-cluster / single-zone case every lookup is a cache hit on the
+		// local set built once in NewRegistry — byte-identical to the fixed
+		// providers below. The fixed providers remain for router-only callers
+		// (contract harness / tests) that build a router without a Registry.
+		Providers:       provReg,
+		ComputeProvider: computeProvider,
+		ClusterProvider: clusterProvider,
+		NetworkProvider: networkProvider,
 		NATProvisioner:      natProvisioner,
 		DNSProvisioner:      dnsProvisioner,
 		DNSSearchDomain:     cfg.VPCDNSSearchDomain,
@@ -460,7 +477,25 @@ func main() {
 //
 // Error handling: individual VPC failures are logged and skipped so a single
 // broken VPC doesn't prevent the API from starting.
-func runNATBackfill(ctx context.Context, repo *db.Repository, kvClient *kubeovn.Client) {
+// isLocalZoneVNet reports whether a VNet's (region, zone) is the local zone the
+// startup backfill loops can act on. dc-api holds direct kubeconfig credentials
+// only for the local zone; an empty region/zone on the row means "unspecified" →
+// the local zone (single-zone deployments never stamp a non-local zone). A
+// remote-zone VNet is skipped — its NAT/DNS has no agent path yet, and running
+// the local kvClient against it would wrongly target the LOCAL cluster.
+func isLocalZoneVNet(region, zone, localRegion, localZone string) bool {
+	r := region
+	if r == "" {
+		r = localRegion
+	}
+	z := zone
+	if z == "" {
+		z = localZone
+	}
+	return r == localRegion && z == localZone
+}
+
+func runNATBackfill(ctx context.Context, repo *db.Repository, kvClient *kubeovn.Client, localRegion, localZone string) {
 	vnets, err := repo.ListAllActiveVNets(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("NAT backfill: failed to list VNets — skipping backfill")
@@ -475,6 +510,14 @@ func runNATBackfill(ctx context.Context, repo *db.Repository, kvClient *kubeovn.
 	for _, vnet := range vnets {
 		if vnet.BackendUID == "" {
 			log.Warn().Str("vnet_id", vnet.ID.String()).Msg("NAT backfill: skipping VNet with no backend_uid (still PENDING?)")
+			continue
+		}
+		// The local kvClient holds credentials ONLY for the local zone. A remote-
+		// zone VNet's NAT cannot be provisioned here (no agent path for NAT yet) —
+		// skip it rather than misroute the CRDs to the LOCAL cluster.
+		if !isLocalZoneVNet(vnet.Region, vnet.Zone, localRegion, localZone) {
+			log.Debug().Str("vpc", vnet.BackendUID).Str("region", vnet.Region).Str("zone", vnet.Zone).
+				Msg("NAT backfill: skipping non-local-zone VNet (NAT plumbing is local-only)")
 			continue
 		}
 
@@ -529,7 +572,7 @@ func runNATBackfill(ctx context.Context, repo *db.Repository, kvClient *kubeovn.
 // CoreDNS Deployment (F20). Mirrors runNATBackfill exactly.
 //
 // Error handling: individual VPC failures are logged and skipped.
-func runDNSBackfill(ctx context.Context, repo *db.Repository, kvClient *kubeovn.Client) {
+func runDNSBackfill(ctx context.Context, repo *db.Repository, kvClient *kubeovn.Client, localRegion, localZone string) {
 	vnets, err := repo.ListAllActiveVNets(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("DNS backfill: failed to list VNets — skipping backfill")
@@ -544,6 +587,12 @@ func runDNSBackfill(ctx context.Context, repo *db.Repository, kvClient *kubeovn.
 	for _, vnet := range vnets {
 		if vnet.BackendUID == "" {
 			log.Warn().Str("vnet_id", vnet.ID.String()).Msg("DNS backfill: skipping VNet with no backend_uid (still PENDING?)")
+			continue
+		}
+		// Local-only: the local kvClient cannot provision a remote zone's CoreDNS.
+		if !isLocalZoneVNet(vnet.Region, vnet.Zone, localRegion, localZone) {
+			log.Debug().Str("vpc", vnet.BackendUID).Str("region", vnet.Region).Str("zone", vnet.Zone).
+				Msg("DNS backfill: skipping non-local-zone VNet (CoreDNS plumbing is local-only)")
 			continue
 		}
 

--- a/dc-api/internal/api/handlers/bastion.go
+++ b/dc-api/internal/api/handlers/bastion.go
@@ -34,8 +34,12 @@ import (
 // Quota: bastions count against the same max_vms quota — they ARE VMs at the
 // backend. A separate max_bastions could land later if usage justifies.
 type BastionHandler struct {
-	repo            *db.Repository
-	provider        providers.ComputeProvider
+	repo *db.Repository
+	// resolve maps a bastion's (region, zone) to that zone's ComputeProvider —
+	// bastions are KubeVirt VMs under the hood. See VMHandler.resolve.
+	resolve         providers.Resolver
+	defaultRegion   string
+	defaultZone     string
 	bastionImage    string // DCAPI_BASTION_IMAGE
 	bastionMgmtNAD  string // DCAPI_BASTION_MGMT_NAD
 	dnsSearchDomain string // DCAPI_VPC_DNS_SEARCH_DOMAIN — same as VMHandler
@@ -45,18 +49,31 @@ type BastionHandler struct {
 // NewBastionHandler creates a BastionHandler with injected dependencies.
 func NewBastionHandler(
 	repo *db.Repository,
-	provider providers.ComputeProvider,
+	resolve providers.Resolver,
+	defaultRegion, defaultZone string,
 	bastionImage, bastionMgmtNAD, dnsSearchDomain string,
 	log zerolog.Logger,
 ) *BastionHandler {
 	return &BastionHandler{
 		repo:            repo,
-		provider:        provider,
+		resolve:         resolve,
+		defaultRegion:   defaultRegion,
+		defaultZone:     defaultZone,
 		bastionImage:    bastionImage,
 		bastionMgmtNAD:  bastionMgmtNAD,
 		dnsSearchDomain: dnsSearchDomain,
 		log:             log,
 	}
+}
+
+// compute resolves the ComputeProvider for a bastion's (region, zone). Empty
+// region/zone resolves to the local zone (cache hit).
+func (h *BastionHandler) compute(region, zone string) (providers.ComputeProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Compute, nil
 }
 
 // ─────────────────────────── Request / Response DTOs ────────────────────────
@@ -219,8 +236,17 @@ func (h *BastionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// phase-0 zone inheritance from the (always present) parent VNet.
-	_, bastionZone := inheritPlacement(placement.Bastion, vnet.Region, vnet.Zone, true)
+	// phase-0 region/zone inheritance from the (always present) parent VNet.
+	bastionRegion, bastionZone := inheritPlacement(placement.Bastion, vnet.Region, vnet.Zone, true)
+
+	// Resolve the bastion's compute provider for its zone BEFORE the PENDING row,
+	// so an unknown / unreachable zone fails clearly without stranding a row.
+	compute, err := h.compute(bastionRegion, bastionZone)
+	if err != nil {
+		h.log.Error().Err(err).Str("region", bastionRegion).Str("zone", bastionZone).Msg("resolve bastion provider for zone")
+		writeError(w, http.StatusBadRequest, "cannot place bastion in the requested zone: "+err.Error())
+		return
+	}
 
 	// SSH key (same flow as VM — private key returned once, never stored).
 	publicKey, privateKeyPEM, err := generateSSHKeyPair()
@@ -251,12 +277,13 @@ func (h *BastionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Type:         models.ResourceTypeBastion,
 		Size:         "small",
 		Status:       models.StatusPending,
-		ProviderType: h.provider.Name(),
+		ProviderType: compute.Name(),
 		VNetID:       &vnet.ID,
 		SubnetID:     &subnet.ID,
-		// phase-0 zone inheritance: bastion is always a VPC child, so it adopts
-		// the parent VNet's zone via the table-driven helper (placement.Bastion).
-		Zone: bastionZone,
+		// phase-0 region/zone inheritance: bastion is always a VPC child, so it
+		// adopts the parent VNet's zone via the table-driven helper.
+		Region: bastionRegion,
+		Zone:   bastionZone,
 	})
 	if err != nil {
 		h.log.Error().Err(err).Str("tenant", tenantID).Msg("create bastion resource in DB")
@@ -291,7 +318,7 @@ func (h *BastionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		DNSSearchDomain:  h.dnsSearchDomain,
 		MgmtNAD:          h.bastionMgmtNAD,
 	}
-	go h.asyncProvision(resource.ID, tenantID, projectID, userID, spec, req.Description)
+	go h.asyncProvision(compute, resource.ID, tenantID, projectID, userID, spec, req.Description)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
@@ -383,6 +410,14 @@ func (h *BastionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the bastion's provider for its OWN zone before marking DELETING.
+	compute, err := h.compute(resource.Region, resource.Zone)
+	if err != nil && resource.BackendUID != "" {
+		h.log.Error().Err(err).Str("zone", resource.Zone).Msg("resolve bastion provider for delete")
+		writeError(w, http.StatusBadGateway, "cannot reach the bastion's zone to delete it: "+err.Error())
+		return
+	}
+
 	if err := h.repo.UpdateStatus(r.Context(), id, models.StatusDeleting, "deletion requested", ""); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update bastion status")
 		return
@@ -395,7 +430,7 @@ func (h *BastionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			_ = h.repo.Delete(ctx, id)
 			return
 		}
-		if err := h.provider.DeleteVM(ctx, resource.BackendUID); err != nil {
+		if err := compute.DeleteVM(ctx, resource.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", resource.BackendUID).Msg("harvester delete bastion VM failed")
 			_ = h.repo.UpdateStatus(ctx, id, models.StatusFailed, "deletion failed: "+err.Error(), "")
 		}
@@ -406,11 +441,11 @@ func (h *BastionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // ─────────────────────────── Async Provisioner ──────────────────────────────
 
-func (h *BastionHandler) asyncProvision(resourceID uuid.UUID, tenantID, projectID, userID string, spec models.VMSpec, _ string) {
+func (h *BastionHandler) asyncProvision(compute providers.ComputeProvider, resourceID uuid.UUID, tenantID, projectID, userID string, spec models.VMSpec, _ string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	providerResource, err := h.provider.CreateVM(ctx, tenantID, projectID, spec)
+	providerResource, err := compute.CreateVM(ctx, tenantID, projectID, spec)
 	if err != nil {
 		h.log.Error().Err(err).Str("bastion", spec.Name).Msg("harvester CreateVM (bastion) failed")
 		_ = h.repo.UpdateStatus(ctx, resourceID, models.StatusFailed,

--- a/dc-api/internal/api/handlers/cluster.go
+++ b/dc-api/internal/api/handlers/cluster.go
@@ -40,14 +40,33 @@ import (
 
 // ClusterHandler handles all /v1/clusters endpoints.
 type ClusterHandler struct {
-	repo     *db.Repository
-	provider providers.ClusterProvider
-	log      zerolog.Logger
+	repo *db.Repository
+	// resolve maps a cluster's (region, zone) to its ClusterProvider. Rancher is
+	// a GLOBAL control plane: every zone resolves to the SAME Rancher client (the
+	// Registry shares one cluster provider across all sets), so cluster resolution
+	// is uniform in code while remaining correct for a fleet-wide Rancher. The
+	// per-zone call still guards against an unknown zone before acting.
+	resolve       providers.Resolver
+	defaultRegion string
+	defaultZone   string
+	log           zerolog.Logger
 }
 
 // NewClusterHandler creates a ClusterHandler with injected dependencies.
-func NewClusterHandler(repo *db.Repository, provider providers.ClusterProvider, log zerolog.Logger) *ClusterHandler {
-	return &ClusterHandler{repo: repo, provider: provider, log: log}
+func NewClusterHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *ClusterHandler {
+	return &ClusterHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+}
+
+// cluster resolves the ClusterProvider for a cluster's (region, zone). Empty
+// region/zone resolves to the local zone. Because Rancher is global, every zone
+// returns the same client — the resolution is for the unknown-zone guard and
+// code uniformity, not because the client differs per zone.
+func (h *ClusterHandler) cluster(region, zone string) (providers.ClusterProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Cluster, nil
 }
 
 // ─────────────────────────── Request / Response DTOs ────────────────────────
@@ -374,7 +393,7 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// failed lookup returns 4xx without creating an orphan resource row.
 	var vnetBackendUID, subnetBackendUID string
 	var vnetUUIDPtr, subnetUUIDPtr *uuid.UUID // F41: persisted on the Resource row when VPC path is used
-	var clusterZone string                    // phase-0 zone: inherited from the parent VNet on the VPC path
+	var clusterRegion, clusterZone string     // phase-0 region/zone: inherited from the parent VNet on the VPC path
 	if req.VNetID != "" {
 		vnetUUID, _ := uuid.Parse(req.VNetID)
 		subnetUUID, _ := uuid.Parse(req.SubnetID)
@@ -410,7 +429,17 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		// Phase-0 zone inheritance: the cluster adopts its parent VNet's zone,
 		// resolved through the table-driven helper (placement.Cluster is a Child
 		// of VNET).
-		_, clusterZone = inheritPlacement(placement.Cluster, vnet.Region, vnet.Zone, true)
+		clusterRegion, clusterZone = inheritPlacement(placement.Cluster, vnet.Region, vnet.Zone, true)
+	}
+
+	// Resolve the cluster provider for the cluster's zone before the PENDING row.
+	// Rancher is global, so this returns the same client for every zone; the call
+	// still guards against an unknown zone surfacing a clear error.
+	cluster, err := h.cluster(clusterRegion, clusterZone)
+	if err != nil {
+		h.log.Error().Err(err).Str("region", clusterRegion).Str("zone", clusterZone).Msg("resolve cluster provider for zone")
+		writeError(w, http.StatusBadRequest, "cannot place cluster in the requested zone: "+err.Error())
+		return
 	}
 
 	// Create PENDING record
@@ -427,8 +456,9 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Status:       models.StatusPending,
 		VNetID:       vnetUUIDPtr,
 		SubnetID:     subnetUUIDPtr,
-		Zone:         clusterZone, // empty on the non-VPC path → Create falls back to zoneStamp()
-		ProviderType: h.provider.Name(),
+		Region:       clusterRegion, // empty on the non-VPC path → Create falls back to the local region
+		Zone:         clusterZone,   // empty on the non-VPC path → Create falls back to zoneStamp()
+		ProviderType: cluster.Name(),
 	})
 	if err != nil {
 		h.log.Error().Err(err).Msg("create cluster resource in DB")
@@ -516,7 +546,7 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		WorkerPools: workerPools,
 	}
-	go h.asyncProvision(resource.ID, tenantID, projectID, userID, spec)
+	go h.asyncProvision(cluster, resource.ID, tenantID, projectID, userID, spec)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
@@ -589,7 +619,13 @@ func (h *ClusterHandler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kubeconfig, err := h.provider.GetKubeconfig(r.Context(), resource.BackendUID)
+	cluster, err := h.cluster(resource.Region, resource.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", resource.Zone).Msg("resolve cluster provider for kubeconfig")
+		writeError(w, http.StatusBadGateway, "cannot reach the cluster's zone: "+err.Error())
+		return
+	}
+	kubeconfig, err := cluster.GetKubeconfig(r.Context(), resource.BackendUID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to retrieve kubeconfig")
 		return
@@ -663,12 +699,19 @@ func (h *ClusterHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cluster, err := h.cluster(resource.Region, resource.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", resource.Zone).Msg("resolve cluster provider for delete")
+		writeError(w, http.StatusBadGateway, "cannot reach the cluster's zone to delete it: "+err.Error())
+		return
+	}
+
 	_ = h.repo.UpdateStatus(r.Context(), id, models.StatusDeleting, "deletion requested", "")
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
-		if err := h.provider.DeleteCluster(ctx, resource.BackendUID); err != nil {
+		if err := cluster.DeleteCluster(ctx, resource.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("cluster", resource.Name).Msg("delete cluster failed")
 			_ = h.repo.UpdateStatus(ctx, id, models.StatusFailed, "deletion failed: "+err.Error(), "")
 		}
@@ -687,7 +730,7 @@ func (h *ClusterHandler) ListNodePools(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clusterID, clusterName, ok := h.resolveCluster(w, r, tenantUUID)
+	clusterID, clusterName, _, ok := h.resolveCluster(w, r, tenantUUID)
 	if !ok {
 		return
 	}
@@ -747,7 +790,7 @@ func (h *ClusterHandler) AddNodePool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clusterID, clusterName, ok := h.resolveCluster(w, r, tenantUUID)
+	clusterID, clusterName, _, ok := h.resolveCluster(w, r, tenantUUID)
 	if !ok {
 		return
 	}
@@ -802,7 +845,14 @@ func (h *ClusterHandler) AddNodePool(w http.ResponseWriter, r *http.Request) {
 	// are empty and the provider falls back to the bridge settings.
 	mgmtNAD, tenantSubnetNAD, vmNamespace := h.resolveClusterNetworkContext(r.Context(), resource, tenantID)
 
-	go h.asyncAddPool(clusterID, clusterName, pool, mgmtNAD, tenantSubnetNAD, vmNamespace, req.ImageName)
+	cluster, err := h.cluster(resource.Region, resource.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", resource.Zone).Msg("resolve cluster provider for add-pool")
+		writeError(w, http.StatusBadGateway, "cannot reach the cluster's zone: "+err.Error())
+		return
+	}
+
+	go h.asyncAddPool(cluster, clusterID, clusterName, pool, mgmtNAD, tenantSubnetNAD, vmNamespace, req.ImageName)
 
 	writeJSON(w, http.StatusAccepted, poolToResponse(pool))
 }
@@ -821,7 +871,7 @@ func (h *ClusterHandler) GetNodePool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clusterID, _, ok := h.resolveCluster(w, r, tenantUUID)
+	clusterID, _, _, ok := h.resolveCluster(w, r, tenantUUID)
 	if !ok {
 		return
 	}
@@ -882,7 +932,7 @@ func (h *ClusterHandler) ScaleOrUpdateNodePool(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	clusterID, clusterName, ok := h.resolveCluster(w, r, tenantUUID)
+	clusterID, clusterName, clusterRes, ok := h.resolveCluster(w, r, tenantUUID)
 	if !ok {
 		return
 	}
@@ -950,7 +1000,13 @@ func (h *ClusterHandler) ScaleOrUpdateNodePool(w http.ResponseWriter, r *http.Re
 	}
 
 	// Async: apply changes to Rancher.
-	go h.asyncPatchPool(clusterName, pool, req.Count > 0, newCount, req.Taints != nil || req.Labels != nil, newTaints, newLabels)
+	cluster, err := h.cluster(clusterRes.Region, clusterRes.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", clusterRes.Zone).Msg("resolve cluster provider for patch-pool")
+		writeError(w, http.StatusBadGateway, "cannot reach the cluster's zone: "+err.Error())
+		return
+	}
+	go h.asyncPatchPool(cluster, clusterName, pool, req.Count > 0, newCount, req.Taints != nil || req.Labels != nil, newTaints, newLabels)
 
 	writeJSON(w, http.StatusAccepted, poolToResponse(pool))
 }
@@ -986,7 +1042,7 @@ func (h *ClusterHandler) RemoveNodePool(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	clusterID, clusterName, ok := h.resolveCluster(w, r, tenantUUID)
+	clusterID, clusterName, clusterRes, ok := h.resolveCluster(w, r, tenantUUID)
 	if !ok {
 		return
 	}
@@ -1002,24 +1058,31 @@ func (h *ClusterHandler) RemoveNodePool(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	cluster, err := h.cluster(clusterRes.Region, clusterRes.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", clusterRes.Zone).Msg("resolve cluster provider for remove-pool")
+		writeError(w, http.StatusBadGateway, "cannot reach the cluster's zone: "+err.Error())
+		return
+	}
+
 	// Mark deleting immediately so the UI shows feedback.
 	pool.Status = models.NodePoolStatusDeleting
 	if err := h.repo.UpdateNodePool(r.Context(), pool); err != nil {
 		h.log.Error().Err(err).Str("pool", poolName).Msg("mark pool deleting")
 	}
 
-	go h.asyncRemovePool(clusterID, clusterName, pool)
+	go h.asyncRemovePool(cluster, clusterID, clusterName, pool)
 
 	w.WriteHeader(http.StatusAccepted)
 }
 
 // ─────────────────────────── Async helpers ──────────────────────────────────
 
-func (h *ClusterHandler) asyncProvision(resourceID uuid.UUID, tenantID, projectID, userID string, spec models.ClusterSpec) {
+func (h *ClusterHandler) asyncProvision(cluster providers.ClusterProvider, resourceID uuid.UUID, tenantID, projectID, userID string, spec models.ClusterSpec) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
-	providerResource, err := h.provider.CreateCluster(ctx, tenantID, projectID, spec)
+	providerResource, err := cluster.CreateCluster(ctx, tenantID, projectID, spec)
 	if err != nil {
 		h.log.Error().Err(err).Str("cluster", spec.Name).Msg("rancher CreateCluster failed")
 		_ = h.repo.UpdateStatus(ctx, resourceID, models.StatusFailed,
@@ -1039,6 +1102,7 @@ func (h *ClusterHandler) asyncProvision(resourceID uuid.UUID, tenantID, projectI
 
 // asyncAddPool calls provider.AddNodePool and updates the pool row on completion.
 func (h *ClusterHandler) asyncAddPool(
+	cluster providers.ClusterProvider,
 	clusterID uuid.UUID,
 	clusterName string,
 	pool *models.NodePool,
@@ -1047,7 +1111,7 @@ func (h *ClusterHandler) asyncAddPool(
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	if err := h.provider.AddNodePool(ctx, clusterName, pool, mgmtNAD, tenantSubnetNAD, vmNamespace, nodeImage); err != nil {
+	if err := cluster.AddNodePool(ctx, clusterName, pool, mgmtNAD, tenantSubnetNAD, vmNamespace, nodeImage); err != nil {
 		h.log.Error().Err(err).Str("cluster", clusterName).Str("pool", pool.Name).Msg("AddNodePool failed")
 		// Fetch fresh pool row to avoid stale update.
 		if p, gErr := h.repo.GetNodePool(ctx, clusterID, pool.Name); gErr == nil {
@@ -1061,6 +1125,7 @@ func (h *ClusterHandler) asyncAddPool(
 
 // asyncPatchPool applies scale / taint / label changes to Rancher.
 func (h *ClusterHandler) asyncPatchPool(
+	cluster providers.ClusterProvider,
 	clusterName string,
 	pool *models.NodePool,
 	doScale bool, newCount int,
@@ -1070,7 +1135,7 @@ func (h *ClusterHandler) asyncPatchPool(
 	defer cancel()
 
 	if doScale {
-		if err := h.provider.ScaleNodePool(ctx, clusterName, pool.Name, newCount); err != nil {
+		if err := cluster.ScaleNodePool(ctx, clusterName, pool.Name, newCount); err != nil {
 			h.log.Error().Err(err).Str("cluster", clusterName).Str("pool", pool.Name).Msg("ScaleNodePool failed")
 			if p, gErr := h.repo.GetNodePool(ctx, pool.ClusterID, pool.Name); gErr == nil {
 				p.Status = models.NodePoolStatusFailed
@@ -1081,7 +1146,7 @@ func (h *ClusterHandler) asyncPatchPool(
 		}
 	}
 	if doTL {
-		if err := h.provider.UpdateNodePoolTaintsLabels(ctx, clusterName, pool.Name, taints, labels); err != nil {
+		if err := cluster.UpdateNodePoolTaintsLabels(ctx, clusterName, pool.Name, taints, labels); err != nil {
 			h.log.Error().Err(err).Str("cluster", clusterName).Str("pool", pool.Name).Msg("UpdateNodePoolTaintsLabels failed")
 			if p, gErr := h.repo.GetNodePool(ctx, pool.ClusterID, pool.Name); gErr == nil {
 				p.Status = models.NodePoolStatusFailed
@@ -1094,11 +1159,11 @@ func (h *ClusterHandler) asyncPatchPool(
 }
 
 // asyncRemovePool drains and removes the pool from Rancher, then deletes the DB row.
-func (h *ClusterHandler) asyncRemovePool(clusterID uuid.UUID, clusterName string, pool *models.NodePool) {
+func (h *ClusterHandler) asyncRemovePool(cluster providers.ClusterProvider, clusterID uuid.UUID, clusterName string, pool *models.NodePool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	if err := h.provider.RemoveNodePool(ctx, clusterName, pool.Name, pool.HarvesterConfigName); err != nil {
+	if err := cluster.RemoveNodePool(ctx, clusterName, pool.Name, pool.HarvesterConfigName); err != nil {
 		h.log.Error().Err(err).Str("cluster", clusterName).Str("pool", pool.Name).Msg("RemoveNodePool failed")
 		if p, gErr := h.repo.GetNodePool(ctx, clusterID, pool.Name); gErr == nil {
 			p.Status = models.NodePoolStatusFailed
@@ -1119,31 +1184,31 @@ func (h *ClusterHandler) asyncRemovePool(clusterID uuid.UUID, clusterName string
 // resolveCluster looks up a cluster resource by the {id} URL parameter, validates
 // it belongs to the caller's tenant, and returns its ID and name.
 // On failure it writes an appropriate error response and returns ok=false.
-func (h *ClusterHandler) resolveCluster(w http.ResponseWriter, r *http.Request, tenantUUID uuid.UUID) (clusterID uuid.UUID, clusterName string, ok bool) {
+func (h *ClusterHandler) resolveCluster(w http.ResponseWriter, r *http.Request, tenantUUID uuid.UUID) (clusterID uuid.UUID, clusterName string, res *models.Resource, ok bool) {
 	projectUUID, ok := middleware.ProjectUUIDFromContext(r.Context())
 	if !ok {
 		writeError(w, http.StatusInternalServerError, "no project UUID in context")
-		return uuid.Nil, "", false
+		return uuid.Nil, "", nil, false
 	}
 
 	rawID := chi.URLParam(r, "id")
 	id, err := uuid.Parse(rawID)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid cluster ID format")
-		return uuid.Nil, "", false
+		return uuid.Nil, "", nil, false
 	}
 
 	resource, err := h.repo.GetForProject(r.Context(), id, tenantUUID, projectUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "cluster not found")
-		return uuid.Nil, "", false
+		return uuid.Nil, "", nil, false
 	}
 	if resource.Type != models.ResourceTypeCluster {
 		writeError(w, http.StatusNotFound, "cluster not found")
-		return uuid.Nil, "", false
+		return uuid.Nil, "", nil, false
 	}
 
-	return id, resource.Name, true
+	return id, resource.Name, resource, true
 }
 
 // resolveClusterNetworkContext extracts the NAD names and VM namespace used

--- a/dc-api/internal/api/handlers/dns_zone.go
+++ b/dc-api/internal/api/handlers/dns_zone.go
@@ -31,14 +31,37 @@ import (
 
 // PrivateDnsZoneHandler handles all /v1/vnets/{vnet_id}/dns-zones endpoints.
 type PrivateDnsZoneHandler struct {
-	repo     *db.Repository
-	provider providers.NetworkProvider
-	log      zerolog.Logger
+	repo *db.Repository
+	// resolve maps the parent VNet's (region, zone) to its NetworkProvider. A
+	// private DNS zone is a VPC child (VpcDns CRD), so it inherits the VNet zone.
+	resolve       providers.Resolver
+	defaultRegion string
+	defaultZone   string
+	log           zerolog.Logger
 }
 
 // NewPrivateDnsZoneHandler creates a PrivateDnsZoneHandler with injected dependencies.
-func NewPrivateDnsZoneHandler(repo *db.Repository, provider providers.NetworkProvider, log zerolog.Logger) *PrivateDnsZoneHandler {
-	return &PrivateDnsZoneHandler{repo: repo, provider: provider, log: log}
+func NewPrivateDnsZoneHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *PrivateDnsZoneHandler {
+	return &PrivateDnsZoneHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+}
+
+// network resolves the NetworkProvider for the parent VNet's (region, zone).
+func (h *PrivateDnsZoneHandler) network(region, zone string) (providers.NetworkProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Network, nil
+}
+
+// networkForVNetID resolves the NetworkProvider for a zone's parent VNet by id.
+// Falls back to the local zone when the VNet can't be loaded.
+func (h *PrivateDnsZoneHandler) networkForVNetID(ctx context.Context, vnetID uuid.UUID) (providers.NetworkProvider, error) {
+	vnet, err := h.repo.GetVNetInternal(ctx, vnetID)
+	if err != nil {
+		return h.network(h.defaultRegion, h.defaultZone)
+	}
+	return h.network(vnet.Region, vnet.Zone)
 }
 
 // ── DTOs — DNS Zone ───────────────────────────────────────────────────────────
@@ -197,6 +220,14 @@ func (h *PrivateDnsZoneHandler) CreateZone(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Resolve the network provider for the parent VNet's zone.
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve dns-zone provider for zone")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+		return
+	}
+
 	projectID, projectUUID, _ := lookupProjectUUID(w, r)
 	zone := &models.PrivateDnsZone{
 		VNetID:       vnet.ID,
@@ -207,9 +238,9 @@ func (h *PrivateDnsZoneHandler) CreateZone(w http.ResponseWriter, r *http.Reques
 		ZoneName:     req.Name,
 		Description:  req.Description,
 		Status:       models.StatusPending,
-		ProviderType: h.provider.Name(),
+		ProviderType: network.Name(),
 	}
-	zone, err := h.repo.CreateDNSZone(r.Context(), zone)
+	zone, err = h.repo.CreateDNSZone(r.Context(), zone)
 	if err != nil {
 		h.log.Error().Err(err).Str("tenant", tenantID).Msg("create dns zone in DB")
 		if strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key") {
@@ -222,7 +253,7 @@ func (h *PrivateDnsZoneHandler) CreateZone(w http.ResponseWriter, r *http.Reques
 	}
 
 
-	go h.asyncProvisionZone(zone.ID, tenantID, userID, vnet.BackendUID, models.DnsZoneSpec{
+	go h.asyncProvisionZone(network, zone.ID, tenantID, userID, vnet.BackendUID, models.DnsZoneSpec{
 		ZoneName:    req.Name,
 		Description: req.Description,
 	})
@@ -330,6 +361,13 @@ func (h *PrivateDnsZoneHandler) DeleteZone(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil && zone.BackendUID != "" {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve dns-zone provider for delete")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone to delete the DNS zone: "+err.Error())
+		return
+	}
+
 	if err := h.repo.UpdateDNSZoneStatus(r.Context(), zoneID, models.StatusDeleting, "deletion requested", ""); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update DNS zone status")
 		return
@@ -342,7 +380,7 @@ func (h *PrivateDnsZoneHandler) DeleteZone(w http.ResponseWriter, r *http.Reques
 			_ = h.repo.DeleteDNSZone(ctx, zoneID)
 			return
 		}
-		if err := h.provider.DeletePrivateDnsZone(ctx, zone.BackendUID); err != nil {
+		if err := network.DeletePrivateDnsZone(ctx, zone.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", zone.BackendUID).Msg("kubeovn DeletePrivateDnsZone failed")
 			_ = h.repo.UpdateDNSZoneStatus(ctx, zoneID, models.StatusFailed, "deletion failed: "+err.Error(), "")
 			return
@@ -355,11 +393,11 @@ func (h *PrivateDnsZoneHandler) DeleteZone(w http.ResponseWriter, r *http.Reques
 
 // ── Zone Async Provisioner ────────────────────────────────────────────────────
 
-func (h *PrivateDnsZoneHandler) asyncProvisionZone(zoneID uuid.UUID, tenantID, userID, vnetUID string, spec models.DnsZoneSpec) {
+func (h *PrivateDnsZoneHandler) asyncProvisionZone(network providers.NetworkProvider, zoneID uuid.UUID, tenantID, userID, vnetUID string, spec models.DnsZoneSpec) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	providerRes, err := h.provider.CreatePrivateDnsZone(ctx, vnetUID, spec)
+	providerRes, err := network.CreatePrivateDnsZone(ctx, vnetUID, spec)
 	if err != nil {
 		h.log.Error().Err(err).Str("zone", spec.ZoneName).Msg("kubeovn CreatePrivateDnsZone failed")
 		_ = h.repo.UpdateDNSZoneStatus(ctx, zoneID, models.StatusFailed,
@@ -444,7 +482,13 @@ func (h *PrivateDnsZoneHandler) UpsertRecord(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Apply to KubeOVN ConfigMap (synchronous per §12).
-	if err := h.provider.UpsertDnsRecord(r.Context(), zone.BackendUID, *rec); err != nil {
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve dns provider for record upsert")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+		return
+	}
+	if err := network.UpsertDnsRecord(r.Context(), zone.BackendUID, *rec); err != nil {
 		h.log.Error().Err(err).Str("zone", zone.ZoneName).Msg("kubeovn UpsertDnsRecord failed")
 		// Record is in DB; KubeOVN update failed — log and surface error.
 		writeError(w, http.StatusInternalServerError, "record persisted but KubeOVN update failed: "+err.Error())
@@ -605,7 +649,13 @@ func (h *PrivateDnsZoneHandler) UpdateRecord(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := h.provider.UpsertDnsRecord(r.Context(), zone.BackendUID, *updated); err != nil {
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve dns provider for record update")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+		return
+	}
+	if err := network.UpsertDnsRecord(r.Context(), zone.BackendUID, *updated); err != nil {
 		h.log.Error().Err(err).Str("record", existing.Name).Msg("kubeovn UpsertDnsRecord (update) failed")
 		writeError(w, http.StatusInternalServerError, "record updated in DB but KubeOVN update failed: "+err.Error())
 		return
@@ -661,7 +711,13 @@ func (h *PrivateDnsZoneHandler) DeleteRecord(w http.ResponseWriter, r *http.Requ
 	}
 
 	if zone.BackendUID != "" {
-		if err := h.provider.DeleteDnsRecord(r.Context(), zone.BackendUID, recordID.String()); err != nil {
+		network, err := h.network(vnet.Region, vnet.Zone)
+		if err != nil {
+			h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve dns provider for record delete")
+			writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+			return
+		}
+		if err := network.DeleteDnsRecord(r.Context(), zone.BackendUID, recordID.String()); err != nil {
 			h.log.Error().Err(err).Str("record_id", recordID.String()).Msg("kubeovn DeleteDnsRecord failed")
 			writeError(w, http.StatusInternalServerError, "failed to delete record from KubeOVN: "+err.Error())
 			return

--- a/dc-api/internal/api/handlers/nsg.go
+++ b/dc-api/internal/api/handlers/nsg.go
@@ -20,6 +20,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,14 +39,48 @@ import (
 
 // NSGHandler handles all /v1/security-groups endpoints.
 type NSGHandler struct {
-	repo     *db.Repository
-	provider providers.NetworkProvider
-	log      zerolog.Logger
+	repo *db.Repository
+	// resolve maps a zone to its NetworkProvider. NSGs are project-scoped; their
+	// rules only land on a backend when attached to a subnet, so attach/detach
+	// resolve from the target subnet's parent VNet zone. Record-only ops resolve
+	// to the default (local) zone. In a single-zone deployment all of these are
+	// the same cache-hit set.
+	resolve       providers.Resolver
+	defaultRegion string
+	defaultZone   string
+	log           zerolog.Logger
 }
 
 // NewNSGHandler creates an NSGHandler with injected dependencies.
-func NewNSGHandler(repo *db.Repository, provider providers.NetworkProvider, log zerolog.Logger) *NSGHandler {
-	return &NSGHandler{repo: repo, provider: provider, log: log}
+func NewNSGHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *NSGHandler {
+	return &NSGHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+}
+
+// network resolves the NetworkProvider for (region, zone). Empty values resolve
+// to the local zone (cache hit).
+func (h *NSGHandler) network(region, zone string) (providers.NetworkProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Network, nil
+}
+
+// catalogNetwork resolves the NetworkProvider for the default (local) zone, used
+// by NSG record ops that have no subnet to inherit a zone from.
+func (h *NSGHandler) catalogNetwork() (providers.NetworkProvider, error) {
+	return h.network(h.defaultRegion, h.defaultZone)
+}
+
+// networkForSubnet resolves the NetworkProvider for a subnet's parent VNet zone.
+// NSG ACLs are written to the Subnet CRD, which lives in the subnet's zone. If
+// the parent VNet can't be loaded the resolution falls back to the local zone.
+func (h *NSGHandler) networkForSubnet(ctx context.Context, subnet *models.Subnet) (providers.NetworkProvider, error) {
+	vnet, err := h.repo.GetVNetInternal(ctx, subnet.VNetID)
+	if err != nil {
+		return h.catalogNetwork()
+	}
+	return h.network(vnet.Region, vnet.Zone)
 }
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
@@ -187,6 +222,16 @@ func (h *NSGHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	projectID, _ := middleware.ProjectFromContext(r.Context())
 
+	// NSGs are project-scoped (governed at project scope, not per resource zone);
+	// their backend ACLs are written to the subnet they attach to. The NSG record
+	// and its no-op pre-attach driver call resolve to the local/default zone.
+	network, err := h.catalogNetwork()
+	if err != nil {
+		h.log.Error().Err(err).Msg("resolve NSG provider")
+		writeError(w, http.StatusInternalServerError, "failed to resolve provider")
+		return
+	}
+
 	// Insert NSG row to get the UUID.
 	nsg := &models.NSG{
 		TenantID:     tenantID,
@@ -197,9 +242,9 @@ func (h *NSGHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Description:  req.Description,
 		Rules:        nsgRuleDTOsToModel(req.Rules),
 		Status:       models.StatusActive,
-		ProviderType: h.provider.Name(),
+		ProviderType: network.Name(),
 	}
-	nsg, err := h.repo.CreateNSG(r.Context(), nsg)
+	nsg, err = h.repo.CreateNSG(r.Context(), nsg)
 	if err != nil {
 		h.log.Error().Err(err).Str("tenant", tenantID).Msg("create NSG in DB")
 		if strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key") {
@@ -227,7 +272,7 @@ func (h *NSGHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Description: req.Description,
 		Rules:       nsgRuleDTOsToModel(req.Rules),
 	}
-	providerRes, err := h.provider.CreateNSG(r.Context(), tenantID, projectID, spec)
+	providerRes, err := network.CreateNSG(r.Context(), tenantID, projectID, spec)
 	if err != nil {
 		h.log.Error().Err(err).Str("nsg", req.Name).Msg("kubeovn CreateNSG failed")
 		// Roll back DB row on driver failure.
@@ -247,7 +292,7 @@ func (h *NSGHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// With no attachments, UpdateNSGRules is a no-op at data plane; call anyway
 	// so rules are available immediately when the first subnet attaches.
 	compositeUID := buildNSGBackendUID(nsg.ID, nil)
-	_ = h.provider.UpdateNSGRules(r.Context(), compositeUID, nsgRuleDTOsToModel(req.Rules))
+	_ = network.UpdateNSGRules(r.Context(), compositeUID, nsgRuleDTOsToModel(req.Rules))
 
 	rules, _ := h.repo.ListNSGRules(r.Context(), nsg.ID)
 	writeJSON(w, http.StatusCreated, nsgToResponse(nsg, rules, nil))
@@ -357,7 +402,13 @@ func (h *NSGHandler) UpdateRules(w http.ResponseWriter, r *http.Request) {
 	compositeUID := buildNSGBackendUID(id, subnetBUIDs)
 
 	// Push updated rules to KubeOVN (no-op if no subnets attached).
-	if err := h.provider.UpdateNSGRules(r.Context(), compositeUID, nsgRuleDTOsToModel(req.Rules)); err != nil {
+	network, err := h.catalogNetwork()
+	if err != nil {
+		h.log.Error().Err(err).Msg("resolve NSG provider for rule update")
+		writeError(w, http.StatusInternalServerError, "failed to resolve provider")
+		return
+	}
+	if err := network.UpdateNSGRules(r.Context(), compositeUID, nsgRuleDTOsToModel(req.Rules)); err != nil {
 		h.log.Error().Err(err).Str("nsg", nsg.Name).Msg("kubeovn UpdateNSGRules failed")
 		writeError(w, http.StatusInternalServerError, "rules persisted but KubeOVN update failed: "+err.Error())
 		return
@@ -414,7 +465,13 @@ func (h *NSGHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if nsg.BackendUID != "" {
-		if err := h.provider.DeleteNSG(r.Context(), nsg.BackendUID); err != nil {
+		network, err := h.catalogNetwork()
+		if err != nil {
+			h.log.Error().Err(err).Msg("resolve NSG provider for delete")
+			writeError(w, http.StatusInternalServerError, "failed to resolve provider")
+			return
+		}
+		if err := network.DeleteNSG(r.Context(), nsg.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", nsg.BackendUID).Msg("kubeovn DeleteNSG failed")
 			writeError(w, http.StatusInternalServerError, "failed to delete NSG from KubeOVN: "+err.Error())
 			return
@@ -487,8 +544,18 @@ func (h *NSGHandler) Attach(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the network provider for the subnet's zone (NSG ACLs are written to
+	// the Subnet CRD, which lives in the subnet's parent VNet zone). Falls back to
+	// the local zone when the parent VNet's zone can't be loaded.
+	network, err := h.networkForSubnet(r.Context(), subnet)
+	if err != nil {
+		h.log.Error().Err(err).Str("nsg", nsg.Name).Msg("resolve NSG provider for attach")
+		writeError(w, http.StatusBadGateway, "cannot reach the subnet's zone: "+err.Error())
+		return
+	}
+
 	// Call driver to write NSG ACLs to the Subnet CRD.
-	if err := h.provider.AttachNSGToSubnet(r.Context(), nsg.BackendUID, subnet.BackendUID); err != nil {
+	if err := network.AttachNSGToSubnet(r.Context(), nsg.BackendUID, subnet.BackendUID); err != nil {
 		h.log.Error().Err(err).Str("nsg", nsg.Name).Msg("kubeovn AttachNSGToSubnet failed")
 		writeError(w, http.StatusInternalServerError, "failed to attach NSG: "+err.Error())
 		return
@@ -525,7 +592,7 @@ func (h *NSGHandler) Attach(w http.ResponseWriter, r *http.Request) {
 	h.log.Info().Str("nsg", sgID.String()).Int("rules", len(rules)).Int("subnets", len(subnetBUIDs)).
 		Strs("subnet_buids", subnetBUIDs).Msg("attach: applying NSG rules to attached subnets")
 	compositeUID := buildNSGBackendUID(sgID, subnetBUIDs)
-	if err := h.provider.UpdateNSGRules(r.Context(), compositeUID, rules); err != nil {
+	if err := network.UpdateNSGRules(r.Context(), compositeUID, rules); err != nil {
 		h.log.Error().Err(err).Str("nsg", sgID.String()).Msg("attach: kubeovn UpdateNSGRules failed")
 	}
 
@@ -581,7 +648,13 @@ func (h *NSGHandler) Detach(w http.ResponseWriter, r *http.Request) {
 	if att.TargetType == "subnet" {
 		subnet, subErr := h.repo.GetSubnet(r.Context(), att.TargetID)
 		if subErr == nil && subnet != nil {
-			if err := h.provider.DetachNSGFromSubnet(r.Context(), nsg.BackendUID, subnet.BackendUID); err != nil {
+			network, nErr := h.networkForSubnet(r.Context(), subnet)
+			if nErr != nil {
+				h.log.Error().Err(nErr).Str("nsg", nsg.Name).Msg("resolve NSG provider for detach")
+				writeError(w, http.StatusBadGateway, "cannot reach the subnet's zone: "+nErr.Error())
+				return
+			}
+			if err := network.DetachNSGFromSubnet(r.Context(), nsg.BackendUID, subnet.BackendUID); err != nil {
 				h.log.Error().Err(err).Str("nsg", nsg.Name).Msg("kubeovn DetachNSGFromSubnet failed")
 				writeError(w, http.StatusInternalServerError, "failed to detach NSG: "+err.Error())
 				return

--- a/dc-api/internal/api/handlers/peering.go
+++ b/dc-api/internal/api/handlers/peering.go
@@ -36,14 +36,30 @@ import (
 
 // PeeringHandler handles all /v1/vnets/{vnet_id}/peerings endpoints.
 type PeeringHandler struct {
-	repo     *db.Repository
-	provider providers.NetworkProvider
-	log      zerolog.Logger
+	repo *db.Repository
+	// resolve maps a peering's local VNet (region, zone) to its NetworkProvider.
+	// A peering's staticRoutes are written to both VNets' Vpc CRDs; the routing
+	// keys off the local VNet (the one on whose behalf the op runs). Cross-zone
+	// peering is out of scope for now — both VNets are expected in the same zone.
+	resolve       providers.Resolver
+	defaultRegion string
+	defaultZone   string
+	log           zerolog.Logger
 }
 
 // NewPeeringHandler creates a PeeringHandler with injected dependencies.
-func NewPeeringHandler(repo *db.Repository, provider providers.NetworkProvider, log zerolog.Logger) *PeeringHandler {
-	return &PeeringHandler{repo: repo, provider: provider, log: log}
+func NewPeeringHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *PeeringHandler {
+	return &PeeringHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+}
+
+// network resolves the NetworkProvider for (region, zone). Empty values resolve
+// to the local zone (cache hit).
+func (h *PeeringHandler) network(region, zone string) (providers.NetworkProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Network, nil
 }
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
@@ -204,6 +220,15 @@ func (h *PeeringHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the network provider for the local VNet's zone before the PENDING
+	// row, so an unreachable zone fails clearly.
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve peering provider for zone")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+		return
+	}
+
 	// Insert PENDING row.
 	projectID, projectUUID, _ := lookupProjectUUID(w, r)
 	peering := &models.Peering{
@@ -216,7 +241,7 @@ func (h *PeeringHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Name:                  req.Name,
 		AllowForwardedTraffic: req.AllowForwardedTraffic,
 		Status:                models.StatusPending,
-		ProviderType:          h.provider.Name(),
+		ProviderType:          network.Name(),
 	}
 	peering, err = h.repo.CreatePeering(r.Context(), peering)
 	if err != nil {
@@ -249,7 +274,7 @@ func (h *PeeringHandler) Create(w http.ResponseWriter, r *http.Request) {
 		PeerAddressSpace:      peerVNet.AddressSpace,
 		TransitCIDR:           transitCIDR,
 	}
-	go h.asyncProvisionPeering(peering.ID, tenantID, userID, vnet.BackendUID, peerVNet.BackendUID, spec)
+	go h.asyncProvisionPeering(network, peering.ID, tenantID, userID, vnet.BackendUID, peerVNet.BackendUID, spec)
 
 	resp := peeringToResponse(peering)
 	w.Header().Set("Content-Type", "application/json")
@@ -398,6 +423,14 @@ func (h *PeeringHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		peerCIDRs = peerVNet.AddressSpace
 	}
 
+	// Resolve the network provider for the local VNet's zone before DELETING.
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil && peering.BackendUID != "" {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve peering provider for delete")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone to delete the peering: "+err.Error())
+		return
+	}
+
 	if err := h.repo.UpdatePeeringStatus(r.Context(), peeringID, models.StatusDeleting, "deletion requested", ""); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update peering status")
 		return
@@ -413,7 +446,7 @@ func (h *PeeringHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			_ = h.repo.DeletePeering(ctx, peeringID)
 			return
 		}
-		if err := h.provider.DeletePeering(ctx, peering.BackendUID, localCIDRs, peerCIDRs); err != nil {
+		if err := network.DeletePeering(ctx, peering.BackendUID, localCIDRs, peerCIDRs); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", peering.BackendUID).Msg("kubeovn DeletePeering failed")
 			_ = h.repo.UpdatePeeringStatus(ctx, peeringID, models.StatusFailed, "deletion failed: "+err.Error(), "")
 			return
@@ -434,13 +467,14 @@ func (h *PeeringHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // ── Async Provisioner ────────────────────────────────────────────────────────
 
 func (h *PeeringHandler) asyncProvisionPeering(
+	network providers.NetworkProvider,
 	peeringID uuid.UUID, tenantID, userID, vnetUID, peerVNetUID string,
 	spec models.PeeringSpec,
 ) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	providerRes, err := h.provider.CreatePeering(ctx, vnetUID, peerVNetUID, spec)
+	providerRes, err := network.CreatePeering(ctx, vnetUID, peerVNetUID, spec)
 	if err != nil {
 		h.log.Error().Err(err).Str("peering", spec.Name).Msg("kubeovn CreatePeering failed")
 		_ = h.repo.UpdatePeeringStatus(ctx, peeringID, models.StatusFailed,

--- a/dc-api/internal/api/handlers/route_table.go
+++ b/dc-api/internal/api/handlers/route_table.go
@@ -17,6 +17,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,14 +36,38 @@ import (
 
 // RouteTableHandler handles all /v1/vnets/{vnet_id}/route-tables endpoints.
 type RouteTableHandler struct {
-	repo     *db.Repository
-	provider providers.NetworkProvider
-	log      zerolog.Logger
+	repo *db.Repository
+	// resolve maps the parent VNet's (region, zone) to its NetworkProvider. Route
+	// tables edit the parent Vpc CRD's staticRoutes, so they inherit the VNet zone.
+	resolve       providers.Resolver
+	defaultRegion string
+	defaultZone   string
+	log           zerolog.Logger
 }
 
 // NewRouteTableHandler creates a RouteTableHandler with injected dependencies.
-func NewRouteTableHandler(repo *db.Repository, provider providers.NetworkProvider, log zerolog.Logger) *RouteTableHandler {
-	return &RouteTableHandler{repo: repo, provider: provider, log: log}
+func NewRouteTableHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *RouteTableHandler {
+	return &RouteTableHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+}
+
+// network resolves the NetworkProvider for the parent VNet's (region, zone).
+func (h *RouteTableHandler) network(region, zone string) (providers.NetworkProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Network, nil
+}
+
+// networkForVNetID resolves the NetworkProvider for a route table's parent VNet
+// by VNet UUID, used by handlers that only carry the VNet id. Falls back to the
+// local zone when the VNet can't be loaded.
+func (h *RouteTableHandler) networkForVNetID(ctx context.Context, vnetID uuid.UUID) (providers.NetworkProvider, error) {
+	vnet, err := h.repo.GetVNetInternal(ctx, vnetID)
+	if err != nil {
+		return h.network(h.defaultRegion, h.defaultZone)
+	}
+	return h.network(vnet.Region, vnet.Zone)
 }
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
@@ -184,6 +209,14 @@ func (h *RouteTableHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Resolve the network provider for the parent VNet's zone.
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve route-table provider for zone")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+		return
+	}
+
 	// Insert DB row — this gives us the UUID for the composite backendUID.
 	projectID, projectUUID, _ := lookupProjectUUID(w, r)
 	rt := &models.RouteTable{
@@ -196,7 +229,7 @@ func (h *RouteTableHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Description:  req.Description,
 		Routes:       dtosToRouteRules(req.Routes),
 		Status:       models.StatusActive,
-		ProviderType: h.provider.Name(),
+		ProviderType: network.Name(),
 	}
 	rt, err = h.repo.CreateRouteTable(r.Context(), rt)
 	if err != nil {
@@ -216,7 +249,7 @@ func (h *RouteTableHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Description: req.Description,
 		Routes:      dtosToRouteRules(req.Routes),
 	}
-	providerRes, err := h.provider.CreateRouteTable(r.Context(), vnet.BackendUID, rtSpec)
+	providerRes, err := network.CreateRouteTable(r.Context(), vnet.BackendUID, rtSpec)
 	if err != nil {
 		h.log.Error().Err(err).Str("route_table", req.Name).Msg("kubeovn CreateRouteTable failed")
 		_ = h.repo.DeleteRouteTable(r.Context(), rt.ID)
@@ -229,7 +262,7 @@ func (h *RouteTableHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	// Step 2: UpdateRouteTableRoutes to write the actual route entries.
 	if len(req.Routes) > 0 {
-		if err := h.provider.UpdateRouteTableRoutes(r.Context(), compositeUID, dtosToRouteRules(req.Routes)); err != nil {
+		if err := network.UpdateRouteTableRoutes(r.Context(), compositeUID, dtosToRouteRules(req.Routes)); err != nil {
 			h.log.Error().Err(err).Str("route_table", req.Name).Msg("kubeovn UpdateRouteTableRoutes failed")
 			// Persist the RT but mark failed so the operator can retry.
 			_ = h.repo.UpdateRouteTableRoutes(r.Context(), rt.ID, []models.RouteRule{}, "")
@@ -380,7 +413,13 @@ func (h *RouteTableHandler) UpdateRoutes(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Call driver to update routes on the VPC CRD.
-	if err := h.provider.UpdateRouteTableRoutes(r.Context(), rt.BackendUID, dtosToRouteRules(req.Routes)); err != nil {
+	network, err := h.networkForVNetID(r.Context(), vnetID)
+	if err != nil {
+		h.log.Error().Err(err).Str("rt_id", rtID.String()).Msg("resolve route-table provider for update")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+		return
+	}
+	if err := network.UpdateRouteTableRoutes(r.Context(), rt.BackendUID, dtosToRouteRules(req.Routes)); err != nil {
 		h.log.Error().Err(err).Str("rt_id", rtID.String()).Msg("kubeovn UpdateRouteTableRoutes failed")
 		writeError(w, http.StatusInternalServerError, "failed to update routes: "+err.Error())
 		return
@@ -441,7 +480,13 @@ func (h *RouteTableHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if rt.BackendUID != "" {
-		if err := h.provider.DeleteRouteTable(r.Context(), rt.BackendUID); err != nil {
+		network, err := h.networkForVNetID(r.Context(), vnetID)
+		if err != nil {
+			h.log.Error().Err(err).Str("rt_id", rtID.String()).Msg("resolve route-table provider for delete")
+			writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+			return
+		}
+		if err := network.DeleteRouteTable(r.Context(), rt.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", rt.BackendUID).Msg("kubeovn DeleteRouteTable failed")
 			writeError(w, http.StatusInternalServerError, "failed to remove routes from KubeOVN: "+err.Error())
 			return
@@ -521,7 +566,9 @@ func (h *RouteTableHandler) Associate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call driver for informational association (no-op in M2 at the data plane).
-	_ = h.provider.AssociateRouteTable(r.Context(), rt.BackendUID, subnet.BackendUID)
+	if network, nErr := h.networkForVNetID(r.Context(), vnetID); nErr == nil {
+		_ = network.AssociateRouteTable(r.Context(), rt.BackendUID, subnet.BackendUID)
+	}
 
 	assoc, err := h.repo.CreateRouteTableAssociation(r.Context(), &db.RouteTableAssociation{
 		RouteTableID: rtID,
@@ -602,7 +649,9 @@ func (h *RouteTableHandler) Disassociate(w http.ResponseWriter, r *http.Request)
 
 	subnet, _ := h.repo.GetSubnet(r.Context(), assoc.SubnetID)
 	if subnet != nil {
-		_ = h.provider.DisassociateRouteTable(r.Context(), rt.BackendUID, subnet.BackendUID)
+		if network, nErr := h.networkForVNetID(r.Context(), vnetID); nErr == nil {
+			_ = network.DisassociateRouteTable(r.Context(), rt.BackendUID, subnet.BackendUID)
+		}
 	}
 
 	if err := h.repo.DeleteRouteTableAssociation(r.Context(), assocID); err != nil {

--- a/dc-api/internal/api/handlers/subnet.go
+++ b/dc-api/internal/api/handlers/subnet.go
@@ -27,17 +27,47 @@ import (
 
 // SubnetHandler handles all /v1/vnets/{vnet_id}/subnets endpoints.
 type SubnetHandler struct {
-	repo     *db.Repository
-	provider providers.NetworkProvider
-	nat      providers.VPCNATProvisioner  // nil = F15 disabled (no SNAT provisioning)
-	dns      providers.VPCDNSProvisioner  // nil = F20 disabled (no per-VPC DNS)
-	log      zerolog.Logger
+	repo *db.Repository
+	// resolve maps the parent VNet's (region, zone) to its NetworkProvider. A
+	// subnet inherits its parent VNet's zone (it is a VPC child).
+	resolve       providers.Resolver
+	defaultRegion string
+	defaultZone   string
+	// nat/dns are the LOCAL-zone VPC NAT/CoreDNS provisioners. Local-only (no
+	// agent path yet): the handler only runs them for a subnet whose parent VNet
+	// is in the local zone. nil = disabled (tests).
+	nat providers.VPCNATProvisioner // nil = F15 disabled (no SNAT provisioning)
+	dns providers.VPCDNSProvisioner // nil = F20 disabled (no per-VPC DNS)
+	log zerolog.Logger
 }
 
 // NewSubnetHandler creates a SubnetHandler with injected dependencies.
 // nat and dns may be nil — when nil, the respective provisioning steps are skipped.
-func NewSubnetHandler(repo *db.Repository, provider providers.NetworkProvider, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, log zerolog.Logger) *SubnetHandler {
-	return &SubnetHandler{repo: repo, provider: provider, nat: nat, dns: dns, log: log}
+func NewSubnetHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, log zerolog.Logger) *SubnetHandler {
+	return &SubnetHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, nat: nat, dns: dns, log: log}
+}
+
+// network resolves the NetworkProvider for a subnet's parent VNet (region, zone).
+func (h *SubnetHandler) network(region, zone string) (providers.NetworkProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Network, nil
+}
+
+// isLocalZone reports whether the parent VNet's (region, zone) is the local zone
+// (where the NAT/DNS provisioners apply). Empty values default to local.
+func (h *SubnetHandler) isLocalZone(region, zone string) bool {
+	r := region
+	if r == "" {
+		r = h.defaultRegion
+	}
+	z := zone
+	if z == "" {
+		z = h.defaultZone
+	}
+	return r == h.defaultRegion && z == h.defaultZone
 }
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
@@ -202,6 +232,15 @@ func (h *SubnetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the network provider for the parent VNet's zone (inherited by the
+	// subnet) before the PENDING row, so an unreachable zone fails clearly.
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve subnet provider for zone")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone: "+err.Error())
+		return
+	}
+
 	subnet := &models.Subnet{
 		VNetID:       vnetID,
 		TenantID:     tenantID,
@@ -213,7 +252,7 @@ func (h *SubnetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Gateway:      gw,
 		Description:  req.Description,
 		Status:       models.StatusPending,
-		ProviderType: h.provider.Name(),
+		ProviderType: network.Name(),
 	}
 	subnet, err = h.repo.CreateSubnet(r.Context(), subnet)
 	if err != nil {
@@ -232,8 +271,10 @@ func (h *SubnetHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 
-	// Async: call KubeOVN CreateSubnet.
-	go h.asyncProvisionSubnet(subnet.ID, vnet.ID, tenantID, projectID, userID, vnet.BackendUID, models.SubnetSpec{
+	// Async: call KubeOVN CreateSubnet. The NAT/DNS provisioning inside the
+	// goroutine is local-only; tell it whether the parent VNet is in the local
+	// zone so a remote-zone subnet skips the local NAT/DNS plumbing.
+	go h.asyncProvisionSubnet(network, h.isLocalZone(vnet.Region, vnet.Zone), subnet.ID, vnet.ID, tenantID, projectID, userID, vnet.BackendUID, models.SubnetSpec{
 		Name:        req.Name,
 		CIDR:        req.CIDR,
 		Gateway:     gw,
@@ -386,6 +427,15 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the network provider for the parent VNet's zone before DELETING.
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil && subnet.BackendUID != "" {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve subnet provider for delete")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone to delete the subnet: "+err.Error())
+		return
+	}
+	localZone := h.isLocalZone(vnet.Region, vnet.Zone)
+
 	if err := h.repo.UpdateSubnetStatus(r.Context(), subnetID, models.StatusDeleting, "deletion requested", ""); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update subnet status")
 		return
@@ -410,7 +460,7 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			h.log.Warn().Err(err).Str("subnet", subnetID.String()).
 				Msg("subnet-delete: CountActiveSubnetsForVNet failed; skipping per-VPC infra teardown")
-		} else if otherActive == 0 {
+		} else if otherActive == 0 && localZone {
 			// Last active subnet — release per-VPC infra that pins LSPs to this subnet.
 			// After each Delete call we poll until the pod is actually gone, because
 			// KubeOVN sets a deletion finalizer on the logical switch and refuses to
@@ -454,7 +504,7 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		if err := h.provider.DeleteSubnet(ctx, subnet.BackendUID); err != nil {
+		if err := network.DeleteSubnet(ctx, subnet.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", subnet.BackendUID).Msg("kubeovn DeleteSubnet failed")
 			_ = h.repo.UpdateSubnetStatus(ctx, subnetID, models.StatusFailed, "deletion failed: "+err.Error(), "")
 			return
@@ -467,11 +517,11 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // ── Async Provisioner ────────────────────────────────────────────────────────
 
-func (h *SubnetHandler) asyncProvisionSubnet(subnetID, vnetID uuid.UUID, tenantID, projectID, userID, vnetUID string, spec models.SubnetSpec) {
+func (h *SubnetHandler) asyncProvisionSubnet(network providers.NetworkProvider, localZone bool, subnetID, vnetID uuid.UUID, tenantID, projectID, userID, vnetUID string, spec models.SubnetSpec) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	providerRes, err := h.provider.CreateSubnet(ctx, vnetUID, spec)
+	providerRes, err := network.CreateSubnet(ctx, vnetUID, spec)
 	if err != nil {
 		h.log.Error().Err(err).Str("subnet", spec.Name).Msg("kubeovn CreateSubnet failed")
 		_ = h.repo.UpdateSubnetStatus(ctx, subnetID, models.StatusFailed,
@@ -481,6 +531,14 @@ func (h *SubnetHandler) asyncProvisionSubnet(subnetID, vnetID uuid.UUID, tenantI
 
 	_ = h.repo.UpdateSubnetStatus(ctx, subnetID, models.StatusActive,
 		"subnet provisioned", providerRes.BackendUID)
+
+	// The per-VPC NAT (F15) and CoreDNS (F20) plumbing is local-only — it runs
+	// against the local kubeconfig and has no agent path yet. A remote-zone subnet
+	// gets its CRD lifecycle through the agent but skips this local-only plumbing
+	// (documented constraint; remote NAT/DNS is future work).
+	if !localZone {
+		return
+	}
 
 	// ── F15: provision per-VPC SNAT if this is the first subnet on the VPC ────
 	// SNAT operates at the VPC router boundary — opaque to any cluster CNI a

--- a/dc-api/internal/api/handlers/vm.go
+++ b/dc-api/internal/api/handlers/vm.go
@@ -49,8 +49,18 @@ import (
 
 // VMHandler handles all /v1/virtual-machines endpoints.
 type VMHandler struct {
-	repo            *db.Repository
-	provider        providers.ComputeProvider
+	repo *db.Repository
+	// resolve maps a resource's (region, zone) to that zone's ComputeProvider.
+	// Per-resource ops (create/delete/provision) resolve from the resource's own
+	// zone; zone-agnostic catalog ops (images/networks) resolve to the default
+	// (local) zone. In a single-zone deployment every lookup is a cache hit on the
+	// same local set, byte-identical to the fixed provider injected before this.
+	resolve providers.Resolver
+	// defaultRegion/defaultZone are the home zone stamped onto a new root resource
+	// that does not specify one, and the zone catalog/image/network lookups default
+	// to. They are NOT the routing key — routing keys off the resource's own zone.
+	defaultRegion   string
+	defaultZone     string
 	dnsSearchDomain string // from DCAPI_VPC_DNS_SEARCH_DOMAIN; empty = no extra search domain
 	// reservedNADs is the set of `namespace/nad-name` references that tenant
 	// VMs MUST NOT attach to via the legacy `network_name` path. F21 — these
@@ -65,18 +75,40 @@ type VMHandler struct {
 // reservedNADs blocks tenant VM creates on infra-claimed bridges (F21).
 func NewVMHandler(
 	repo *db.Repository,
-	provider providers.ComputeProvider,
+	resolve providers.Resolver,
+	defaultRegion, defaultZone string,
 	dnsSearchDomain string,
 	reservedNADs map[string]bool,
 	log zerolog.Logger,
 ) *VMHandler {
 	return &VMHandler{
 		repo:            repo,
-		provider:        provider,
+		resolve:         resolve,
+		defaultRegion:   defaultRegion,
+		defaultZone:     defaultZone,
 		dnsSearchDomain: dnsSearchDomain,
 		reservedNADs:    reservedNADs,
 		log:             log,
 	}
+}
+
+// compute resolves the ComputeProvider for a resource's (region, zone). An empty
+// region/zone resolves to the local zone inside the Resolver. The error is the
+// clear "unknown zone" / "no agent for zone" message from the Registry; callers
+// surface it as a 5xx (sync paths) or fail the async provision cleanly.
+func (h *VMHandler) compute(region, zone string) (providers.ComputeProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Compute, nil
+}
+
+// catalogCompute resolves the ComputeProvider for the default (local) zone, used
+// by the zone-agnostic catalog endpoints (images/networks). Harvester images are
+// a local catalog; there is no per-resource zone for these reads.
+func (h *VMHandler) catalogCompute() (providers.ComputeProvider, error) {
+	return h.compute(h.defaultRegion, h.defaultZone)
 }
 
 // ─────────────────────────── Request / Response DTOs ────────────────────────
@@ -285,7 +317,7 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// queries the DB directly (single-responsibility principle).
 	var vnetBackendUID, subnetBackendUID string
 	var vnetUUIDPtr, subnetUUIDPtr *uuid.UUID // F41: persisted on the Resource row when VPC path is used
-	var vmZone string                         // phase-0 zone: inherited from the parent VNet on the VPC path
+	var vmRegion, vmZone string               // phase-0 region/zone: inherited from the parent VNet on the VPC path
 	if req.VNetID != "" {
 		vnetUUID, _ := uuid.Parse(req.VNetID)    // already validated above
 		subnetUUID, _ := uuid.Parse(req.SubnetID) // already validated above
@@ -322,7 +354,7 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 		// through the table-driven helper (placement.VM is a Child of VNET). The
 		// subnet was already verified to belong to this VNet (single-parent
 		// containment above), so there is no independent zone to mismatch.
-		_, vmZone = inheritPlacement(placement.VM, vnet.Region, vnet.Zone, true)
+		vmRegion, vmZone = inheritPlacement(placement.VM, vnet.Region, vnet.Zone, true)
 	}
 
 	// ── Step 4a: read VPC DNS server IP (F20) ────────────────────────────────
@@ -339,7 +371,20 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// ── Step 4b: create PENDING resource in PostgreSQL ────────────────────────
+	// ── Step 4b: resolve the VM's compute provider for ITS zone ───────────────
+	// Resolve BEFORE writing the PENDING row so an unknown zone, or a remote zone
+	// with no connected agent, fails with a clear error rather than stranding a
+	// PENDING row the reconciler would churn on. On the legacy bridge path the
+	// region/zone are empty → the Resolver maps them to the local zone (cache
+	// hit), byte-identical to today.
+	compute, err := h.compute(vmRegion, vmZone)
+	if err != nil {
+		h.log.Error().Err(err).Str("region", vmRegion).Str("zone", vmZone).Msg("resolve VM provider for zone")
+		writeError(w, http.StatusBadRequest, "cannot place VM in the requested zone: "+err.Error())
+		return
+	}
+
+	// ── Step 4c: create PENDING resource in PostgreSQL ────────────────────────
 	// We write the record BEFORE calling Harvester. This means:
 	//   a. The resource is immediately visible to GET requests (status: PENDING).
 	//   b. If DC-API crashes mid-provisioning, the orphan record is detectable.
@@ -354,10 +399,11 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Type:         models.ResourceTypeVM,
 		Size:         req.Size,
 		Status:       models.StatusPending,
-		ProviderType: h.provider.Name(),
+		ProviderType: compute.Name(),
 		VNetID:       vnetUUIDPtr,
 		SubnetID:     subnetUUIDPtr,
-		Zone:         vmZone, // empty on the legacy bridge path → Create falls back to zoneStamp()
+		Region:       vmRegion, // empty on the legacy bridge path → Create falls back to the local region
+		Zone:         vmZone,   // empty on the legacy bridge path → Create falls back to zoneStamp()
 	})
 	if err != nil {
 		h.log.Error().Err(err).Str("tenant", tenantID).Msg("create resource in DB")
@@ -390,7 +436,7 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 		DNSServerIP:      dnsSrvIP,
 		DNSSearchDomain:  h.dnsSearchDomain,
 	}
-	go h.asyncProvision(resource.ID, tenantID, projectID, userID, spec)
+	go h.asyncProvision(compute, resource.ID, tenantID, projectID, userID, spec)
 
 	// ── Step 6: return 202 Accepted ───────────────────────────────────────────
 	// Credentials are returned ONCE here — never stored server-side.
@@ -493,6 +539,17 @@ func (h *VMHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the provider for the VM's OWN zone. An empty zone (legacy bridge
+	// rows) maps to the local zone (cache hit). Resolve before marking DELETING
+	// so an unknown / unreachable zone surfaces clearly instead of stranding the
+	// row. The empty-BackendUID short-circuit below never needs a provider.
+	compute, err := h.compute(resource.Region, resource.Zone)
+	if err != nil && resource.BackendUID != "" {
+		h.log.Error().Err(err).Str("zone", resource.Zone).Msg("resolve VM provider for delete")
+		writeError(w, http.StatusBadGateway, "cannot reach the VM's zone to delete it: "+err.Error())
+		return
+	}
+
 	// Mark as DELETING in DB — visible to pollers immediately.
 	if err := h.repo.UpdateStatus(r.Context(), id, models.StatusDeleting, "deletion requested", ""); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update resource status")
@@ -512,7 +569,7 @@ func (h *VMHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := h.provider.DeleteVM(ctx, resource.BackendUID); err != nil {
+		if err := compute.DeleteVM(ctx, resource.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", resource.BackendUID).Msg("harvester delete VM failed")
 			_ = h.repo.UpdateStatus(ctx, id, models.StatusFailed, "deletion failed: "+err.Error(), "")
 		}
@@ -527,13 +584,13 @@ func (h *VMHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // asyncProvision calls Harvester to create the VM and updates the DB on completion.
 // This runs in a goroutine so the HTTP handler returns 202 immediately.
-func (h *VMHandler) asyncProvision(resourceID uuid.UUID, tenantID, projectID, userID string, spec models.VMSpec) {
+func (h *VMHandler) asyncProvision(compute providers.ComputeProvider, resourceID uuid.UUID, tenantID, projectID, userID string, spec models.VMSpec) {
 	// Use a background context — the HTTP request context is cancelled when the
 	// response is sent, but provisioning continues for minutes.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	providerResource, err := h.provider.CreateVM(ctx, tenantID, projectID, spec)
+	providerResource, err := compute.CreateVM(ctx, tenantID, projectID, spec)
 	if err != nil {
 		h.log.Error().Err(err).Str("vm", spec.Name).Msg("harvester CreateVM failed")
 		_ = h.repo.UpdateStatus(ctx, resourceID, models.StatusFailed,
@@ -594,7 +651,13 @@ func generateSSHKeyPair() (string, string, error) {
 
 // ListNetworks handles GET /v1/networks.
 func (h *VMHandler) ListNetworks(w http.ResponseWriter, r *http.Request) {
-	networks, err := h.provider.ListNetworks(r.Context())
+	compute, err := h.catalogCompute()
+	if err != nil {
+		h.log.Error().Err(err).Msg("resolve catalog provider for networks")
+		writeError(w, http.StatusInternalServerError, "failed to resolve provider")
+		return
+	}
+	networks, err := compute.ListNetworks(r.Context())
 	if err != nil {
 		h.log.Error().Err(err).Msg("list networks")
 		writeError(w, http.StatusInternalServerError, "failed to list networks")
@@ -605,7 +668,13 @@ func (h *VMHandler) ListNetworks(w http.ResponseWriter, r *http.Request) {
 
 // ListImages handles GET /v1/images.
 func (h *VMHandler) ListImages(w http.ResponseWriter, r *http.Request) {
-	images, err := h.provider.ListImages(r.Context())
+	compute, err := h.catalogCompute()
+	if err != nil {
+		h.log.Error().Err(err).Msg("resolve catalog provider for images")
+		writeError(w, http.StatusInternalServerError, "failed to resolve provider")
+		return
+	}
+	images, err := compute.ListImages(r.Context())
 	if err != nil {
 		h.log.Error().Err(err).Msg("list images")
 		writeError(w, http.StatusInternalServerError, "failed to list images")
@@ -633,7 +702,13 @@ func (h *VMHandler) CreateImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	image, err := h.provider.CreateImage(r.Context(), req.DisplayName, req.URL)
+	compute, err := h.catalogCompute()
+	if err != nil {
+		h.log.Error().Err(err).Msg("resolve catalog provider for image create")
+		writeError(w, http.StatusInternalServerError, "failed to resolve provider")
+		return
+	}
+	image, err := compute.CreateImage(r.Context(), req.DisplayName, req.URL)
 	if err != nil {
 		h.log.Error().Err(err).Str("name", req.DisplayName).Msg("create image")
 		writeError(w, http.StatusInternalServerError, "failed to create image: "+err.Error())

--- a/dc-api/internal/api/handlers/vnet.go
+++ b/dc-api/internal/api/handlers/vnet.go
@@ -33,17 +33,53 @@ import (
 
 // VNetHandler handles all /v1/vnets endpoints.
 type VNetHandler struct {
-	repo     *db.Repository
-	provider providers.NetworkProvider
-	nat      providers.VPCNATProvisioner // nil = SNAT disabled (e.g. in tests)
-	dns      providers.VPCDNSProvisioner // nil = F20 DNS disabled (e.g. in tests)
-	log      zerolog.Logger
+	repo *db.Repository
+	// resolve maps a VNet's (region, zone) to that zone's NetworkProvider. A VNet
+	// is a root network resource; its children (subnet/nsg/peering/dns) inherit
+	// its zone. In a single-zone deployment every lookup is a cache hit on the
+	// same local set.
+	resolve       providers.Resolver
+	defaultRegion string
+	defaultZone   string
+	// nat/dns are the LOCAL-zone VPC NAT/CoreDNS provisioners (kubeovn driver
+	// against the local kubeconfig). They have no agent path yet, so they are a
+	// documented local-only constraint: the handler only invokes them for a VNet
+	// in the local zone (see isLocalZone). nil = disabled (tests).
+	nat providers.VPCNATProvisioner // nil = SNAT disabled (e.g. in tests)
+	dns providers.VPCDNSProvisioner // nil = F20 DNS disabled (e.g. in tests)
+	log zerolog.Logger
 }
 
 // NewVNetHandler creates a VNetHandler with injected dependencies.
 // nat and dns may be nil — when nil, the respective provisioning is skipped.
-func NewVNetHandler(repo *db.Repository, provider providers.NetworkProvider, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, log zerolog.Logger) *VNetHandler {
-	return &VNetHandler{repo: repo, provider: provider, nat: nat, dns: dns, log: log}
+func NewVNetHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, log zerolog.Logger) *VNetHandler {
+	return &VNetHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, nat: nat, dns: dns, log: log}
+}
+
+// network resolves the NetworkProvider for a VNet's (region, zone). Empty
+// region/zone resolves to the local zone (cache hit).
+func (h *VNetHandler) network(region, zone string) (providers.NetworkProvider, error) {
+	set, err := h.resolve.For(region, zone)
+	if err != nil {
+		return nil, err
+	}
+	return set.Network, nil
+}
+
+// isLocalZone reports whether (region, zone) is the local zone (where dc-api
+// holds direct credentials and the local NAT/DNS provisioners apply). Empty
+// region/zone means "unspecified" → the local zone. The NAT/DNS plumbing has no
+// agent path yet, so it is only run for local-zone VNets.
+func (h *VNetHandler) isLocalZone(region, zone string) bool {
+	r := region
+	if r == "" {
+		r = h.defaultRegion
+	}
+	z := zone
+	if z == "" {
+		z = h.defaultZone
+	}
+	return r == h.defaultRegion && z == h.defaultZone
 }
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
@@ -182,6 +218,17 @@ func (h *VNetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the VNet's network provider for its (region, default zone) before
+	// the PENDING row. A VNet is a root resource created in the local/default zone
+	// (no zone selector in the API); req.Region defaults to the local region. An
+	// unknown region/zone fails clearly here instead of stranding a PENDING row.
+	network, err := h.network(req.Region, "")
+	if err != nil {
+		h.log.Error().Err(err).Str("region", req.Region).Msg("resolve VNet provider for region")
+		writeError(w, http.StatusBadRequest, "cannot place VNet in the requested region: "+err.Error())
+		return
+	}
+
 	// Insert PENDING row.
 	vnet := &models.VNet{
 		TenantID:     tenantID,
@@ -193,7 +240,7 @@ func (h *VNetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AddressSpace: req.AddressSpace,
 		Description:  req.Description,
 		Status:       models.StatusPending,
-		ProviderType: h.provider.Name(),
+		ProviderType: network.Name(),
 	}
 	vnet, err = h.repo.CreateVNet(r.Context(), vnet)
 	if err != nil {
@@ -207,7 +254,7 @@ func (h *VNetHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 
-	go h.asyncProvisionVNet(vnet.ID, tenantID, projectID, userID, models.VNetSpec{
+	go h.asyncProvisionVNet(network, vnet.ID, tenantID, projectID, userID, models.VNetSpec{
 		Name:         req.Name,
 		AddressSpace: req.AddressSpace,
 		Region:       req.Region,
@@ -351,6 +398,18 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the VNet's network provider for its OWN zone before marking
+	// DELETING, so an unknown / unreachable zone surfaces clearly.
+	network, err := h.network(vnet.Region, vnet.Zone)
+	if err != nil && vnet.BackendUID != "" {
+		h.log.Error().Err(err).Str("zone", vnet.Zone).Msg("resolve VNet provider for delete")
+		writeError(w, http.StatusBadGateway, "cannot reach the VNet's zone to delete it: "+err.Error())
+		return
+	}
+	// The NAT/DNS plumbing is local-only (no agent path). Only run it for a VNet
+	// in the local zone; a remote VNet never had local NAT/DNS to clean up.
+	localZone := h.isLocalZone(vnet.Region, vnet.Zone)
+
 	// Mark DELETING.
 	if err := h.repo.UpdateVNetStatus(r.Context(), id, models.StatusDeleting, "deletion requested", ""); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update VNet status")
@@ -370,8 +429,8 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		// Doing it after means the VPC controller may have already torn down
 		// dependent objects, leaving orphaned NAT resources or controller confusion.
 		// No external-IP release needed — KubeOVN owns the IP and frees it when
-		// IptablesEIP is deleted.
-		if h.nat != nil {
+		// IptablesEIP is deleted. Local-zone only (NAT plumbing has no agent path).
+		if h.nat != nil && localZone {
 			if natErr := h.nat.DeleteVpcNAT(ctx, vnet.BackendUID); natErr != nil {
 				h.log.Warn().Err(natErr).Str("vpc", vnet.BackendUID).Msg("kubeovn DeleteVpcNAT failed; proceeding with VPC delete anyway")
 			}
@@ -379,14 +438,14 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 		// F20: remove the per-VPC CoreDNS Deployment BEFORE deleting the VPC.
 		// The Multus secondary NIC is released when the pod terminates; no
-		// separate cleanup is needed for the IP pin.
-		if h.dns != nil {
+		// separate cleanup is needed for the IP pin. Local-zone only.
+		if h.dns != nil && localZone {
 			if dnsErr := h.dns.DeleteVpcDNS(ctx, vnet.BackendUID); dnsErr != nil {
 				h.log.Warn().Err(dnsErr).Str("vpc", vnet.BackendUID).Msg("kubeovn DeleteVpcDNS failed; proceeding with VPC delete anyway")
 			}
 		}
 
-		if err := h.provider.DeleteVNet(ctx, vnet.BackendUID); err != nil {
+		if err := network.DeleteVNet(ctx, vnet.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("backend_uid", vnet.BackendUID).Msg("kubeovn DeleteVNet failed")
 			_ = h.repo.UpdateVNetStatus(ctx, id, models.StatusFailed, "deletion failed: "+err.Error(), "")
 			return
@@ -399,7 +458,7 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // ── Async Provisioner ────────────────────────────────────────────────────────
 
-func (h *VNetHandler) asyncProvisionVNet(resourceID uuid.UUID, tenantID, projectID, userID string, spec models.VNetSpec) {
+func (h *VNetHandler) asyncProvisionVNet(network providers.NetworkProvider, resourceID uuid.UUID, tenantID, projectID, userID string, spec models.VNetSpec) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
@@ -410,7 +469,7 @@ func (h *VNetHandler) asyncProvisionVNet(resourceID uuid.UUID, tenantID, project
 	}
 
 	// ── 1. Create KubeOVN VPC ─────────────────────────────────────────────────
-	providerRes, err := h.provider.CreateVNet(ctx, tenantID, projectID, spec)
+	providerRes, err := network.CreateVNet(ctx, tenantID, projectID, spec)
 	if err != nil {
 		fail("kubeovn CreateVNet failed", err)
 		return

--- a/dc-api/internal/api/router.go
+++ b/dc-api/internal/api/router.go
@@ -37,7 +37,17 @@ import (
 // This is a form of Dependency Injection at the router level.
 // main.go constructs this struct and passes it to NewRouter.
 type RouterDeps struct {
-	Repo            *db.Repository
+	Repo *db.Repository
+	// Providers is the per-resource provider resolver (*providers.Registry).
+	// Handlers call Providers.For(region, zone) per resource so a resource in a
+	// remote zone reaches that zone's agent; in a single-zone / single-cluster
+	// deployment every resource resolves to the SAME local set (a cache hit),
+	// byte-identical to the fixed providers dc-api injected before this change.
+	Providers providers.Resolver
+	// ComputeProvider/ClusterProvider/NetworkProvider remain for router-only
+	// callers (contract harness, some tests) that build a router without a full
+	// Registry. When Providers is nil, NewRouter synthesises a fixed-set Resolver
+	// from these three so the single-cluster path keeps working unchanged.
 	ComputeProvider providers.ComputeProvider
 	ClusterProvider providers.ClusterProvider
 	NetworkProvider providers.NetworkProvider
@@ -125,6 +135,16 @@ type RouterDeps struct {
 // It wires all middleware, handlers, and routes.
 func NewRouter(deps RouterDeps) http.Handler {
 	r := chi.NewRouter()
+
+	// Per-resource provider resolver. main.go injects the *providers.Registry
+	// (the per-(region,zone) cache). Router-only callers (contract harness, some
+	// tests) build a router without a Registry and instead pass three fixed
+	// providers — for those, synthesise a single-zone FixedResolver so every
+	// resource resolves to the same set (the pre-routing single-cluster model).
+	resolve := deps.Providers
+	if resolve == nil {
+		resolve = providers.NewFixedResolver(deps.ComputeProvider, deps.ClusterProvider, deps.NetworkProvider)
+	}
 
 	// ── Global middleware (applied to ALL routes) ─────────────────────────────
 	r.Use(chimiddleware.RealIP)
@@ -228,9 +248,9 @@ func NewRouter(deps RouterDeps) http.Handler {
 		// Instantiate handlers with their dependencies.
 		// Dependency Injection: we pass repo and provider INTO the handler.
 		// The handler does not create these — it receives them.
-		vmHandler := handlers.NewVMHandler(deps.Repo, deps.ComputeProvider, deps.DNSSearchDomain, deps.InfraReservedNADs, deps.Log)
-		bastionHandler := handlers.NewBastionHandler(deps.Repo, deps.ComputeProvider, deps.BastionImage, deps.BastionMgmtNAD, deps.DNSSearchDomain, deps.Log)
-		clusterHandler := handlers.NewClusterHandler(deps.Repo, deps.ClusterProvider, deps.Log)
+		vmHandler := handlers.NewVMHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.DNSSearchDomain, deps.InfraReservedNADs, deps.Log)
+		bastionHandler := handlers.NewBastionHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.BastionImage, deps.BastionMgmtNAD, deps.DNSSearchDomain, deps.Log)
+		clusterHandler := handlers.NewClusterHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
 
 		// M1.5 member management handler. The directory provider (possibly nil)
 		// powers invite-by-email resolution.
@@ -252,12 +272,12 @@ func NewRouter(deps RouterDeps) http.Handler {
 		serviceAccountHandler := handlers.NewServiceAccountHandler(deps.Repo, deps.Log)
 
 		// M2 network handlers — all share the same NetworkProvider.
-		vnetHandler := handlers.NewVNetHandler(deps.Repo, deps.NetworkProvider, deps.NATProvisioner, deps.DNSProvisioner, deps.Log)
-		subnetHandler := handlers.NewSubnetHandler(deps.Repo, deps.NetworkProvider, deps.NATProvisioner, deps.DNSProvisioner, deps.Log)
-		rtHandler := handlers.NewRouteTableHandler(deps.Repo, deps.NetworkProvider, deps.Log)
-		nsgHandler := handlers.NewNSGHandler(deps.Repo, deps.NetworkProvider, deps.Log)
-		peeringHandler := handlers.NewPeeringHandler(deps.Repo, deps.NetworkProvider, deps.Log)
-		dnsHandler := handlers.NewPrivateDnsZoneHandler(deps.Repo, deps.NetworkProvider, deps.Log)
+		vnetHandler := handlers.NewVNetHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.NATProvisioner, deps.DNSProvisioner, deps.Log)
+		subnetHandler := handlers.NewSubnetHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.NATProvisioner, deps.DNSProvisioner, deps.Log)
+		rtHandler := handlers.NewRouteTableHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
+		nsgHandler := handlers.NewNSGHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
+		peeringHandler := handlers.NewPeeringHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
+		dnsHandler := handlers.NewPrivateDnsZoneHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
 
 		// Tenant list — used by cloud-ui's tenant switcher. Lives at the
 		// /v1/ level (not under /v1/tenants/{tenant_id}) because it's how

--- a/dc-api/internal/db/db.go
+++ b/dc-api/internal/db/db.go
@@ -706,7 +706,8 @@ func (r *Repository) GetQuota(ctx context.Context, tenantID string) (*models.Quo
 func (r *Repository) ListPending(ctx context.Context) ([]*models.Resource, error) {
 	const q = `
 		SELECT id, tenant_id, tenant_uuid, project_id, project_uuid, owner_id, name, type, size, status,
-		       provider_type, backend_uid, ip_address, mgmt_ip, vnet_id, subnet_id, message, created_at, updated_at
+		       provider_type, backend_uid, ip_address, mgmt_ip, vnet_id, subnet_id, message,
+		       region, zone, created_at, updated_at
 		FROM   resources
 		WHERE  backend_uid IS NOT NULL
 		AND    (
@@ -726,6 +727,7 @@ func (r *Repository) ListPending(ctx context.Context) ([]*models.Resource, error
 	for rows.Next() {
 		var res models.Resource
 		var size, backendUID, ipAddress, mgmtIP, message, projectID *string
+		var region, zone *string
 		var projectUUID *uuid.UUID
 		if err := rows.Scan(
 			&res.ID, &res.TenantID, &res.TenantUUID,
@@ -733,9 +735,18 @@ func (r *Repository) ListPending(ctx context.Context) ([]*models.Resource, error
 			&res.OwnerID, &res.Name,
 			&res.Type, &size, &res.Status,
 			&res.ProviderType, &backendUID, &ipAddress, &mgmtIP, &res.VNetID, &res.SubnetID, &message,
+			&region, &zone,
 			&res.CreatedAt, &res.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("db scan pending resource: %w", err)
+		}
+		// Region/Zone drive per-resource provider resolution in the reconciler.
+		// Nullable for pre-stamp rows (the resolver maps empty → the local zone).
+		if region != nil {
+			res.Region = *region
+		}
+		if zone != nil {
+			res.Zone = *zone
 		}
 		if projectID != nil {
 			res.ProjectID = *projectID

--- a/dc-api/internal/db/regions.go
+++ b/dc-api/internal/db/regions.go
@@ -110,6 +110,21 @@ func (r *Repository) ListRegionsWithZones(ctx context.Context) ([]RegionRow, err
 	return regions, nil
 }
 
+// IsKnownZone reports whether (region, zone) exists in the regions/zones
+// catalog. It backs providers.ZoneCatalog: the per-zone resolver consults it on
+// a build-on-miss to distinguish a registered REMOTE zone (build an agent-only
+// provider set) from an UNKNOWN zone (refuse — never fall back to the local
+// cluster). A lookup failure is returned as an error so the resolver fails
+// closed rather than treating an unreachable catalog as "known".
+func (r *Repository) IsKnownZone(ctx context.Context, region, zone string) (bool, error) {
+	const q = `SELECT EXISTS (SELECT 1 FROM zones WHERE region_name = $1 AND name = $2)`
+	var exists bool
+	if err := r.pool.QueryRow(ctx, q, region, zone).Scan(&exists); err != nil {
+		return false, fmt.Errorf("db is-known-zone %s/%s: %w", region, zone, err)
+	}
+	return exists, nil
+}
+
 // EnsureRegionZone records a region and its zone if they don't already exist,
 // so an admin minting the first token for a freshly bootstrapped cluster
 // implicitly registers it. This is metadata only — provisioning the underlying

--- a/dc-api/internal/providers/clusteraccess/nocreds.go
+++ b/dc-api/internal/providers/clusteraccess/nocreds.go
@@ -1,0 +1,63 @@
+package clusteraccess
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NoCreds is the Direct-fallback replacement used for a REMOTE zone, where
+// dc-api holds NO kubeconfig and therefore has no dynamic client to dial. It is
+// the second half of the no-silent-wrong-cluster guarantee: a Routed accessor
+// for a remote zone uses NoCreds as its `direct` fallback, so when the per-call
+// AgentDecision declines to route (toggle off, verb not in the allow-set, OR —
+// critically — no agent connected for the zone) the op fails with a CLEAR error
+// naming the zone instead of silently hitting the LOCAL cluster (which is the
+// wrong cluster for a remote-zone resource).
+//
+// Contrast with Direct (direct.go), whose fallback IS the local master
+// kubeconfig — correct for the LOCAL zone because dc-api genuinely holds those
+// credentials. NoCreds is correct for a remote zone because dc-api does not.
+type NoCreds struct {
+	region, zone string
+}
+
+// NewNoCreds builds a NoCreds accessor bound to the region/zone it guards, so
+// every error names the zone the caller tried to reach.
+func NewNoCreds(region, zone string) *NoCreds { return &NoCreds{region: region, zone: zone} }
+
+// Ensure NoCreds satisfies Accessor at compile time.
+var _ Accessor = (*NoCreds)(nil)
+
+func (n *NoCreds) err(verb string) error {
+	return fmt.Errorf(
+		"no agent connected for zone %s/%s: cannot %s — dc-api holds no direct credentials for a remote zone, so the operation cannot fall back to the local cluster; connect a dc-agent for this zone",
+		n.region, n.zone, verb)
+}
+
+func (n *NoCreds) Get(_ context.Context, _ schema.GroupVersionResource, _, _ string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	return nil, n.err("get")
+}
+
+func (n *NoCreds) List(_ context.Context, _ schema.GroupVersionResource, _ string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return nil, n.err("list")
+}
+
+func (n *NoCreds) Create(_ context.Context, _ schema.GroupVersionResource, _ string, _ *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	return nil, n.err("create")
+}
+
+func (n *NoCreds) Apply(_ context.Context, _ schema.GroupVersionResource, _ string, _ *unstructured.Unstructured, _ string, _ bool) (*unstructured.Unstructured, error) {
+	return nil, n.err("apply")
+}
+
+func (n *NoCreds) Update(_ context.Context, _ schema.GroupVersionResource, _ string, _ *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, n.err("update")
+}
+
+func (n *NoCreds) Delete(_ context.Context, _ schema.GroupVersionResource, _, _ string, _ metav1.DeleteOptions) error {
+	return n.err("delete")
+}

--- a/dc-api/internal/providers/harvester/client.go
+++ b/dc-api/internal/providers/harvester/client.go
@@ -102,6 +102,45 @@ type Client struct {
 	// c.dynamic directly — those GVRs are not in the agent's mapper/RBAC. The seam
 	// never leaks an agent concept past the ComputeProvider interface.
 	access clusteraccess.Accessor
+
+	// remoteRegion/remoteZone are non-empty ONLY for a credential-free REMOTE
+	// client built by NewRemoteClient (multi-zone routing). For such a client
+	// c.dynamic is nil: the seam ops (CreateVM/GetVM/DeleteVM via c.access) route
+	// to that zone's agent, but the direct-only ops (ListVMs, the VMI IP read,
+	// images, ListNetworks, the cloud-provider SA bootstrap) have no direct path
+	// and return a clear local-only error naming the zone instead of panicking on
+	// a nil dynamic client. Empty for the LOCAL client → today's behaviour.
+	remoteRegion, remoteZone string
+}
+
+// localOnlyErr is returned by a REMOTE client's direct-only methods (image
+// lookup/import, ListVMs, ListNetworks, the cloud-provider SA bootstrap). These
+// touch c.dynamic, which a remote client does not have. Failing here — BEFORE a
+// PENDING row or a provisioner call — is the documented local-only constraint
+// for the remote-zone build: routing the VM-object CRUD lifecycle is in scope;
+// routing image/SA bootstrap is future work behind this explicit error.
+func (c *Client) localOnlyErr(op string) error {
+	return fmt.Errorf(
+		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct Harvester credentials there (image lookup, ListVMs/Networks, and the cloud-provider SA bootstrap are local-only for now)",
+		op, c.remoteRegion, c.remoteZone)
+}
+
+// NewRemoteClient builds a credential-free Harvester client for a REMOTE zone.
+// It has NO kubeconfig and NO dynamic client; every VM-object op runs through
+// the supplied agent-only Accessor (a clusteraccess.Routed whose Direct fallback
+// is a clusteraccess.NoCreds, so a missing agent fails clearly rather than
+// hitting the local cluster). The direct-only methods return localOnlyErr.
+//
+// This is the second mandatory red-team gap: a remote provider cannot just stub
+// Direct — it must route the lifecycle through the agent while refusing the
+// direct-only ops. region/zone are carried only for clear error messages.
+func NewRemoteClient(access clusteraccess.Accessor, region, zone string) *Client {
+	return &Client{
+		// dynamic + restConfig deliberately nil — guarded by remoteZone.
+		access:       access,
+		remoteRegion: region,
+		remoteZone:   zone,
+	}
 }
 
 // NewClient creates a Harvester client from a base64-encoded kubeconfig string.
@@ -176,6 +215,13 @@ func (c *Client) Name() string { return "harvester" }
 // EnsureProjectNamespace). CreateVM does NOT create it — missing namespace
 // is a handler-layer bug, not a recoverable provider condition.
 func (c *Client) CreateVM(ctx context.Context, tenantID, projectID string, spec models.VMSpec) (*models.Resource, error) {
+	if c.dynamic == nil {
+		// REMOTE client: VM create needs the image template resolved against the
+		// zone's local VirtualMachineImage catalog (resolveImage → c.dynamic),
+		// which we don't have for a remote zone. Fail clearly BEFORE building the
+		// manifest so the handler surfaces a useful error rather than misrouting.
+		return nil, c.localOnlyErr("VM create")
+	}
 	ns := common.NamespaceForProject(tenantID, projectID)
 
 	// Resolve the image display name or ID to a "namespace/resource-name" string.
@@ -266,6 +312,18 @@ func (c *Client) GetVM(ctx context.Context, backendUID string) (*models.Resource
 	// For single-NIC VMs neither is named "ovn" or "mgmt" (it's "default" or
 	// the legacy single "ovn"), so fall back to the legacy "first IP" reader.
 	var ip, mgmtIP string
+	if c.dynamic == nil {
+		// REMOTE client: status came from the agent (c.access above); IP
+		// enrichment via the direct VMI read is local-only. Return the status
+		// without IPs rather than dereferencing a nil dynamic client.
+		return &models.Resource{
+			Type:         models.ResourceTypeVM,
+			ProviderType: c.Name(),
+			BackendUID:   backendUID,
+			Name:         name,
+			Status:       vmStatusFromUnstructured(obj),
+		}, nil
+	}
 	vmi, vmiErr := c.dynamic.
 		Resource(harvesterVMIResource).
 		Namespace(ns).
@@ -327,6 +385,9 @@ func (c *Client) DeleteVM(ctx context.Context, backendUID string) error {
 // ListVMs returns all VMs in the tenant+project namespace.
 // projectID is the human-readable project slug.
 func (c *Client) ListVMs(ctx context.Context, tenantID, projectID string) ([]*models.Resource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("ListVMs")
+	}
 	ns := common.NamespaceForProject(tenantID, projectID)
 	list, err := c.dynamic.
 		Resource(harvesterVMResource).
@@ -417,6 +478,9 @@ func (c *Client) HarvesterCACert() []byte { return c.restConfig.CAData }
 // the Secret's .data.token field). Polls up to 30 s for the token controller
 // to populate the Secret after creation.
 func (c *Client) EnsureCloudProviderSA(ctx context.Context, tenantNamespace string) ([]byte, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("cloud-provider ServiceAccount bootstrap")
+	}
 	saName := "harvester-cloud-provider-" + tenantNamespace
 
 	commonLabels := map[string]interface{}{
@@ -627,6 +691,9 @@ func vmIPByInterfaceName(obj *unstructured.Unstructured) (ovnIP, mgmtIP string) 
 // ListImages returns all VirtualMachineImages available in Harvester across all namespaces.
 // The Image.ID field ("namespace/resource-name") is what callers pass to CreateVM.
 func (c *Client) ListImages(ctx context.Context) ([]*models.Image, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("ListImages")
+	}
 	list, err := c.dynamic.Resource(vmImageGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("harvester list images: %w", err)
@@ -651,6 +718,9 @@ func (c *Client) ListImages(ctx context.Context) ([]*models.Image, error) {
 // Harvester stores a human-readable label in annotation "network.harvesterhci.io/route"
 // or falls back to the resource name.
 func (c *Client) ListNetworks(ctx context.Context) ([]*models.Network, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("ListNetworks")
+	}
 	list, err := c.dynamic.Resource(networkAttachmentGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("harvester list networks: %w", err)
@@ -675,6 +745,9 @@ func (c *Client) ListNetworks(ctx context.Context) ([]*models.Network, error) {
 // Harvester to download the image from the given URL into Longhorn storage.
 // The image is available for VM creation once its status transitions to "active".
 func (c *Client) CreateImage(ctx context.Context, displayName, downloadURL string) (*models.Image, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("CreateImage")
+	}
 	// Images are created in the "default" namespace in Harvester.
 	const imageNamespace = "default"
 

--- a/dc-api/internal/providers/kubeovn/client.go
+++ b/dc-api/internal/providers/kubeovn/client.go
@@ -153,6 +153,36 @@ type Client struct {
 	// dnsConf holds the F20 per-VPC DNS configuration injected via
 	// WithDNSConfig(). nil means F20 DNS is not configured.
 	dnsConf *DNSConfig
+
+	// remoteRegion/remoteZone are non-empty ONLY for a credential-free REMOTE
+	// client built by NewRemoteClient. For such a client c.dynamic is nil and the
+	// network CRD lifecycle is NOT yet routed through the agent (the network
+	// plumbing — NAD creation, ACL/route patches, NAT/CoreDNS — has no agent
+	// path), so every NetworkProvider method returns a clear local-only error
+	// naming the zone instead of dereferencing a nil dynamic client. Empty for the
+	// LOCAL client → today's behaviour. This is the documented boundary of the
+	// remote-zone build: VPC networking for a remote zone is deferred behind this
+	// explicit error rather than silently misrouting to the local cluster.
+	remoteRegion, remoteZone string
+}
+
+// localOnlyErr is returned by a REMOTE client's NetworkProvider methods. dc-api
+// holds no kubeconfig for a remote zone, and the kubeovn lifecycle still leans on
+// c.dynamic for the NAD/ACL/route/NAT/DNS plumbing that has no agent path. Per
+// the design, remote-zone VPC networking is deferred behind this clear error.
+func (c *Client) localOnlyErr(op string) error {
+	return fmt.Errorf(
+		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct KubeOVN credentials there and the VPC network plumbing (NAD/ACL/route/NAT/DNS) is local-only for now",
+		op, c.remoteRegion, c.remoteZone)
+}
+
+// NewRemoteClient builds a credential-free KubeOVN client for a REMOTE zone. It
+// has NO kubeconfig and NO dynamic client; every NetworkProvider method returns
+// localOnlyErr. region/zone are carried only for clear error messages. This
+// keeps the per-zone resolver uniform (every zone yields a *ProviderSet) while
+// remote-zone networking stays explicitly gated rather than misrouted.
+func NewRemoteClient(region, zone string) *Client {
+	return &Client{remoteRegion: region, remoteZone: zone}
 }
 
 // New creates a KubeOVN Client.
@@ -247,6 +277,9 @@ func (c *Client) RESTConfig() *rest.Config { return c.restConfig }
 // determines the Kubernetes namespace: "dc-<tenant>-<project>". The namespace
 // must already exist (created by the project handler via EnsureProjectNamespace).
 func (c *Client) CreateVNet(ctx context.Context, tenantID, projectID string, spec models.VNetSpec) (*models.VNetResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("CreateVNet")
+	}
 	ns := common.NamespaceForProject(tenantID, projectID)
 
 	vpc := &unstructured.Unstructured{
@@ -303,6 +336,9 @@ func (c *Client) CreateVNet(ctx context.Context, tenantID, projectID string, spe
 
 // GetVNet returns the current provider state of a VNet.
 func (c *Client) GetVNet(ctx context.Context, backendUID string) (*models.VNetResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("GetVNet")
+	}
 	// Cluster-scoped → ns="". Routes via the agent only under DCAPI_AGENT_ROUTE_READS
 	// + a live agent; otherwise the byte-identical Direct Get.
 	obj, err := c.access.Get(ctx, vpcGVR, "", backendUID, metav1.GetOptions{})
@@ -326,6 +362,9 @@ func (c *Client) GetVNet(ctx context.Context, backendUID string) (*models.VNetRe
 // delete child subnets before calling DeleteVNet.  This driver does NOT
 // force-remove finalizers.
 func (c *Client) DeleteVNet(ctx context.Context, backendUID string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DeleteVNet")
+	}
 	// Cluster-scoped → ns="". Routes via the agent only under DCAPI_AGENT_ROUTE_WRITES
 	// + a live agent; otherwise the byte-identical Direct Delete.
 	err := c.access.Delete(ctx, vpcGVR, "", backendUID, metav1.DeleteOptions{})
@@ -354,6 +393,9 @@ func (c *Client) DeleteVNet(ctx context.Context, backendUID string) error {
 //
 // vnetUID is the KubeOVN Vpc CRD name (the backendUID of the parent VNet row).
 func (c *Client) CreateSubnet(ctx context.Context, vnetUID string, spec models.SubnetSpec) (*models.SubnetResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("CreateSubnet")
+	}
 	// Derive tenant namespace from the Vpc name ("vnet-<name>-<tenantID>" → extract tenantID).
 	// The Vpc CRD holds a dc-api/tenant label — fetch it rather than parsing.
 	vpcObj, err := c.dynamic.Resource(vpcGVR).Get(ctx, vnetUID, metav1.GetOptions{})
@@ -483,6 +525,9 @@ func (c *Client) CreateSubnet(ctx context.Context, vnetUID string, spec models.S
 
 // GetSubnet returns the current provider state of a Subnet.
 func (c *Client) GetSubnet(ctx context.Context, backendUID string) (*models.SubnetResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("GetSubnet")
+	}
 	// Cluster-scoped → ns="". Routes via the agent under DCAPI_AGENT_ROUTE_READS
 	// + a live agent; otherwise the byte-identical Direct Get.
 	obj, err := c.access.Get(ctx, subnetGVR, "", backendUID, metav1.GetOptions{})
@@ -505,6 +550,9 @@ func (c *Client) GetSubnet(ctx context.Context, backendUID string) (*models.Subn
 // finalizer blocks deletion while consumers exist).  The caller ensures VMs
 // detach first; the driver patches ACLs to empty before issuing the delete.
 func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DeleteSubnet")
+	}
 	// First: fetch the subnet to find the tenant namespace (for the NAD).
 	// Cluster-scoped → ns="". This Get is the leading read of the delete lifecycle,
 	// so it routes with the same accessor as the Delete below (under the reads
@@ -748,6 +796,9 @@ func (c *Client) forceRemoveNADFinalizerIfStuck(ctx context.Context, ns, nadName
 //
 // This method is synchronous (no reconciler loop needed).
 func (c *Client) CreateRouteTable(ctx context.Context, vnetUID string, spec models.RouteTableSpec) (*models.RouteTableResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("CreateRouteTable")
+	}
 	if len(spec.Routes) == 0 {
 		// Nothing to write to the VPC — return immediately.
 		return &models.RouteTableResource{
@@ -789,6 +840,9 @@ func (c *Client) CreateRouteTable(ctx context.Context, vnetUID string, spec mode
 //  3. Append new entries tagged with <routeTableUUID>.
 //  4. JSON MergePatch the Vpc — never delete the CRD (gotcha 4).
 func (c *Client) UpdateRouteTableRoutes(ctx context.Context, backendUID string, routes []models.RouteRule) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("UpdateRouteTableRoutes")
+	}
 	vnetUID, rtUUID, err := parseRouteTableUID(backendUID)
 	if err != nil {
 		return fmt.Errorf("update route table routes: %w", err)
@@ -820,6 +874,9 @@ func (c *Client) UpdateRouteTableRoutes(ctx context.Context, backendUID string, 
 // backendUID format: "<vnetUID>/<routeTableUUID>" (same as UpdateRouteTableRoutes).
 // The Vpc CRD itself is NOT deleted.
 func (c *Client) DeleteRouteTable(ctx context.Context, backendUID string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DeleteRouteTable")
+	}
 	vnetUID, rtUUID, err := parseRouteTableUID(backendUID)
 	if err != nil {
 		return fmt.Errorf("delete route table: %w", err)
@@ -845,6 +902,9 @@ func (c *Client) DeleteRouteTable(ctx context.Context, backendUID string) error 
 // DC-API DB only.  When OVN policy routes land in M2.5 (issue #152), this
 // method will patch Vpc.spec.policyRoutes.
 func (c *Client) AssociateRouteTable(_ context.Context, _, _ string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("AssociateRouteTable")
+	}
 	// M2 stance (a): routes apply VPC-wide.  No backend change.
 	// See m2-network-api-design.md § 13 Decision 3.
 	return nil
@@ -852,6 +912,9 @@ func (c *Client) AssociateRouteTable(_ context.Context, _, _ string) error {
 
 // DisassociateRouteTable is a no-op for the same reason as AssociateRouteTable.
 func (c *Client) DisassociateRouteTable(_ context.Context, _, _ string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DisassociateRouteTable")
+	}
 	return nil
 }
 
@@ -864,6 +927,9 @@ func (c *Client) DisassociateRouteTable(_ context.Context, _, _ string) error {
 // itself (no KubeOVN CRD created here).  Rule application happens at attach
 // time.
 func (c *Client) CreateNSG(_ context.Context, _, _ string, spec models.NSGSpec) (*models.NSGResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("CreateNSG")
+	}
 	// No KubeOVN object created.  BackendUID = "" (will be populated when
 	// attached to a subnet).  The handler generates the UUID and stores it.
 	return &models.NSGResource{
@@ -891,6 +957,9 @@ func (c *Client) CreateNSG(_ context.Context, _, _ string, spec models.NSGSpec) 
 // If no subnets are attached (no "|" separator), the method is a no-op
 // (rules are buffered in the DB only).
 func (c *Client) UpdateNSGRules(ctx context.Context, backendUID string, rules []models.NSGRule) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("UpdateNSGRules")
+	}
 	nsgUID, subnetUIDs := parseNSGBackendUID(backendUID)
 	if len(subnetUIDs) == 0 {
 		// NSG not yet attached — rules are buffered in DC-API DB.
@@ -910,6 +979,9 @@ func (c *Client) UpdateNSGRules(ctx context.Context, backendUID string, rules []
 // DeleteNSG removes the NSG.  The caller (handler) guarantees no attachments
 // exist (returns 409 if attachments remain).  Nothing to do at the backend.
 func (c *Client) DeleteNSG(_ context.Context, _ string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DeleteNSG")
+	}
 	// No backend CRD exists for an unattached NSG.  Attached NSGs must be
 	// detached (which patches the Subnet CRD) before calling DeleteNSG.
 	return nil
@@ -928,6 +1000,9 @@ func (c *Client) DeleteNSG(_ context.Context, _ string) error {
 // nsgUID is the NSG UUID (no "nsg-" prefix — the driver adds it internally).
 // subnetUID is the KubeOVN Subnet CRD name.
 func (c *Client) AttachNSGToSubnet(ctx context.Context, nsgUID, subnetUID string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("AttachNSGToSubnet")
+	}
 	// For attach with no rules provided, we fetch the NSG rules from the
 	// backendUID.  However, this interface only gives us nsgUID and subnetUID.
 	// The caller should ensure UpdateNSGRules is called after attach to push
@@ -951,6 +1026,9 @@ func (c *Client) AttachNSGToSubnet(ctx context.Context, nsgUID, subnetUID string
 // DetachNSGFromSubnet removes the NSG's ACL entries from the Subnet CRD
 // via PATCH.  The Subnet CRD is NOT deleted (gotcha 4).
 func (c *Client) DetachNSGFromSubnet(ctx context.Context, nsgUID, subnetUID string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DetachNSGFromSubnet")
+	}
 	// Read current ACLs.
 	subnet, err := c.dynamic.Resource(subnetGVR).Get(ctx, subnetUID, metav1.GetOptions{})
 	if err != nil {
@@ -992,6 +1070,9 @@ func (c *Client) DetachNSGFromSubnet(ctx context.Context, nsgUID, subnetUID stri
 // Reciprocal staticRoutes addition keeps the same per-peering tag so they
 // can be cleanly removed on delete.
 func (c *Client) CreatePeering(ctx context.Context, vnetUID, peerVnetUID string, spec models.PeeringSpec) (*models.PeeringResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("CreatePeering")
+	}
 	backendUID := vnetUID + "/" + peerVnetUID
 
 	// F6: the peering handler allocates the transit /24 from a DB-backed
@@ -1062,6 +1143,9 @@ func (c *Client) CreatePeering(ctx context.Context, vnetUID, peerVnetUID string,
 // Both are required to identify which staticRoutes to remove now that routes
 // are in the default (empty) routeTable and cannot be filtered by a named tag.
 func (c *Client) DeletePeering(ctx context.Context, backendUID string, localCIDRs, peerCIDRs []string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DeletePeering")
+	}
 	parts := strings.SplitN(backendUID, "/", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("delete peering: backendUID %q must be \"<vnetA>/<vnetB>\"", backendUID)
@@ -1245,6 +1329,9 @@ func (c *Client) removeVpcPeering(ctx context.Context, vpcName, peerVpcName stri
 //   - VpcDns mode:    "vpcdns-<zoneUID>"
 //   - ConfigMap mode: "configmap-<ns>/<zoneUID>"
 func (c *Client) CreatePrivateDnsZone(ctx context.Context, vnetUID string, spec models.DnsZoneSpec) (*models.DnsZoneResource, error) {
+	if c.dynamic == nil {
+		return nil, c.localOnlyErr("CreatePrivateDnsZone")
+	}
 	// Fetch the VPC to find the tenant.
 	vpcObj, err := c.dynamic.Resource(vpcGVR).Get(ctx, vnetUID, metav1.GetOptions{})
 	if err != nil {
@@ -1272,6 +1359,9 @@ func (c *Client) CreatePrivateDnsZone(ctx context.Context, vnetUID string, spec 
 
 // DeletePrivateDnsZone removes the VpcDns CRD or ConfigMap for the zone.
 func (c *Client) DeletePrivateDnsZone(ctx context.Context, backendUID string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DeletePrivateDnsZone")
+	}
 	if strings.HasPrefix(backendUID, "vpcdns-") {
 		crdName := strings.TrimPrefix(backendUID, "vpcdns-")
 		err := c.dynamic.Resource(vpcDnsGVR).Delete(ctx, crdName, metav1.DeleteOptions{})
@@ -1305,6 +1395,9 @@ func (c *Client) DeletePrivateDnsZone(ctx context.Context, backendUID string) er
 // Record entries are keyed by the DC-API record UUID so they are individually
 // addressable without scanning the full record list.
 func (c *Client) UpsertDnsRecord(ctx context.Context, zoneUID string, record models.DnsRecord) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("UpsertDnsRecord")
+	}
 	if strings.HasPrefix(zoneUID, "vpcdns-") {
 		return c.upsertVpcDnsRecord(ctx, zoneUID, record)
 	}
@@ -1316,6 +1409,9 @@ func (c *Client) UpsertDnsRecord(ctx context.Context, zoneUID string, record mod
 
 // DeleteDnsRecord removes a specific DNS record from the zone.
 func (c *Client) DeleteDnsRecord(ctx context.Context, zoneUID, recordID string) error {
+	if c.dynamic == nil {
+		return c.localOnlyErr("DeleteDnsRecord")
+	}
 	if strings.HasPrefix(zoneUID, "vpcdns-") {
 		return c.deleteVpcDnsRecord(ctx, zoneUID, recordID)
 	}

--- a/dc-api/internal/providers/registry.go
+++ b/dc-api/internal/providers/registry.go
@@ -4,36 +4,39 @@
 // whether that zone's provider ops go through the direct dynamic client or the
 // zone's dc-agent command channel.
 //
-// ── M-C scope ─────────────────────────────────────────────────────────────────
-// The registry holds exactly ONE zone — the local zone (cfg.LocalRegion /
-// cfg.LocalZone) — built from the process-global DCAPI_* credentials, i.e. the
-// same Direct providers main.go built before M-C. The compute provider for that
-// zone is constructed with a clusteraccess.Routed accessor whose decision
-// closure consults:
+// ── Per-resource zone routing ───────────────────────────────────────────────
+// The Registry is the per-(region,zone) ProviderSet cache AND the live per-call
+// agent-routing decision. Handlers and the reconciler hold the Registry as a
+// providers.Resolver and call For(resource.Region, resource.Zone) per resource,
+// so a resource in another zone reaches that zone's agent — instead of one fixed
+// provider set keyed to DCAPI_LOCAL_ZONE.
 //
-//  1. the per-family toggle for the verb — AgentRouteReads (DCAPI_AGENT_ROUTE_READS,
-//     default false) for reads, AgentRouteWrites (DCAPI_AGENT_ROUTE_WRITES, default
-//     false) for the VM write slice — AND
-//  2. a non-nil agent gateway, AND
-//  3. a LIVE agent session for the zone right now, AND
-//  4. the verb being in the routed allow-set ({Get} for reads; {Create, Delete}
-//     for the VM create/delete write slice).
+//  - LOCAL zone — built eagerly in NewRegistry from cfg (the direct Harvester
+//    kubeconfig + Rancher token), wrapped with the Routed accessor. This is the
+//    SAME set dc-api injected before this change, so single-cluster / single-zone
+//    deployments are byte-identical: every resource is stamped with the local
+//    region/zone, every For(local) is a cache HIT on this one set, and the lazy
+//    build-on-miss path is never taken.
 //
-// If ANY is false the accessor uses Direct — today's behaviour, byte-identical.
-// Condition 3 is the safety belt: even with a toggle on, a zone with no
-// connected agent silently uses Direct, so flipping the env var can never strand
-// the local zone if the agent is down. The toggles are independent: reads can
-// route while writes stay on the direct path.
+//  - REMOTE zone — built lazily on first For(region,zone) miss for a zone that
+//    is in the regions/zones catalog but is NOT the local zone. dc-api holds NO
+//    kubeconfig there, so the remote set's Compute/Network providers are agent-
+//    only (a Routed accessor whose Direct fallback is a clusteraccess.NoCreds
+//    that errors clearly — never a silent fallback to the LOCAL cluster). The
+//    Cluster provider is the SAME global Rancher client every zone shares (see
+//    rancherScope in the design: Rancher is one global control plane, not per-DC).
 //
-// The cluster provider stays plain Direct — rancher is an HTTP Steve client that
-// does not fit the Accessor seam. The network provider (kubeovn) now ALSO carries
-// a routed seam: the kubeovn CRD CRUD lifecycle (Vpc/Subnet/NAD create/get/delete)
-// routes per-family under the SAME reads/writes toggles, gated by the network
-// families' RouteVerbs. The intricate plumbing (NAT, CoreDNS, ACL/route/peering
-// patches, DNS ConfigMaps, namespace/quota) stays Direct on the master kubeconfig.
+//  - UNKNOWN zone — neither the local zone nor a catalog zone → For returns a
+//    clear "unknown zone" error and never builds or caches anything.
+//
+// The agent decision closure is bound PER zone (region/zone captured in
+// buildSet), so remote traffic routes to the remote zone's agent session, never
+// the local one. With the toggles off (default) every op is the byte-identical
+// Direct (local) path; remote ops fail closed until an agent connects.
 package providers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -55,6 +58,49 @@ type ProviderSet struct {
 	Network NetworkProvider
 }
 
+// Resolver is the per-resource provider-set lookup the handlers and the
+// reconciler depend on. *Registry satisfies it. The signature is deliberately
+// the same For(region,zone) the Registry already exposed, so the per-zone cache,
+// the agent-decision closure, and the no-agent warn path are reused with zero
+// new machinery — only the injection point moved from "once at boot" to "per
+// request / per resource".
+type Resolver interface {
+	For(region, zone string) (*ProviderSet, error)
+}
+
+// FixedResolver is a Resolver that returns the SAME ProviderSet for every
+// (region, zone). It exists for callers that build the handler graph from three
+// fixed providers without a full Registry — the contract-test harness and unit
+// tests that nop the backends, and as the single-cluster fallback in NewRouter
+// when no Registry is injected. For these callers there is exactly one (implicit
+// local) zone, so resolving any zone to the one set is correct and behavior-
+// preserving: it is literally the pre-routing "one fixed provider set" model.
+type FixedResolver struct{ set *ProviderSet }
+
+// NewFixedResolver wraps three fixed providers into a Resolver. Every For(...)
+// call returns the same set — appropriate only when there is a single zone.
+func NewFixedResolver(compute ComputeProvider, cluster ClusterProvider, network NetworkProvider) *FixedResolver {
+	return &FixedResolver{set: &ProviderSet{Compute: compute, Cluster: cluster, Network: network}}
+}
+
+// For returns the single fixed set regardless of region/zone.
+func (f *FixedResolver) For(_, _ string) (*ProviderSet, error) { return f.set, nil }
+
+// ZoneCatalog answers "is this a registered remote zone?" for the build-on-miss
+// path. It is consulted OUTSIDE the Registry's write lock (so a slow DB query
+// can't serialize unrelated zone lookups) and MUST fail closed: when the catalog
+// can't be reached the zone is treated as unknown, never as the local zone.
+//
+// The db.Repository satisfies this via its regions/zones catalog. A nil catalog
+// (router-only tests, the single-cluster default that never asks for a non-local
+// zone) means only the local zone ever resolves — any other zone is "unknown".
+type ZoneCatalog interface {
+	// IsKnownZone reports whether (region, zone) exists in the regions/zones
+	// catalog. err is non-nil only on a catalog lookup failure; callers treat a
+	// failure as "not known" (fail closed).
+	IsKnownZone(ctx context.Context, region, zone string) (bool, error)
+}
+
 // Registry resolves the provider set for a (region, zone). It mirrors
 // handlers.Registry's map+RWMutex+zoneKey shape.
 type Registry struct {
@@ -64,6 +110,16 @@ type Registry struct {
 	// agentGateway resolves a zone's live agent Session. nil ⇒ the agent path is
 	// disabled entirely (always the Direct seam).
 	agentGateway agentgw.SessionResolver
+
+	// catalog gates build-on-miss for non-local zones (fail closed). nil ⇒ only
+	// the local zone resolves (the single-cluster default).
+	catalog ZoneCatalog
+
+	// cluster is the GLOBAL Rancher cluster provider, built once in NewRegistry
+	// and shared by EVERY ProviderSet (local and remote). Rancher is one
+	// management control plane across the fleet — there is no per-zone cluster
+	// client and no agent seam for it. buildSet never reconstructs it.
+	cluster ClusterProvider
 
 	// routeReads gates the dark read slice (DCAPI_AGENT_ROUTE_READS).
 	routeReads bool
@@ -90,7 +146,9 @@ const noAgentWarnEvery = 30 * time.Second
 func registryKey(region, zone string) string { return region + "/" + zone }
 
 // NewRegistry builds the local-zone ProviderSet from cfg and wires its compute
-// provider's cluster-access seam to the agent gateway behind the read toggle.
+// and network providers' cluster-access seam to the agent gateway behind the
+// per-family toggles. The global Rancher cluster provider is built once here and
+// shared by every zone.
 //
 // agentGateway may be nil (agent path disabled). It is the handlers.Registry
 // adapted to agentgw.SessionResolver (handlers.NewAgentGateway), constructed in
@@ -108,93 +166,31 @@ func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log z
 		noAgentWarn:  make(map[string]time.Time),
 	}
 
-	// One GVR-aware decision closure serves BOTH families: it is per-GVR (Part A),
-	// so the same closure correctly routes VM verbs for the kubevirt GVRs and
-	// network verbs for the kubeovn/NAD GVRs, each gated by that family's RouteVerbs.
-	decide := r.agentDecision(cfg)
-
-	// ── Compute provider (harvester) with the routed cluster-access seam ───────
-	// Only the harvester path supports the seam. WithRoutedAccessor builds the
-	// Routed accessor over the client's OWN dynamic client (the Direct fallback),
-	// so the off-path and every not-yet-routed method share one client.
-	var compute ComputeProvider
-	switch cfg.VMProvider {
-	case "harvester":
-		hc, err := harvester.NewClient(cfg.HarvesterKubeconfig, cfg.HarvesterNamespace)
-		if err != nil {
-			return nil, fmt.Errorf("build harvester client for registry: %w", err)
-		}
-		hc.WithRoutedAccessor(func(direct clusteraccess.Accessor) clusteraccess.Accessor {
-			return clusteraccess.NewRouted(direct, decide)
-		})
-		compute = hc
-	default:
-		// Non-harvester compute providers don't have the seam yet — fall back to
-		// the plain factory (Direct behaviour). Nothing routes through the agent.
-		c, err := NewComputeProvider(cfg)
-		if err != nil {
-			return nil, err
-		}
-		compute = c
-	}
-
-	// ── Cluster provider: plain Direct (unchanged — rancher is an HTTP Steve
-	// client that does not fit the Accessor seam). ─────────────────────────────
+	// ── Cluster provider: GLOBAL, built once, shared by every zone. Plain Direct
+	// (rancher is an HTTP Steve client that does not fit the Accessor seam). ─────
 	cluster, err := NewClusterProvider(cfg)
 	if err != nil {
 		return nil, err
 	}
+	r.cluster = cluster
 
-	// ── Network provider (kubeovn) with the routed cluster-access seam ─────────
-	// Mirrors the compute path: build the kubeovn client directly so we can wire
-	// WithRoutedAccessor over its OWN dynamic client (the same SHARED decide
-	// closure). The kubeovn CRD CRUD lifecycle (Vpc/Subnet/NAD create/get/delete)
-	// then routes per-family under the SAME reads/writes toggles, gated by the
-	// network families' RouteVerbs. main.go still applies F15 WithExternalNetwork
-	// and F20 WithDNSConfig to localSet.Network (this same instance) AFTER the
-	// registry returns, so that plumbing is untouched — WithRoutedAccessor only
-	// swaps c.access. With the toggles off (default) every network op is the
-	// byte-identical Direct path.
-	var network NetworkProvider
-	switch cfg.NetworkProvider {
-	case "kubeovn":
-		kc, err := kubeovn.New(cfg.HarvesterKubeconfig, cfg.KubeOVNNamespace)
-		if err != nil {
-			return nil, fmt.Errorf("build kubeovn client for registry: %w", err)
-		}
-		kc.WithRoutedAccessor(func(direct clusteraccess.Accessor) clusteraccess.Accessor {
-			return clusteraccess.NewRouted(direct, decide)
-		})
-		network = kc
-	default:
-		// Non-kubeovn network providers don't have the seam — plain factory (Direct).
-		n, err := NewNetworkProvider(cfg)
-		if err != nil {
-			return nil, err
-		}
-		network = n
+	// ── Local-zone set (direct Harvester/KubeOVN, routed seam) ─────────────────
+	localSet, err := r.buildLocalSet(cfg)
+	if err != nil {
+		return nil, err
 	}
+	r.set[registryKey(cfg.LocalRegion, cfg.LocalZone)] = localSet
 
-	r.set[registryKey(cfg.LocalRegion, cfg.LocalZone)] = &ProviderSet{
-		Compute: compute,
-		Cluster: cluster,
-		Network: network,
-	}
-
-	// One explicit "which zone do I route to" line at boot. This is the routing
-	// TARGET (cfg.LocalRegion/LocalZone) — the zone whose token an agent must be
-	// minted for to receive routed traffic. Surfacing it here makes the
-	// colombo-vs-zone-1 class of misconfig visible at startup rather than as a
-	// silent no-route at request time.
+	// One explicit "which zone do I route to" line at boot. This is the LOCAL
+	// routing target; per-resource resolution now routes other zones to their own
+	// agents. Surfacing it here makes the colombo-vs-zone-1 class of misconfig
+	// visible at startup rather than as a silent no-route at request time.
 	log.Info().
 		Str("route_region", cfg.LocalRegion).Str("route_zone", cfg.LocalZone).
 		Bool("reads", cfg.AgentRouteReads).Bool("writes", cfg.AgentRouteWrites).
 		Bool("gateway", agentGateway != nil).
-		Msg("agent routing config: routed traffic targets this region/zone; an agent must present a token minted for it (else routing warns and uses the direct path)")
+		Msg("agent routing config: the LOCAL region/zone uses the direct kubeconfig (plus the local agent when routing toggles are on); remote zones route to their own agent")
 
-	// One log line covering BOTH toggles so an operator can tell from the logs
-	// whether reads and/or writes route. Each only ever engages when a live agent
-	// is connected for the zone; with the gateway absent both are forced off.
 	if agentGateway != nil && cfg.AgentRouteReads {
 		log.Info().
 			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
@@ -218,42 +214,184 @@ func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log z
 	return r, nil
 }
 
-// For returns the cached provider set for a (region, zone). Only the local zone
-// exists in M-C; any other zone is an error (no second zone is provisioned yet).
+// WithZoneCatalog injects the regions/zones catalog used to gate build-on-miss
+// for remote zones (fail closed). Returns the same *Registry for chaining. Wired
+// in main.go after the repo exists. Without it, only the local zone resolves.
+func (r *Registry) WithZoneCatalog(c ZoneCatalog) *Registry {
+	r.catalog = c
+	return r
+}
+
+// buildLocalSet builds the LOCAL zone's ProviderSet from cfg: the direct
+// Harvester compute provider and direct KubeOVN network provider, each wrapped
+// with a Routed accessor whose decision is bound to the LOCAL region/zone. This
+// is the exact construction dc-api used before per-resource routing, so the
+// local set is byte-identical.
+func (r *Registry) buildLocalSet(cfg *config.Config) (*ProviderSet, error) {
+	// The decision closure for the LOCAL zone, bound to the local region/zone.
+	decide := r.agentDecision(cfg.LocalRegion, cfg.LocalZone)
+
+	// ── Compute provider (harvester) with the routed cluster-access seam ───────
+	var compute ComputeProvider
+	switch cfg.VMProvider {
+	case "harvester":
+		hc, err := harvester.NewClient(cfg.HarvesterKubeconfig, cfg.HarvesterNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("build harvester client for registry: %w", err)
+		}
+		hc.WithRoutedAccessor(func(direct clusteraccess.Accessor) clusteraccess.Accessor {
+			return clusteraccess.NewRouted(direct, decide)
+		})
+		compute = hc
+	default:
+		c, err := NewComputeProvider(cfg)
+		if err != nil {
+			return nil, err
+		}
+		compute = c
+	}
+
+	// ── Network provider (kubeovn) with the routed cluster-access seam ─────────
+	var network NetworkProvider
+	switch cfg.NetworkProvider {
+	case "kubeovn":
+		kc, err := kubeovn.New(cfg.HarvesterKubeconfig, cfg.KubeOVNNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("build kubeovn client for registry: %w", err)
+		}
+		kc.WithRoutedAccessor(func(direct clusteraccess.Accessor) clusteraccess.Accessor {
+			return clusteraccess.NewRouted(direct, decide)
+		})
+		network = kc
+	default:
+		n, err := NewNetworkProvider(cfg)
+		if err != nil {
+			return nil, err
+		}
+		network = n
+	}
+
+	return &ProviderSet{
+		Compute: compute,
+		Cluster: r.cluster,
+		Network: network,
+	}, nil
+}
+
+// buildRemoteSet builds a REMOTE zone's agent-only ProviderSet. dc-api holds NO
+// kubeconfig for the zone, so:
+//
+//   - Compute/Network are credential-free clients (harvester.NewRemoteClient /
+//     kubeovn.NewRemoteClient). The harvester client routes the VM-object CRUD
+//     lifecycle through a Routed accessor bound to THIS zone, whose Direct
+//     fallback is a clusteraccess.NoCreds — so a missing agent yields a clear
+//     "no agent connected for zone" error, never a silent hit on the LOCAL
+//     cluster. The kubeovn remote client defers networking behind a clear
+//     local-only error (the network plumbing has no agent path yet).
+//   - Cluster is the SAME global Rancher client every zone shares.
+//
+// buildRemoteSet performs NO network I/O (no kubeconfig to dial), so it is safe
+// to run under the Registry write lock without serializing unrelated lookups.
+func (r *Registry) buildRemoteSet(region, zone string) *ProviderSet {
+	decide := r.agentDecision(region, zone)
+	// Agent-only accessor: route via the agent, fall back to NoCreds (clear error)
+	// — NEVER to the local direct path.
+	remoteAccessor := clusteraccess.NewRouted(clusteraccess.NewNoCreds(region, zone), decide)
+
+	return &ProviderSet{
+		Compute: harvester.NewRemoteClient(remoteAccessor, region, zone),
+		Cluster: r.cluster, // global Rancher
+		Network: kubeovn.NewRemoteClient(region, zone),
+	}
+}
+
+// For returns the cached provider set for a (region, zone), building it lazily
+// on a miss.
+//
+// Fast path (the single-cluster / single-zone case and every repeated lookup):
+// an RLock read of the map. The LOCAL zone is always present (built eagerly in
+// NewRegistry), so For(local) is a pure cache hit returning the SAME *ProviderSet
+// pointer every time — byte-identical to today's fixed providers.
+//
+// Build-on-miss (multi-zone): empty region/zone (pre-stamp rows) resolve to the
+// local zone. Otherwise the catalog is consulted OUTSIDE the lock (fail closed):
+//   - not a known zone → clear "unknown zone" error, nothing built or cached;
+//   - a known REMOTE zone → build the agent-only set once under the write lock
+//     (double-checked), cache it, and return it. buildRemoteSet does no network
+//     I/O, so the lock is held only briefly.
+//
+// A failed catalog lookup is treated as unknown — never a fallback to the local
+// cluster (the silent-wrong-cluster failure mode).
 func (r *Registry) For(region, zone string) (*ProviderSet, error) {
+	// Empty region/zone (pre-stamp rows, or callers that don't carry a zone)
+	// resolve to the local zone — that is where those resources actually live.
+	if region == "" {
+		region = r.localRegion
+	}
+	if zone == "" {
+		zone = r.localZone
+	}
+	key := registryKey(region, zone)
+
+	// ── Fast path: cache hit (local-first; covers Mode A entirely). ────────────
 	r.mu.RLock()
-	set, ok := r.set[registryKey(region, zone)]
+	set, ok := r.set[key]
 	r.mu.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("no provider set for zone %s/%s (only the local zone %s/%s is configured)",
+	if ok {
+		return set, nil
+	}
+
+	// The local zone is always cached, so a miss here is a non-local zone. It
+	// must be a registered remote zone or it does not resolve. Consult the
+	// catalog OUTSIDE the lock (fail closed).
+	if r.catalog == nil {
+		return nil, fmt.Errorf(
+			"no provider set for zone %s/%s: not the local zone %s/%s and no zone catalog is configured",
 			region, zone, r.localRegion, r.localZone)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	known, err := r.catalog.IsKnownZone(ctx, region, zone)
+	if err != nil {
+		// Fail closed: a catalog failure must NOT open a fallback to the local
+		// cluster. Surface it as unresolved so the handler/reconciler retries.
+		return nil, fmt.Errorf("resolve zone %s/%s: zone catalog lookup failed (failing closed, not falling back to the local cluster): %w", region, zone, err)
+	}
+	if !known {
+		return nil, fmt.Errorf(
+			"unknown zone %s/%s: not the local zone %s/%s and not a registered remote zone",
+			region, zone, r.localRegion, r.localZone)
+	}
+
+	// ── Build-on-miss for a known remote zone (double-checked under the lock). ──
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if set, ok := r.set[key]; ok {
+		// Another goroutine built it between our RUnlock and Lock.
+		return set, nil
+	}
+	set = r.buildRemoteSet(region, zone)
+	r.set[key] = set
+	r.log.Info().Str("region", region).Str("zone", zone).
+		Msg("provider registry: built agent-only provider set for remote zone (no direct credentials; ops route to the zone's agent or fail clearly)")
 	return set, nil
 }
 
-// agentDecision builds the live decision closure for the local zone's Routed
+// agentDecision builds the live decision closure for the given zone's Routed
 // accessor. It re-evaluates the toggles + live-session check + verb allow-set on
 // EVERY call, so "toggle on / toggle off" and "agent connected / disconnected"
 // are observable on the very next request with no provider reconstruction.
 //
+// region/zone are bound to THIS zone (not cfg.Local*), so the live-session check
+// and the no-agent warning target the correct zone — this is what lets a remote
+// resource route to its OWN agent session rather than the local one.
+//
 // The routed allow-set is gated per family via clusteraccess.RoutableVerbs(gvr)
 // (the capability registry's RouteVerbs for that GVR), then split reads (VerbGet)
-// by AgentRouteReads, writes (VerbCreate, VerbDelete) by AgentRouteWrites. Each
-// verb is declared on a capability IN THE SAME PR as the matching dc-agent RBAC
-// rule — never one without the other. A GVR/verb the registry does not declare
-// always returns (_, false) → Direct. Because membership is per-GVR, onboarding a
-// second family (e.g. KubeOVN networks) routes ONLY that family's declared verbs;
-// it cannot inherit a verb that only another family (e.g. VMs) declared.
-//
-// NOTE: the write allow-set uses VerbCreate (not VerbApply) because CreateVM
-// calls c.access.Create(...). On the Direct path that is a byte-identical POST;
-// only the AgentBacked path turns VerbCreate into a server-side apply, since SSA
-// is the agent's only create mechanism. VerbApply/VerbUpdate stay out until a
-// later phase needs them.
-func (r *Registry) agentDecision(cfg *config.Config) clusteraccess.AgentDecision {
+// by AgentRouteReads, writes (VerbCreate, VerbDelete) by AgentRouteWrites.
+func (r *Registry) agentDecision(region, zone string) clusteraccess.AgentDecision {
 	mapper := clusteraccess.DefaultGVKMapper()
 	fieldManager := "dc-api"
-	region, zone := cfg.LocalRegion, cfg.LocalZone
 
 	return func(verb clusteraccess.Verb, gvr schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
 		// (2) gateway present — shared precondition for any routing.
@@ -261,13 +399,6 @@ func (r *Registry) agentDecision(cfg *config.Config) clusteraccess.AgentDecision
 			return nil, false
 		}
 		// (1)+(4) PER-FAMILY registry membership AND per-family toggle, together.
-		//   reads  → AgentRouteReads  gates read verbs  (VerbGet)
-		//   writes → AgentRouteWrites gates write verbs (VerbCreate, VerbDelete)
-		// RoutableVerbs(gvr) is the per-family allow-set declared in the capability
-		// registry (RouteVerbs). A GVR that is not an onboarded routable family, or
-		// a verb that family did not declare, always falls through to Direct. This
-		// REPLACES the cross-family UnionRouteVerbs() so a second family routes ONLY
-		// its own declared verbs — never a verb another family happened to declare.
 		routable, ok := clusteraccess.RoutableVerbs(gvr)
 		if !ok || !routable[verb] {
 			return nil, false
@@ -284,14 +415,14 @@ func (r *Registry) agentDecision(cfg *config.Config) clusteraccess.AgentDecision
 		default:
 			return nil, false
 		}
-		// (3) a live agent session must exist for the zone RIGHT NOW.
+		// (3) a live agent session must exist for THIS zone RIGHT NOW.
 		sess, ok := r.agentGateway.Session(region, zone)
 		if !ok {
-			// The toggle for this verb is ON (we passed the checks above) but no
-			// agent is connected for the routing zone. Direct is still the correct,
-			// byte-identical safety belt — but this used to be SILENT, which is
-			// exactly how the colombo-vs-zone-1 misconfig hid. Make it observable
-			// without flooding: warn at most once per zone per noAgentWarnEvery.
+			// The toggle for this verb is ON but no agent is connected for the
+			// zone. For the LOCAL zone the Routed accessor's Direct fallback is the
+			// correct byte-identical safety belt; for a REMOTE zone the fallback is
+			// NoCreds, which errors clearly. Either way warn (rate-limited) so the
+			// colombo-vs-zone-1 misconfig is observable.
 			r.warnNoAgent(region, zone)
 			return nil, false
 		}
@@ -300,10 +431,10 @@ func (r *Registry) agentDecision(cfg *config.Config) clusteraccess.AgentDecision
 }
 
 // warnNoAgent emits a rate-limited WARNING when a routed verb's toggle is on but
-// no agent is connected for the zone dc-api routes to. It fires at most once per
-// zone per noAgentWarnEvery so a routed call hammered at request rate cannot
-// flood the log. The caller still returns Direct — this is observability only,
-// the byte-identical fallthrough behaviour is unchanged.
+// no agent is connected for the zone. It fires at most once per zone per
+// noAgentWarnEvery. The caller still returns "not routed" — the Routed accessor's
+// Direct fallback then runs (local: the byte-identical direct path; remote: a
+// clear NoCreds error).
 func (r *Registry) warnNoAgent(region, zone string) {
 	key := registryKey(region, zone)
 	now := time.Now()
@@ -318,5 +449,5 @@ func (r *Registry) warnNoAgent(region, zone string) {
 
 	r.log.Warn().
 		Str("region", region).Str("zone", zone).
-		Msg("agent routing enabled for this region/zone but no agent is connected; using the direct cluster path — mint and connect an agent for this zone, or the routed traffic stays direct")
+		Msg("agent routing enabled for this region/zone but no agent is connected; the local zone uses the direct cluster path while a remote zone fails clearly — mint and connect an agent for this zone")
 }

--- a/dc-api/internal/providers/registry_test.go
+++ b/dc-api/internal/providers/registry_test.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/wso2/dc-api/internal/agentgw"
-	"github.com/wso2/dc-api/internal/config"
 	"github.com/wso2/dc-api/internal/providers/clusteraccess"
 )
 
@@ -70,26 +69,176 @@ func decisionRegistryToggles(routeReads, routeWrites bool, gw agentgw.SessionRes
 	}
 }
 
-// cfgWith builds a config with only the read toggle set (write toggle off).
-func cfgWith(routeReads bool) *config.Config {
-	return cfgWithToggles(routeReads, false)
+// ─────────────────────── Per-resource resolver (For) tests ──────────────────
+//
+// These exercise the per-(region,zone) cache that backs per-resource routing:
+// local-zone cache hits are pointer-identical (Mode A byte-identical), unknown
+// zones fail clearly, a known remote zone builds an agent-only set whose ops
+// fail clearly with no agent, and the local set is never rebuilt.
+
+// fakeCatalog is a providers.ZoneCatalog whose known-set and error are fixed.
+type fakeCatalog struct {
+	known map[string]bool
+	err   error
 }
 
-// cfgWithToggles builds a config with both per-family agent-routing toggles set.
-// agentDecision reads LocalRegion/LocalZone off cfg, so they are populated to
-// match decisionRegistry's zone.
-func cfgWithToggles(routeReads, routeWrites bool) *config.Config {
-	return &config.Config{
-		LocalRegion:      "lk",
-		LocalZone:        "zone-1",
-		AgentRouteReads:  routeReads,
-		AgentRouteWrites: routeWrites,
+func (f fakeCatalog) IsKnownZone(_ context.Context, region, zone string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.known[region+"/"+zone], nil
+}
+
+// resolverRegistry builds a *Registry with a pre-seeded LOCAL set (no kubeconfig
+// parsing), so the For() cache path can be tested directly. The local set's
+// providers are nil — these tests assert pointers and errors, never call into a
+// provider that needs a real backend.
+func resolverRegistry(catalog ZoneCatalog, gw agentgw.SessionResolver) *Registry {
+	r := &Registry{
+		set:          make(map[string]*ProviderSet, 1),
+		agentGateway: gw,
+		catalog:      catalog,
+		localRegion:  "lk",
+		localZone:    "zone-1",
+		log:          zerolog.Nop(),
+		noAgentWarn:  make(map[string]time.Time),
+	}
+	r.set[registryKey("lk", "zone-1")] = &ProviderSet{} // the local set (sentinel)
+	return r
+}
+
+func TestFor_LocalZone_CacheHit_PointerIdentical(t *testing.T) {
+	r := resolverRegistry(nil, nil)
+	a, err := r.For("lk", "zone-1")
+	if err != nil {
+		t.Fatalf("For(local) must succeed: %v", err)
+	}
+	b, err := r.For("lk", "zone-1")
+	if err != nil {
+		t.Fatalf("For(local) repeat must succeed: %v", err)
+	}
+	if a != b {
+		t.Error("For(local) must return the SAME *ProviderSet pointer across calls (no rebuild)")
+	}
+	// Empty region/zone must resolve to the same local set (pre-stamp rows / Mode A).
+	c, err := r.For("", "")
+	if err != nil {
+		t.Fatalf("For(empty) must resolve to the local zone: %v", err)
+	}
+	if c != a {
+		t.Error("For(\"\",\"\") must resolve to the SAME local set as For(local)")
+	}
+}
+
+func TestFor_LocalZone_NeverRebuilt_ConcurrentSamePointer(t *testing.T) {
+	r := resolverRegistry(nil, nil)
+	want, _ := r.For("lk", "zone-1")
+
+	const n = 50
+	got := make(chan *ProviderSet, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			set, err := r.For("lk", "zone-1")
+			if err != nil {
+				got <- nil
+				return
+			}
+			got <- set
+		}()
+	}
+	for i := 0; i < n; i++ {
+		if set := <-got; set != want {
+			t.Fatal("concurrent For(local) returned a different pointer — the local set must never be rebuilt")
+		}
+	}
+}
+
+func TestFor_UnknownZone_NoCatalog_ClearError(t *testing.T) {
+	r := resolverRegistry(nil, nil) // no catalog ⇒ only the local zone resolves
+	_, err := r.For("us", "zone-9")
+	if err == nil {
+		t.Fatal("an unknown zone with no catalog must NOT resolve")
+	}
+	// Must NOT have built or cached anything for the unknown zone.
+	r.mu.RLock()
+	_, cached := r.set[registryKey("us", "zone-9")]
+	r.mu.RUnlock()
+	if cached {
+		t.Error("an unknown zone must never be cached")
+	}
+}
+
+func TestFor_UnknownZone_WithCatalog_ClearError(t *testing.T) {
+	cat := fakeCatalog{known: map[string]bool{"lk/zone-1": true}} // remote not known
+	r := resolverRegistry(cat, nil)
+	_, err := r.For("us", "zone-9")
+	if err == nil {
+		t.Fatal("a zone absent from the catalog must return a clear unknown-zone error")
+	}
+}
+
+func TestFor_CatalogFailure_FailsClosed(t *testing.T) {
+	cat := fakeCatalog{err: errCatalog}
+	r := resolverRegistry(cat, nil)
+	_, err := r.For("us", "zone-9")
+	if err == nil {
+		t.Fatal("a catalog lookup failure must fail CLOSED (unresolved), never fall back to local")
+	}
+	r.mu.RLock()
+	_, cached := r.set[registryKey("us", "zone-9")]
+	r.mu.RUnlock()
+	if cached {
+		t.Error("a failed catalog lookup must not cache a set")
+	}
+}
+
+func TestFor_RemoteZone_BuildsAgentOnlySet_NoAgent_ClearError(t *testing.T) {
+	// Remote zone is in the catalog, but no agent is connected.
+	cat := fakeCatalog{known: map[string]bool{"lk/zone-1": true, "us/zone-9": true}}
+	r := resolverRegistry(cat, fakeResolver{connected: false})
+
+	set, err := r.For("us", "zone-9")
+	if err != nil {
+		t.Fatalf("a known remote zone must build an agent-only set: %v", err)
+	}
+	if set == nil || set.Compute == nil || set.Network == nil {
+		t.Fatal("the remote set must have non-nil agent-only providers")
+	}
+	// The remote set must be cached and pointer-stable.
+	set2, _ := r.For("us", "zone-9")
+	if set2 != set {
+		t.Error("the remote set must be cached (same pointer on the second call)")
+	}
+	// With NO agent connected, a remote-zone op must fail with a CLEAR error — it
+	// must NOT silently hit the local cluster. The remote compute provider's
+	// GetVM goes through the NoCreds fallback.
+	if _, err := set.Compute.GetVM(context.Background(), "ns:vm"); err == nil {
+		t.Error("a remote-zone op with no connected agent must return a clear error, not silently succeed")
+	}
+}
+
+var errCatalog = errCatalogT{}
+
+type errCatalogT struct{}
+
+func (errCatalogT) Error() string { return "catalog unreachable" }
+
+func TestFixedResolver_AlwaysSameSet(t *testing.T) {
+	set := &ProviderSet{}
+	f := &FixedResolver{set: set}
+	a, err := f.For("lk", "zone-1")
+	if err != nil {
+		t.Fatalf("FixedResolver.For must not error: %v", err)
+	}
+	b, _ := f.For("us", "zone-99") // any zone → the one fixed set (single-zone model)
+	if a != set || b != set {
+		t.Error("FixedResolver must return the SAME set for every zone")
 	}
 }
 
 func TestAgentDecision_ToggleOff_AlwaysDirect(t *testing.T) {
 	r := decisionRegistry(false, fakeResolver{connected: true})
-	decide := r.agentDecision(cfgWith(false))
+	decide := r.agentDecision("lk", "zone-1")
 	if _, ok := decide(clusteraccess.VerbGet, vmGVR); ok {
 		t.Error("toggle off must NOT route to the agent (Get)")
 	}
@@ -97,7 +246,7 @@ func TestAgentDecision_ToggleOff_AlwaysDirect(t *testing.T) {
 
 func TestAgentDecision_NoGateway_AlwaysDirect(t *testing.T) {
 	r := decisionRegistry(true, nil)
-	decide := r.agentDecision(cfgWith(true))
+	decide := r.agentDecision("lk", "zone-1")
 	if _, ok := decide(clusteraccess.VerbGet, vmGVR); ok {
 		t.Error("nil gateway must NOT route to the agent")
 	}
@@ -105,7 +254,7 @@ func TestAgentDecision_NoGateway_AlwaysDirect(t *testing.T) {
 
 func TestAgentDecision_ToggleOn_NoLiveAgent_Direct(t *testing.T) {
 	r := decisionRegistry(true, fakeResolver{connected: false})
-	decide := r.agentDecision(cfgWith(true))
+	decide := r.agentDecision("lk", "zone-1")
 	if _, ok := decide(clusteraccess.VerbGet, vmGVR); ok {
 		t.Error("toggle on but no connected agent must fall back to Direct")
 	}
@@ -114,7 +263,7 @@ func TestAgentDecision_ToggleOn_NoLiveAgent_Direct(t *testing.T) {
 func TestAgentDecision_ToggleOn_LiveAgent_RoutesGetOnly(t *testing.T) {
 	// Reads-only configuration: read toggle on, WRITE toggle off.
 	r := decisionRegistryToggles(true, false, fakeResolver{connected: true})
-	decide := r.agentDecision(cfgWithToggles(true, false))
+	decide := r.agentDecision("lk", "zone-1")
 
 	if _, ok := decide(clusteraccess.VerbGet, vmGVR); !ok {
 		t.Error("toggle on + live agent must route Get through the agent")
@@ -135,7 +284,7 @@ func TestAgentDecision_ToggleOn_LiveAgent_RoutesGetOnly(t *testing.T) {
 func TestAgentDecision_WritesOn_LiveAgent_RoutesCreateAndDelete(t *testing.T) {
 	// writes on, reads off — proves the toggles are independent.
 	r := decisionRegistryToggles(false, true, fakeResolver{connected: true})
-	decide := r.agentDecision(cfgWithToggles(false, true))
+	decide := r.agentDecision("lk", "zone-1")
 
 	for _, v := range []clusteraccess.Verb{clusteraccess.VerbCreate, clusteraccess.VerbDelete} {
 		if _, ok := decide(v, vmGVR); !ok {
@@ -162,7 +311,7 @@ func TestAgentDecision_WritesOn_LiveAgent_RoutesCreateAndDelete(t *testing.T) {
 func TestAgentDecision_WritesOff_CreateDeleteStayDirect(t *testing.T) {
 	// reads on, writes off.
 	r := decisionRegistryToggles(true, false, fakeResolver{connected: true})
-	decide := r.agentDecision(cfgWithToggles(true, false))
+	decide := r.agentDecision("lk", "zone-1")
 
 	for _, v := range []clusteraccess.Verb{clusteraccess.VerbCreate, clusteraccess.VerbDelete} {
 		if _, ok := decide(v, vmGVR); ok {
@@ -177,7 +326,7 @@ func TestAgentDecision_WritesOff_CreateDeleteStayDirect(t *testing.T) {
 // never strand the zone when the agent is down.
 func TestAgentDecision_WritesOn_NoLiveAgent_StayDirect(t *testing.T) {
 	r := decisionRegistryToggles(true, true, fakeResolver{connected: false})
-	decide := r.agentDecision(cfgWithToggles(true, true))
+	decide := r.agentDecision("lk", "zone-1")
 
 	for _, v := range []clusteraccess.Verb{clusteraccess.VerbGet, clusteraccess.VerbCreate, clusteraccess.VerbDelete} {
 		if _, ok := decide(v, vmGVR); ok {
@@ -195,7 +344,7 @@ func TestAgentDecision_WritesOn_NoLiveAgent_StayDirect(t *testing.T) {
 // matched, so this is exactly the over-permit Part A closes.
 func TestAgentDecision_PerFamily_UnonboardedGVRStaysDirect(t *testing.T) {
 	r := decisionRegistryToggles(true, true, fakeResolver{connected: true})
-	decide := r.agentDecision(cfgWithToggles(true, true))
+	decide := r.agentDecision("lk", "zone-1")
 
 	imgGVR := schema.GroupVersionResource{Group: "harvesterhci.io", Version: "v1beta1", Resource: "virtualmachineimages"}
 	for _, v := range []clusteraccess.Verb{clusteraccess.VerbGet, clusteraccess.VerbCreate, clusteraccess.VerbDelete} {

--- a/dc-api/internal/reconciler/reconciler.go
+++ b/dc-api/internal/reconciler/reconciler.go
@@ -29,26 +29,31 @@ import (
 // Reconciler polls PENDING and DELETING resources and syncs their status
 // from the provider back into PostgreSQL.
 type Reconciler struct {
-	repo            *db.Repository
-	computeProvider providers.ComputeProvider
-	clusterProvider providers.ClusterProvider
-	interval        time.Duration
-	log             zerolog.Logger
+	repo *db.Repository
+	// resolve maps a resource's (region, zone) to that zone's provider set. In a
+	// single-zone deployment every resource resolves to the same local set
+	// (pointer-identical to the providers dc-api injected before per-resource
+	// routing); in a multi-zone deployment a remote resource resolves to its own
+	// zone's agent-backed set. Resolution errors (unknown zone, remote zone with
+	// no agent) are isolated per resource so one unreachable zone never stalls
+	// reconciling resources in other zones.
+	resolve  providers.Resolver
+	interval time.Duration
+	log      zerolog.Logger
 }
 
-// New creates a Reconciler. Call Run(ctx) to start it.
+// New creates a Reconciler. Call Run(ctx) to start it. resolve is the per-zone
+// provider resolver (*providers.Registry).
 func New(
 	repo *db.Repository,
-	compute providers.ComputeProvider,
-	cluster providers.ClusterProvider,
+	resolve providers.Resolver,
 	log zerolog.Logger,
 ) *Reconciler {
 	return &Reconciler{
-		repo:            repo,
-		computeProvider: compute,
-		clusterProvider: cluster,
-		interval:        60 * time.Second,
-		log:             log.With().Str("component", "reconciler").Logger(),
+		repo:     repo,
+		resolve:  resolve,
+		interval: 60 * time.Second,
+		log:      log.With().Str("component", "reconciler").Logger(),
 	}
 }
 
@@ -116,7 +121,21 @@ func (r *Reconciler) reconcileOne(ctx context.Context, res *models.Resource) {
 		Str("name", res.Name).
 		Str("type", string(res.Type)).
 		Str("status", string(res.Status)).
+		Str("region", res.Region).
+		Str("zone", res.Zone).
 		Logger()
+
+	// Resolve the provider set for THIS resource's zone. An error here (unknown
+	// zone, or a remote zone whose agent is down) is isolated to this resource:
+	// we log a per-resource warning and return, leaving the row in its current
+	// status to be retried next tick. Because each resource is reconciled
+	// independently in the reconcileAll loop, one unreachable zone never stalls
+	// resources in other zones on the same tick.
+	set, err := r.resolve.For(res.Region, res.Zone)
+	if err != nil {
+		log.Warn().Err(err).Msg("cannot resolve provider for resource's zone — skipping this tick")
+		return
+	}
 
 	var (
 		providerStatus models.ResourceStatus
@@ -131,7 +150,7 @@ func (r *Reconciler) reconcileOne(ctx context.Context, res *models.Resource) {
 		// Bastions are KubeVirt VMs under the hood — same provider call.
 		// For bastions providerRes.MgmtIP carries the mgmt-VLAN IP; it's
 		// empty for regular VMs.
-		providerRes, err := r.computeProvider.GetVM(ctx, res.BackendUID)
+		providerRes, err := set.Compute.GetVM(ctx, res.BackendUID)
 		if err != nil {
 			if isNotFound(err) {
 				notFound = true
@@ -147,7 +166,7 @@ func (r *Reconciler) reconcileOne(ctx context.Context, res *models.Resource) {
 		}
 
 	case models.ResourceTypeCluster:
-		providerRes, err := r.clusterProvider.GetCluster(ctx, res.BackendUID)
+		providerRes, err := set.Cluster.GetCluster(ctx, res.BackendUID)
 		if err != nil {
 			if isNotFound(err) {
 				notFound = true

--- a/dc-api/test/integration/vm_on_vpc_test.go
+++ b/dc-api/test/integration/vm_on_vpc_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wso2/dc-api/internal/api"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/providers"
 	"github.com/wso2/dc-api/internal/providers/harvester"
 	"github.com/wso2/dc-api/internal/providers/kubeovn"
 	"github.com/wso2/dc-api/internal/reconciler"
@@ -185,7 +186,12 @@ func newSubEnvWithHarvester(t *testing.T) *TestEnv {
 	// 3s interval gives fast feedback in tests; production uses 60s.
 	reconCtx, reconCancel := context.WithCancel(context.Background())
 	t.Cleanup(reconCancel)
-	go reconciler.New(env.DB, harvesterProvider, &nopClusterProvider{}, logger).
+	// The reconciler now resolves a provider per resource via a Resolver. In this
+	// single-zone integration test every resource resolves to the same fixed set,
+	// so wrap the test's fixed providers in a FixedResolver — byte-identical to
+	// the pre-routing single-provider reconciler.
+	reconResolver := providers.NewFixedResolver(harvesterProvider, &nopClusterProvider{}, netProvider)
+	go reconciler.New(env.DB, reconResolver, logger).
 		WithInterval(3 * time.Second).
 		Run(reconCtx)
 


### PR DESCRIPTION
## What this changes

dc-api used to build one set of backend providers at startup — for the local zone — and hand that same set to every handler and to the reconciler, so everything talked to a single zone. This makes provider selection **per resource**: each time a handler or the reconciler acts on a resource, it looks up the provider set for that resource's own region and zone (which the resource now carries). `DCAPI_LOCAL_ZONE` stops being the routing key and becomes only the default zone for a new root resource that doesn't name one.

## The single-cluster mode stays first-class

Many deployments are just one Harvester cluster reached through a direct kubeconfig, with no agent — and that stays the simple default, byte-identical to today. The local zone's provider set is built once at startup and cached, so a local-zone resource is a plain cache hit returning the same direct providers as before; with one zone and no agent, every resource resolves to that set and the zone catalog is never consulted. The same per-resource lookup serves both this mode and the multi-zone mode — it is not a fork.

## Multi-zone, and failing safely

A remote zone's provider set is built lazily and has **no direct credentials** in dc-api, so its operations route through that zone's agent. The failure modes are handled deliberately rather than silently:

- a remote zone with **no connected agent** → a clear "no agent for zone" error, never a silent fall back to the local cluster;
- an **unknown zone**, or a **zone-catalog lookup failure** → fails closed with a clear error, again never the local cluster;
- each zone's routing decision is **bound to that zone**, so remote traffic reaches the remote agent, not the local one.

## Decisions worth knowing

- **Operations with no agent path yet** — Harvester image lookup, the cloud-provider ServiceAccount bootstrap, and the per-network NAT/DNS plumbing — are a documented **local-only** constraint: for a remote zone they refuse with a clear error rather than misrouting. They are deferred until the agent can carry them.
- **Cluster provisioning (Rancher) is treated as global** — one Rancher manages clusters, rather than one per datacenter — so cluster resolution is not per-zone.
- VM/cluster/VNet **delete** now returns a clear error if the resource's zone is unreachable (only reachable in the multi-zone case; never hit in single-cluster).

## How to verify

`go build`, `go vet`, and race-enabled unit tests pass. New resolver tests cover the per-zone cache (built once, pointer-identical, concurrency-safe), both deployment modes, and every fail-closed path (unknown zone, catalog failure, remote-with-no-agent). The Postgres-backed zone integration tests pass against the refactored resolution with no changes to the tests. The live-cluster integration tests need a real Harvester and were not run here.

## Not in this PR

Actually standing up a remote zone (a second datacenter's agent, image distribution, remote NAT/DNS) — the resolution plumbing here is correct and cached, and remote operations fail closed until an agent for the zone exists. This is the routing engine; bringing up a real second zone is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
