### PR TITLE
[CI] Enable CodeRabbit auto-review on the terraform-provider-dcapi branch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    enabled: true
+    # This branch is a separate, long-lived development line with its own
+    # root tree, so CodeRabbit must be opted in here explicitly — the default
+    # branch's config does not reach it. Anchored so it matches only this branch.
+    base_branches:
+      - "^terraform-provider-dcapi$"


### PR DESCRIPTION
CodeRabbit only auto-reviews pull requests against the repository's default branch unless other base branches are explicitly opted in. This branch is a separate, long-lived line of development that shares no history with the default branch, so any CodeRabbit configuration on the default branch never reaches the feature branches opened against this one — which is why PRs here currently get no review.

This adds a `.coderabbit.yaml` that opts this branch into auto-review via `reviews.auto_review.base_branches`. The pattern is anchored so it matches only this branch; the default branch stays covered automatically. Because these branches are independent trees, the file has to live on each base branch — there is no single shared copy.

No code or workflow changes — this only turns CodeRabbit back on for PRs targeting this branch. CodeRabbit should review this very PR (its branch already carries the config), which doubles as confirmation that it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
