### PR TITLE
Remove k8s provider from tenant space module

### DIFF
--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -201,48 +201,6 @@ module "vyos_tenant" {
   vyos_api_key  = var.vyos_api_key
 }
 
-# ── Consumer VM access kubeconfig (read from provisioner-created secret) ───────
-# The namespace-credential-provisioner automatically creates a "harvester-vm-kubeconfig"
-# Secret in each tenant namespace containing a namespace-scoped Harvester kubeconfig.
-# This data source surfaces it as a Terraform output so the platform team can
-# retrieve it once at onboarding and hand it to the tenant team:
-#
-#   terraform output -raw <tenant>_vm_kubeconfig > <team>.harvester.kubeconfig.secret
-#
-# Requires the kubernetes.harvester provider to be passed in (set expose_vm_kubeconfig = true
-# and configure kubernetes.harvester in the caller's provider block).
-#
-# IMPORTANT — two-pass apply required:
-# This data source races with the out-of-band reconciler. On a fresh namespace the
-# provisioner may not have created the secret yet when Terraform runs the data read.
-# Apply in two steps:
-#   1. terraform apply                  # creates namespaces; provisioner reconciles
-#   2. terraform apply                  # reads the now-present secret
-# Alternatively, run `terraform apply -target=rancher2_namespace.this` first, wait
-# for the provisioner, then run the full apply.
-
-locals {
-  # Primary workload namespace for the VM kubeconfig.
-  # Uses var.vm_access_namespace when explicitly set; falls back to the first
-  # resolved namespace (or project_name when no namespaces are configured).
-  vm_access_ns = var.vm_access_namespace != null ? var.vm_access_namespace : (
-    length(local.namespaces) > 0 ? local.namespaces[0] : var.project_name
-  )
-}
-
-data "kubernetes_secret_v1" "vm_access_kubeconfig" {
-  count    = var.expose_vm_kubeconfig ? 1 : 0
-  provider = kubernetes.harvester
-  metadata {
-    name      = "harvester-vm-kubeconfig"
-    namespace = local.vm_access_ns
-  }
-  depends_on = [rancher2_namespace.this]
-}
-
-locals {
-  vm_access_kubeconfig = var.expose_vm_kubeconfig ? data.kubernetes_secret_v1.vm_access_kubeconfig[0].data["kubeconfig"] : null
-}
 
 # ── One binding per (principal, role) pair. ───────────────────────────────────
 # Key is derived from the principal value + role so that switching principal

--- a/modules/tenancy/tenant-space/outputs.tf
+++ b/modules/tenancy/tenant-space/outputs.tf
@@ -38,11 +38,6 @@ output "gateway_ip" {
   description = "VyOS gateway IP for this tenant (first host in subnet_cidr). Non-null only when vlan_id and vyos_endpoint are both set."
 }
 
-output "vm_access_kubeconfig" {
-  value       = local.vm_access_kubeconfig
-  sensitive   = true
-  description = "Namespace-scoped Harvester kubeconfig for the tenant team. Non-null when expose_vm_kubeconfig = true and the namespace-credential-provisioner has already created the secret. Hand to the tenant team once at onboarding. See examples/consumer-workloads in wso2-datacenter-project for usage."
-}
 
 output "bot_users" {
   value = {

--- a/modules/tenancy/tenant-space/variables.tf
+++ b/modules/tenancy/tenant-space/variables.tf
@@ -245,21 +245,6 @@ variable "shared_image_namespace" {
   }
 }
 
-variable "expose_vm_kubeconfig" {
-  type        = bool
-  description = "When true, reads the 'harvester-vm-kubeconfig' Secret created by the namespace-credential-provisioner and exposes it via the vm_access_kubeconfig output. Requires the kubernetes.harvester provider alias to be configured in the caller. The provisioner must have run before apply."
-  default     = false
-}
-
-variable "vm_access_namespace" {
-  type        = string
-  description = "Namespace from which to read the 'harvester-vm-kubeconfig' Secret when expose_vm_kubeconfig = true. Defaults to the first resolved namespace (or project_name when no namespaces are configured). Set explicitly when the tenant has multiple namespaces and the kubeconfig should target a specific one."
-  default     = null
-  validation {
-    condition     = var.vm_access_namespace == null ? true : trimspace(var.vm_access_namespace) != ""
-    error_message = "vm_access_namespace must be null or a non-empty namespace name."
-  }
-}
 
 variable "vyos_endpoint" {
   type        = string

--- a/modules/tenancy/tenant-space/versions.tf
+++ b/modules/tenancy/tenant-space/versions.tf
@@ -9,11 +9,6 @@ terraform {
       source  = "harvester/harvester"
       version = "~> 1.7"
     }
-    kubernetes = {
-      source                = "hashicorp/kubernetes"
-      version               = "~> 2.35"
-      configuration_aliases = [kubernetes.harvester]
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"


### PR DESCRIPTION
## Summary

This removes the kubernetes provider and the data resources which are parts of the `namespace-credential-provisioner` which no longer requires


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the exposed VM kubeconfig output from the tenant space module.
  * Simplified tenant space configuration by dropping settings related to per-namespace kubeconfig access.
  * Reduced the module’s provider requirements accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->