### PR TITLE
[CI] Enable CodeRabbit auto-review for non-default branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit reads this file ONLY from the repository's default branch (main),
+# so all auto-review gating lives here. Our long-lived development lines are on
+# separate branches that must be opted in below; the default branch is always
+# reviewed automatically. Patterns are regex — anchored so that, e.g.,
+# "terraform" does not also match "terraform-provider-dcapi".
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - "^controlplane$"
+      - "^terraform$"
+      - "^operators$"
+      - "^terraform-provider-dcapi$"


### PR DESCRIPTION
CodeRabbit reads its configuration only from the repository's default branch. Because `main` had no `.coderabbit.yaml`, CodeRabbit fell back to the dashboard defaults — which auto-review the default branch only — so pull requests targeting the long-lived `controlplane`, `terraform`, `operators`, and `terraform-provider-dcapi` branches were skipped (for example #194).

This adds a single `.coderabbit.yaml` on `main` that opts those branches into auto-review via `reviews.auto_review.base_branches`. The patterns are anchored regexes so that, for example, `terraform` does not also match `terraform-provider-dcapi`. The default branch stays covered automatically.

This supersedes the per-branch `.coderabbit.yaml` files merged earlier (#189–#192): CodeRabbit never reads configuration from non-default branches, so those files have no effect on review gating and can be removed in a follow-up.

No code or workflow changes — configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
