### PR TITLE
[Fix] Deliver buffered watch-status snapshots before returning

### DIFF
--- a/dc-api/internal/api/handlers/agentchannel.go
+++ b/dc-api/internal/api/handlers/agentchannel.go
@@ -396,6 +396,23 @@ func (s *Session) WatchStatus(
 		case p := <-progressCh:
 			deliver(p)
 		case res := <-ch:
+			// The result frame can win this select while progress frames are
+			// still buffered. The agent sends its progress frames before the
+			// terminal result, so by the time res is ready those frames are
+			// already in progressCh — but select picks a ready case at random and
+			// may take res first, abandoning buffered progress. Drain and deliver
+			// it before returning, so onSnapshot fires for every snapshot the
+			// agent sent ahead of the result and WatchStatus never reports more
+			// snapshots than the caller actually received.
+			for {
+				select {
+				case p := <-progressCh:
+					deliver(p)
+					continue
+				default:
+				}
+				break
+			}
 			if res == nil { // session closed under us
 				return zero, ErrAgentUnavailable
 			}


### PR DESCRIPTION
## What this fixes

`controlplane` CI went red after the last merge on `TestSessionWatchStatus_Streaming` ("onSnapshot fired 2 times, want 3"). That is an intermittent **timing flake**, not a regression from any recent change — it passes locally and in isolation and only trips under CI's load. Behind the flake is a real, narrow bug.

## The bug

`WatchStatus` delivers status snapshots to the caller through a buffered channel and waits for the terminal result on a separate channel, draining both in a single `select`. When the last snapshot and the result are both ready at once, `select` picks one at random — and if it picks the result, `WatchStatus` returns while a snapshot is still buffered. That snapshot is never delivered, and the summary it returns reports more snapshots than the caller actually received.

## The fix

On the result branch, drain and deliver any buffered snapshots before returning. The agent always sends its progress frames ahead of the terminal result, so by the time the result is ready those frames are already buffered; delivering them first makes the stream complete and the count accurate. One small change in `agentchannel.go`.

## How to verify

The previously-flaky test now passes **500 runs in a row under the race detector**, and the full handlers package is race-clean. This turns `controlplane` CI green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
