### PR TITLE
[Feature] Add a zones-enabled flag for agent-only zones

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,11 +40,15 @@ export DCAPI_ADMIN_GROUP="dc-admin"
 # export DCAPI_PLATFORM_ADMIN_SUBS="sub-uuid-1,sub-uuid-2"
 
 # ── Harvester ────────────────────────────────────────────────────────────────
-# REQUIRED. Base64-encoded kubeconfig for the Harvester cluster.
+# Base64-encoded kubeconfig for the Harvester cluster.
 #   macOS: base64 -i ~/.kube/harvester.yaml | tr -d '\n'
 #   Linux: base64 -w0 < ~/.kube/harvester.yaml
 # This kubeconfig is reused by the network provider (KubeOVN runs on the same
 # Harvester cluster) — you don't need a second one.
+#
+# REQUIRED in single-cluster mode (DCAPI_ZONES_ENABLED=false, the default).
+# IGNORED in multi-zone mode (DCAPI_ZONES_ENABLED=true): every zone is agent-only
+# and dc-api needs no kubeconfig — see the Multi-region section below.
 export DCAPI_HARVESTER_KUBECONFIG="<base64-harvester-kubeconfig>"
 
 # OPTIONAL. Harvester namespace where dc-api creates tenant resources when
@@ -217,6 +221,23 @@ export DCAPI_BFF_COOKIE_SECURE="false"
 # first routed call, then uses the direct path — it never silently strands routing.
 export DCAPI_LOCAL_REGION="lk"      # region slug this control plane owns (regions table)
 export DCAPI_LOCAL_ZONE="zone-1"    # local zone slug (zones table); pairs with LOCAL_REGION
+#
+# DCAPI_ZONES_ENABLED flips how the LOCAL (control-plane-host) zone is treated.
+#
+#   false (DEFAULT, single-cluster): dc-api builds a DIRECT provider set for the
+#   local zone from DCAPI_HARVESTER_KUBECONFIG (which is REQUIRED), runs the local
+#   F32 cluster-SA wiring and the F15/F20 VPC NAT + per-VPC DNS startup bootstrap,
+#   and serves the local zone over the direct client. Remote zones (if any) still
+#   route through the per-resource agent engine. Byte-identical to legacy behavior.
+#
+#   true (multi-zone, agent-only): there is NO inherent local zone. EVERY zone,
+#   including the control-plane-host zone, is agent-only and resolves through the
+#   same catalog-gated path as a remote zone — dc-api needs no kubeconfig (any
+#   DCAPI_HARVESTER_KUBECONFIG that is set is IGNORED). The local F32/F15/F20
+#   startup bootstrap is skipped. A zone with no connected agent fails clearly
+#   (no silent fallback to a local cluster). Register/connect an agent for the
+#   local zone before creating resources in it.
+export DCAPI_ZONES_ENABLED="false"
 #
 # DCAPI_AGENT_ROUTE_READS routes provider read operations through the per-zone
 # agent instead of dc-api's direct client. Default false keeps the direct path.

--- a/dc-api/cmd/dc-api/main.go
+++ b/dc-api/cmd/dc-api/main.go
@@ -49,6 +49,13 @@ func main() {
 		l := zerolog.New(os.Stdout).With().Timestamp().Logger()
 		l.Fatal().Err(err).Msg("failed to load configuration — check DCAPI_* environment variables")
 	}
+	// DCAPI_ZONES_ENABLED gates whether the local zone needs a direct kubeconfig
+	// (single-cluster) or is agent-only like every other zone (multi-zone). Fail
+	// fast on the single-cluster-without-kubeconfig misconfiguration.
+	if err := cfg.ValidateZones(); err != nil {
+		l := zerolog.New(os.Stdout).With().Timestamp().Logger()
+		l.Fatal().Err(err).Msg("invalid zones configuration")
+	}
 
 	// ── Logging ───────────────────────────────────────────────────────────────
 	// Apply log level from config before any other log calls.
@@ -59,6 +66,9 @@ func main() {
 	zerolog.SetGlobalLevel(level)
 	log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
 	log.Info().Str("listen", cfg.ListenAddr).Str("log_level", level.String()).Msg("DC-API starting")
+	if cfg.ZonesEnabled && cfg.HarvesterKubeconfig != "" {
+		log.Info().Msg("DCAPI_HARVESTER_KUBECONFIG is set but ignored (DCAPI_ZONES_ENABLED=true); agents provide cluster access")
+	}
 
 	// ── Background context with signal handling ────────────────────────────────
 	// We use a context that is cancelled when SIGINT or SIGTERM is received.
@@ -119,124 +129,171 @@ func main() {
 	// local cluster). In the single-cluster default no remote zone is ever asked
 	// for, so this is inert there. The LOCAL set below stays the eager cache hit.
 	provReg.WithZoneCatalog(repo)
-	localSet, err := provReg.For(cfg.LocalRegion, cfg.LocalZone)
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to resolve local provider set")
-	}
-	computeProvider := localSet.Compute
-	clusterProvider := localSet.Cluster
-	log.Info().Str("provider", computeProvider.Name()).Msg("compute provider ready")
-	log.Info().Str("provider", clusterProvider.Name()).Msg("cluster provider ready")
 
-	// ── F32: wire cloud-provider SA bootstrap into the cluster provisioner ─────
-	// Both the harvester client (for SA creation + API info) and the rancher
-	// client (for the Steve provisioner) must be ready before we can call
-	// WithHarvesterProviders. This is the only place both exist at the same time.
-	if rancherClient, ok := clusterProvider.(*rancher.Client); ok {
-		if harvesterClient, ok := computeProvider.(*harvester.Client); ok {
-			rancherClient.WithHarvesterProviders(harvesterClient, harvesterClient)
-			log.Info().Msg("F32: cluster provisioner wired with Harvester SA bootstrap")
-		}
-	}
-
-	networkProvider := localSet.Network
-	log.Info().Str("provider", networkProvider.Name()).Msg("network provider ready")
-
-	// ── F15 VPC SNAT + F20 Per-VPC DNS bootstrap ────────────────────────────
+	// ── Local-zone provider trio + startup bootstrap ───────────────────────────
 	//
-	// Ordering invariant (F29 fix): ALL bootstrap calls (cheap, idempotent
-	// SA/ConfigMap/CRD creation) MUST complete before any backfill loop starts.
-	// Backfill loops contain per-VPC waits that can exhaust a shared context
-	// budget if a NAT gateway pod is slow to start; if that kills the context,
-	// any bootstrap step that runs afterwards sees "context canceled" on its
-	// first k8s write and crashes the process. The correct ordering is:
+	// These three locals (computeProvider/clusterProvider/networkProvider) and the
+	// two provisioners (natProvisioner/dnsProvisioner) exist ONLY for startup
+	// bootstrap (F32 cluster-SA wiring, F15 VPC NAT, F20 per-VPC DNS) and as the
+	// router-only fixed-provider fallback in RouterDeps. The handlers and the
+	// reconciler resolve providers PER RESOURCE via provReg (the providers.Resolver),
+	// NOT via these locals — so leaving them nil in zones-enabled mode is safe.
 	//
-	//   1. EnsureExternalNetworkBootstrap  (F15, cheap, 2 min budget)
-	//   2. EnsureVpcDNSBootstrap           (F20, cheap, 1 min budget)
-	//   3. runNATBackfill                  (F15, per-VPC loop, 10 min budget)
-	//   4. runDNSBackfill                  (F20, per-VPC loop, 10 min budget)
+	// Single-cluster mode (DCAPI_ZONES_ENABLED=false): eager-build the local direct
+	// set and run the full F32/F15/F20 startup bootstrap — byte-identical to before.
 	//
-	// Each step uses its OWN context.WithTimeout so a slow VPC in step 3 cannot
-	// poison steps 1/2 (which have already finished) or step 4 (which has its
-	// own independent budget). The process-root context is NOT consumed here.
+	// Multi-zone mode (DCAPI_ZONES_ENABLED=true): there is NO local cluster to
+	// bootstrap. The local zone resolves through the same catalog-gated agent-only
+	// path as any remote zone (provReg.For build-on-miss). Skip this whole block;
+	// the local F32/F15/F20 plumbing becomes deferred per-zone agent work.
+	var computeProvider providers.ComputeProvider
+	var clusterProvider providers.ClusterProvider
+	var networkProvider providers.NetworkProvider
 	var natProvisioner providers.VPCNATProvisioner
 	var dnsProvisioner providers.VPCDNSProvisioner
-	if kvClient, ok := networkProvider.(*kubeovn.Client); ok {
-		if err := cfg.ValidateF15(); err != nil {
-			log.Fatal().Err(err).Msg("F15 VPC external network config is invalid — check DCAPI_VPC_EXTERNAL_* vars")
+	if !cfg.ZonesEnabled {
+		localSet, err := provReg.For(cfg.LocalRegion, cfg.LocalZone)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to resolve local provider set")
 		}
+		computeProvider = localSet.Compute
+		clusterProvider = localSet.Cluster
+		log.Info().Str("provider", computeProvider.Name()).Msg("compute provider ready")
+		log.Info().Str("provider", clusterProvider.Name()).Msg("cluster provider ready")
 
-		kvClient.WithExternalNetwork(kubeovn.ExternalNetworkConfig{
-			Bridge:      cfg.VPCExternalBridge,
-			CIDR:        cfg.VPCExternalCIDR,
-			Gateway:     cfg.VPCExternalGateway,
-			ReservedIPs: cfg.ParseReservedIPs(),
-			VLANID:      cfg.VPCExternalVLANID,
-		})
-		natProvisioner = kvClient
-
-		// ── Step 1: F15 bootstrap (2 min budget) ──────────────────────────────
-		{
-			bsCtx, bsCancel := context.WithTimeout(ctx, 2*time.Minute)
-			err := kvClient.EnsureExternalNetworkBootstrap(bsCtx)
-			bsCancel()
-			if err != nil {
-				log.Fatal().Err(err).Msg("failed to bootstrap external network resources (ProviderNetwork/Vlan/Subnet/NAD)")
+		// ── F32: wire cloud-provider SA bootstrap into the cluster provisioner ─────
+		// Both the harvester client (for SA creation + API info) and the rancher
+		// client (for the Steve provisioner) must be ready before we can call
+		// WithHarvesterProviders. This is the only place both exist at the same time.
+		if rancherClient, ok := clusterProvider.(*rancher.Client); ok {
+			if harvesterClient, ok := computeProvider.(*harvester.Client); ok {
+				rancherClient.WithHarvesterProviders(harvesterClient, harvesterClient)
+				log.Info().Msg("F32: cluster provisioner wired with Harvester SA bootstrap")
 			}
 		}
-		log.Info().
-			Str("cidr", cfg.VPCExternalCIDR).
-			Strs("reserved_ips", cfg.ParseReservedIPs()).
-			Msg("kubeovn: F15 external network bootstrap verified")
 
-		// ── Step 2: F20 bootstrap (1 min budget) ──────────────────────────────
-		// Bootstrap BEFORE backfill so the SA/ConfigMap are present even if
-		// runNATBackfill below is slow or times out on its own context.
-		if err := cfg.ValidateF20(); err != nil {
-			log.Fatal().Err(err).Msg("F20 per-VPC DNS config is invalid — check DCAPI_VPC_DNS_FORWARDERS")
-		}
+		networkProvider = localSet.Network
+		log.Info().Str("provider", networkProvider.Name()).Msg("network provider ready")
 
-		dnsImage := cfg.VPCDNSImage
-		if dnsImage == "" {
-			dnsImage = kvClient.AutoDetectCoreDNSImage(ctx)
-		}
+		// ── F15 VPC SNAT + F20 Per-VPC DNS bootstrap ────────────────────────────
+		//
+		// Ordering invariant (F29 fix): ALL bootstrap calls (cheap, idempotent
+		// SA/ConfigMap/CRD creation) MUST complete before any backfill loop starts.
+		// Backfill loops contain per-VPC waits that can exhaust a shared context
+		// budget if a NAT gateway pod is slow to start; if that kills the context,
+		// any bootstrap step that runs afterwards sees "context canceled" on its
+		// first k8s write and crashes the process. The correct ordering is:
+		//
+		//   1. EnsureExternalNetworkBootstrap  (F15, cheap, 2 min budget)
+		//   2. EnsureVpcDNSBootstrap           (F20, cheap, 1 min budget)
+		//   3. runNATBackfill                  (F15, per-VPC loop, 10 min budget)
+		//   4. runDNSBackfill                  (F20, per-VPC loop, 10 min budget)
+		//
+		// Each step uses its OWN context.WithTimeout so a slow VPC in step 3 cannot
+		// poison steps 1/2 (which have already finished) or step 4 (which has its
+		// own independent budget). The process-root context is NOT consumed here.
+		if kvClient, ok := networkProvider.(*kubeovn.Client); ok {
+			if err := cfg.ValidateF15(); err != nil {
+				log.Fatal().Err(err).Msg("F15 VPC external network config is invalid — check DCAPI_VPC_EXTERNAL_* vars")
+			}
 
-		kvClient.WithDNSConfig(kubeovn.DNSConfig{
-			Forwarders:   cfg.ParseDNSForwarders(),
-			Image:        dnsImage,
-			SearchDomain: cfg.VPCDNSSearchDomain,
-		})
-		dnsProvisioner = kvClient
+			kvClient.WithExternalNetwork(kubeovn.ExternalNetworkConfig{
+				Bridge:      cfg.VPCExternalBridge,
+				CIDR:        cfg.VPCExternalCIDR,
+				Gateway:     cfg.VPCExternalGateway,
+				ReservedIPs: cfg.ParseReservedIPs(),
+				VLANID:      cfg.VPCExternalVLANID,
+			})
+			natProvisioner = kvClient
 
-		{
-			bsCtx, bsCancel := context.WithTimeout(ctx, 1*time.Minute)
-			err := kvClient.EnsureVpcDNSBootstrap(bsCtx)
-			bsCancel()
-			if err != nil {
-				log.Fatal().Err(err).Msg("failed to bootstrap F20 DNS resources (ServiceAccount/ConfigMap)")
+			// ── Step 1: F15 bootstrap (2 min budget) ──────────────────────────────
+			{
+				bsCtx, bsCancel := context.WithTimeout(ctx, 2*time.Minute)
+				err := kvClient.EnsureExternalNetworkBootstrap(bsCtx)
+				bsCancel()
+				if err != nil {
+					log.Fatal().Err(err).Msg("failed to bootstrap external network resources (ProviderNetwork/Vlan/Subnet/NAD)")
+				}
+			}
+			log.Info().
+				Str("cidr", cfg.VPCExternalCIDR).
+				Strs("reserved_ips", cfg.ParseReservedIPs()).
+				Msg("kubeovn: F15 external network bootstrap verified")
+
+			// ── Step 2: F20 bootstrap (1 min budget) ──────────────────────────────
+			// Bootstrap BEFORE backfill so the SA/ConfigMap are present even if
+			// runNATBackfill below is slow or times out on its own context.
+			if err := cfg.ValidateF20(); err != nil {
+				log.Fatal().Err(err).Msg("F20 per-VPC DNS config is invalid — check DCAPI_VPC_DNS_FORWARDERS")
+			}
+
+			dnsImage := cfg.VPCDNSImage
+			if dnsImage == "" {
+				dnsImage = kvClient.AutoDetectCoreDNSImage(ctx)
+			}
+
+			kvClient.WithDNSConfig(kubeovn.DNSConfig{
+				Forwarders:   cfg.ParseDNSForwarders(),
+				Image:        dnsImage,
+				SearchDomain: cfg.VPCDNSSearchDomain,
+			})
+			dnsProvisioner = kvClient
+
+			{
+				bsCtx, bsCancel := context.WithTimeout(ctx, 1*time.Minute)
+				err := kvClient.EnsureVpcDNSBootstrap(bsCtx)
+				bsCancel()
+				if err != nil {
+					log.Fatal().Err(err).Msg("failed to bootstrap F20 DNS resources (ServiceAccount/ConfigMap)")
+				}
+			}
+			log.Info().
+				Strs("forwarders", cfg.ParseDNSForwarders()).
+				Str("image", dnsImage).
+				Msg("kubeovn: F20 per-VPC DNS bootstrap verified")
+
+			// ── Step 3: F15 backfill (10 min budget) ──────────────────────────────
+			// Per-VPC loop; individual EnsureVpcNAT calls can wait up to ~90s for
+			// the NAT gateway pod. Budget must be generous enough for all existing
+			// VPCs to be processed. Don't fatal on failure — a transient
+			// kube-ovn-controller hiccup must not prevent the API from starting.
+			{
+				bfCtx, bfCancel := context.WithTimeout(ctx, 10*time.Minute)
+				runNATBackfill(bfCtx, repo, kvClient, cfg.LocalRegion, cfg.LocalZone)
+				bfCancel()
+			}
+
+			// ── Step 4: F20 backfill (10 min budget) ──────────────────────────────
+			{
+				bfCtx, bfCancel := context.WithTimeout(ctx, 10*time.Minute)
+				runDNSBackfill(bfCtx, repo, kvClient, cfg.LocalRegion, cfg.LocalZone)
+				bfCancel()
 			}
 		}
+	} else {
+		// Multi-zone (agent-only) mode: no local cluster, no local startup
+		// bootstrap. The local zone resolves through provReg's catalog-gated
+		// agent-only path exactly like a remote zone. Remote-zone support is
+		// unchanged. Per-zone NAT/DNS/SA bootstrap is deferred agent work (task #7).
 		log.Info().
-			Strs("forwarders", cfg.ParseDNSForwarders()).
-			Str("image", dnsImage).
-			Msg("kubeovn: F20 per-VPC DNS bootstrap verified")
+			Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
+			Msg("DCAPI_ZONES_ENABLED=true: skipping local-zone provider build + F32/F15/F20 startup bootstrap; all zones (including the control-plane host) are agent-only and resolve via the provider registry")
 
-		// ── Step 3: F15 backfill (10 min budget) ──────────────────────────────
-		// Per-VPC loop; individual EnsureVpcNAT calls can wait up to ~90s for
-		// the NAT gateway pod. Budget must be generous enough for all existing
-		// VPCs to be processed. Don't fatal on failure — a transient
-		// kube-ovn-controller hiccup must not prevent the API from starting.
-		{
-			bfCtx, bfCancel := context.WithTimeout(ctx, 10*time.Minute)
-			runNATBackfill(bfCtx, repo, kvClient, cfg.LocalRegion, cfg.LocalZone)
-			bfCancel()
-		}
-
-		// ── Step 4: F20 backfill (10 min budget) ──────────────────────────────
-		{
-			bfCtx, bfCancel := context.WithTimeout(ctx, 10*time.Minute)
-			runDNSBackfill(bfCtx, repo, kvClient, cfg.LocalRegion, cfg.LocalZone)
-			bfCancel()
+		// Best-effort: warn (do NOT block startup) if the local zone is not yet a
+		// registered zone. Until an agent is minted/connected for it, resources in
+		// this zone cannot be created.
+		zoneCtx, zoneCancel := context.WithTimeout(ctx, 5*time.Second)
+		known, err := repo.IsKnownZone(zoneCtx, cfg.LocalRegion, cfg.LocalZone)
+		zoneCancel()
+		switch {
+		case err != nil:
+			log.Warn().Err(err).
+				Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
+				Msg("could not verify whether the local zone is registered (catalog lookup failed) — continuing startup")
+		case !known:
+			log.Warn().
+				Str("region", cfg.LocalRegion).Str("zone", cfg.LocalZone).
+				Msg("local zone is not registered yet — mint and connect an agent for it before resources can be created in this zone")
 		}
 	}
 

--- a/dc-api/internal/config/config.go
+++ b/dc-api/internal/config/config.go
@@ -71,7 +71,13 @@ type Config struct {
 	// ── Harvester ─────────────────────────────────────────────────────────────
 	// HarvesterKubeconfig: base64-encoded kubeconfig for the Harvester cluster.
 	// Generate with: base64 < ~/.kube/harvester.yaml
-	HarvesterKubeconfig string `envconfig:"HARVESTER_KUBECONFIG" required:"true"`
+	//
+	// REQUIRED in single-cluster mode (DCAPI_ZONES_ENABLED=false) — dc-api uses
+	// it to build the local zone's direct provider set. IGNORED when zones are
+	// enabled (DCAPI_ZONES_ENABLED=true): every zone, including the
+	// control-plane-host zone, is agent-only and dc-api holds no kubeconfig. The
+	// optionality is enforced by ValidateZones(), not the envconfig tag.
+	HarvesterKubeconfig string `envconfig:"HARVESTER_KUBECONFIG" default:""`
 	HarvesterNamespace  string `envconfig:"HARVESTER_NAMESPACE"  default:"default"`
 
 	// ── Rancher ───────────────────────────────────────────────────────────────
@@ -299,6 +305,24 @@ type Config struct {
 	// zone with a connected agent whose RBAC already permits the op.
 	AgentRouteWrites bool `envconfig:"AGENT_ROUTE_WRITES" default:"false"`
 
+	// ZonesEnabled flips how the LOCAL (control-plane-host) zone is treated.
+	//
+	// Default FALSE — single-cluster mode: dc-api eager-builds a DIRECT provider
+	// set for the local zone from DCAPI_HARVESTER_KUBECONFIG (required), runs the
+	// F32 cluster-SA wiring and the F15/F20 VPC NAT + per-VPC DNS startup
+	// bootstrap, and serves the local zone over the direct dynamic client. Remote
+	// zones (if any) still resolve through the per-resource agent-routing engine.
+	// This is byte-identical to the pre-flag behavior.
+	//
+	// TRUE — multi-zone mode: there is NO inherent "local zone". EVERY zone,
+	// including the control-plane-host zone (LocalRegion/LocalZone), is agent-only
+	// and resolves through the SAME catalog-gated build-on-miss path as any remote
+	// zone — dc-api needs no kubeconfig. The DCAPI_HARVESTER_KUBECONFIG, if set, is
+	// ignored. The local F32/F15/F20 startup bootstrap is skipped (no local
+	// cluster; those become per-zone agent work). Remote zones keep working — the
+	// flag never disables remote-zone support.
+	ZonesEnabled bool `envconfig:"ZONES_ENABLED" default:"false"`
+
 	// ── Logging ───────────────────────────────────────────────────────────────
 	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
 
@@ -423,6 +447,23 @@ func (c *Config) ValidateF15() error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateZones enforces the kubeconfig requirement implied by DCAPI_ZONES_ENABLED.
+//
+//   - Zones DISABLED (single-cluster, the default): DCAPI_HARVESTER_KUBECONFIG
+//     MUST be set — dc-api builds the local zone's direct provider set from it.
+//     An empty kubeconfig here is a fatal misconfiguration (the API could not
+//     serve any local resource), so we fail fast with a clear message.
+//   - Zones ENABLED (multi-zone, agent-only): the kubeconfig is OPTIONAL and
+//     ignored — agents provide cluster access for every zone. We do NOT refuse a
+//     set kubeconfig (an operator may leave the secret in place across the cutover);
+//     main.go logs one INFO noting it is ignored.
+func (c *Config) ValidateZones() error {
+	if !c.ZonesEnabled && c.HarvesterKubeconfig == "" {
+		return fmt.Errorf("DCAPI_HARVESTER_KUBECONFIG is required when DCAPI_ZONES_ENABLED=false (single-cluster mode); when zones are enabled, agents provide cluster access")
+	}
 	return nil
 }
 

--- a/dc-api/internal/config/config_test.go
+++ b/dc-api/internal/config/config_test.go
@@ -74,3 +74,81 @@ func TestAgentRouteToggles_Independent(t *testing.T) {
 		})
 	}
 }
+
+// TestZonesEnabled_DefaultFalse asserts the flag defaults to false (single-cluster
+// mode) when DCAPI_ZONES_ENABLED is unset — byte-identical legacy behavior.
+func TestZonesEnabled_DefaultFalse(t *testing.T) {
+	setRequiredEnv(t)
+	// Intentionally do NOT set DCAPI_ZONES_ENABLED.
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.ZonesEnabled {
+		t.Error("ZonesEnabled = true by default, want false")
+	}
+}
+
+// TestZonesEnabled_True asserts the flag reads true when the env var is set.
+func TestZonesEnabled_True(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("DCAPI_ZONES_ENABLED", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if !cfg.ZonesEnabled {
+		t.Error("ZonesEnabled = false with DCAPI_ZONES_ENABLED=true, want true")
+	}
+}
+
+// TestValidateZones_DisabledRequiresKubeconfig asserts single-cluster mode fails
+// fast when the Harvester kubeconfig is empty.
+func TestValidateZones_DisabledRequiresKubeconfig(t *testing.T) {
+	setRequiredEnv(t)
+	// Clear the kubeconfig AFTER setRequiredEnv so the empty value wins.
+	t.Setenv("DCAPI_HARVESTER_KUBECONFIG", "")
+	// Zones disabled is the default; make it explicit for clarity.
+	t.Setenv("DCAPI_ZONES_ENABLED", "false")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if err := cfg.ValidateZones(); err == nil {
+		t.Error("ValidateZones() = nil with zones disabled + empty kubeconfig, want an error")
+	}
+}
+
+// TestValidateZones_EnabledKubeconfigOptional asserts multi-zone mode accepts an
+// empty kubeconfig — agents provide cluster access.
+func TestValidateZones_EnabledKubeconfigOptional(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("DCAPI_HARVESTER_KUBECONFIG", "")
+	t.Setenv("DCAPI_ZONES_ENABLED", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if err := cfg.ValidateZones(); err != nil {
+		t.Errorf("ValidateZones() = %v with zones enabled + empty kubeconfig, want nil", err)
+	}
+}
+
+// TestValidateZones_EnabledKubeconfigIgnored asserts multi-zone mode does NOT
+// refuse a set kubeconfig — it is simply ignored (main.go logs one INFO).
+func TestValidateZones_EnabledKubeconfigIgnored(t *testing.T) {
+	setRequiredEnv(t) // sets a non-empty DCAPI_HARVESTER_KUBECONFIG
+	t.Setenv("DCAPI_ZONES_ENABLED", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if err := cfg.ValidateZones(); err != nil {
+		t.Errorf("ValidateZones() = %v with zones enabled + set kubeconfig, want nil (ignored, not refused)", err)
+	}
+}

--- a/dc-api/internal/providers/registry.go
+++ b/dc-api/internal/providers/registry.go
@@ -128,6 +128,14 @@ type Registry struct {
 	// create (SSA apply) + delete first. Independent of routeReads.
 	routeWrites bool
 
+	// zonesEnabled (DCAPI_ZONES_ENABLED) flips how the LOCAL zone is treated.
+	// false (default, single-cluster): the local zone is eager-built from cfg as a
+	// DIRECT provider set and cached, so For(local) is a byte-identical cache hit.
+	// true (multi-zone): the local zone is NOT pre-built — it resolves through the
+	// SAME catalog-gated agent-only build-on-miss path as any remote zone, so
+	// dc-api needs no kubeconfig and a missing agent yields a clear error.
+	zonesEnabled bool
+
 	localRegion, localZone string
 	log                    zerolog.Logger
 
@@ -160,6 +168,7 @@ func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log z
 		agentGateway: agentGateway,
 		routeReads:   cfg.AgentRouteReads,
 		routeWrites:  cfg.AgentRouteWrites,
+		zonesEnabled: cfg.ZonesEnabled,
 		localRegion:  cfg.LocalRegion,
 		localZone:    cfg.LocalZone,
 		log:          log,
@@ -174,22 +183,39 @@ func NewRegistry(cfg *config.Config, agentGateway agentgw.SessionResolver, log z
 	}
 	r.cluster = cluster
 
-	// ── Local-zone set (direct Harvester/KubeOVN, routed seam) ─────────────────
-	localSet, err := r.buildLocalSet(cfg)
-	if err != nil {
-		return nil, err
+	// ── Local-zone set ─────────────────────────────────────────────────────────
+	// Single-cluster (zones disabled): eager-build + cache the local zone's DIRECT
+	// set from cfg (the Harvester kubeconfig + Rancher token), so For(local) is a
+	// byte-identical cache hit and the build-on-miss path is never taken.
+	//
+	// Multi-zone (zones enabled): do NOT pre-build the local set. The local zone is
+	// agent-only and resolves through the SAME catalog-gated build-on-miss path as
+	// any remote zone (buildRemoteSet / NoCreds fallback). We never read the
+	// kubeconfig here, so dc-api needs none.
+	if !r.zonesEnabled {
+		localSet, err := r.buildLocalSet(cfg)
+		if err != nil {
+			return nil, err
+		}
+		r.set[registryKey(cfg.LocalRegion, cfg.LocalZone)] = localSet
 	}
-	r.set[registryKey(cfg.LocalRegion, cfg.LocalZone)] = localSet
 
-	// One explicit "which zone do I route to" line at boot. This is the LOCAL
-	// routing target; per-resource resolution now routes other zones to their own
-	// agents. Surfacing it here makes the colombo-vs-zone-1 class of misconfig
-	// visible at startup rather than as a silent no-route at request time.
-	log.Info().
-		Str("route_region", cfg.LocalRegion).Str("route_zone", cfg.LocalZone).
-		Bool("reads", cfg.AgentRouteReads).Bool("writes", cfg.AgentRouteWrites).
-		Bool("gateway", agentGateway != nil).
-		Msg("agent routing config: the LOCAL region/zone uses the direct kubeconfig (plus the local agent when routing toggles are on); remote zones route to their own agent")
+	// One explicit "how do I reach my zones" line at boot. This makes the
+	// colombo-vs-zone-1 class of misconfig visible at startup rather than as a
+	// silent no-route at request time.
+	if r.zonesEnabled {
+		log.Info().
+			Str("local_region", cfg.LocalRegion).Str("local_zone", cfg.LocalZone).
+			Bool("reads", cfg.AgentRouteReads).Bool("writes", cfg.AgentRouteWrites).
+			Bool("gateway", agentGateway != nil).
+			Msg("agent routing config (DCAPI_ZONES_ENABLED=true): ALL zones, including the local/control-plane-host zone, are agent-only — there is no direct kubeconfig fallback; a zone with no connected agent fails clearly. Remote zones route to their own agent.")
+	} else {
+		log.Info().
+			Str("route_region", cfg.LocalRegion).Str("route_zone", cfg.LocalZone).
+			Bool("reads", cfg.AgentRouteReads).Bool("writes", cfg.AgentRouteWrites).
+			Bool("gateway", agentGateway != nil).
+			Msg("agent routing config: the LOCAL region/zone uses the direct kubeconfig (plus the local agent when routing toggles are on); remote zones route to their own agent")
+	}
 
 	if agentGateway != nil && cfg.AgentRouteReads {
 		log.Info().
@@ -309,9 +335,12 @@ func (r *Registry) buildRemoteSet(region, zone string) *ProviderSet {
 // on a miss.
 //
 // Fast path (the single-cluster / single-zone case and every repeated lookup):
-// an RLock read of the map. The LOCAL zone is always present (built eagerly in
-// NewRegistry), so For(local) is a pure cache hit returning the SAME *ProviderSet
-// pointer every time — byte-identical to today's fixed providers.
+// an RLock read of the map. With DCAPI_ZONES_ENABLED=false the LOCAL zone is
+// present (built eagerly in NewRegistry), so For(local) is a pure cache hit
+// returning the SAME *ProviderSet pointer every time — byte-identical to today's
+// fixed providers. With DCAPI_ZONES_ENABLED=true the local zone is NOT pre-built,
+// so For(local) misses and goes through the catalog-gated agent-only build-on-miss
+// path below, exactly like a remote zone.
 //
 // Build-on-miss (multi-zone): empty region/zone (pre-stamp rows) resolve to the
 // local zone. Otherwise the catalog is consulted OUTSIDE the lock (fail closed):

--- a/dc-api/internal/providers/registry_test.go
+++ b/dc-api/internal/providers/registry_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 	"time"
@@ -10,8 +11,111 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/wso2/dc-api/internal/agentgw"
+	"github.com/wso2/dc-api/internal/config"
 	"github.com/wso2/dc-api/internal/providers/clusteraccess"
 )
+
+// minimalKubeconfig is a syntactically valid kubeconfig that parses into a REST
+// config without dialing anything — enough for harvester.NewClient / kubeovn.New
+// to build their dynamic clients in the zones-disabled eager-build path. No
+// cluster is contacted at construction time.
+const minimalKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: test-token
+`
+
+// zonesTestConfig returns a *config.Config sufficient to build a Registry, with
+// ZonesEnabled set as requested and a valid (but unreachable) local kubeconfig.
+func zonesTestConfig(zonesEnabled bool) *config.Config {
+	return &config.Config{
+		ZonesEnabled:        zonesEnabled,
+		HarvesterKubeconfig: base64.StdEncoding.EncodeToString([]byte(minimalKubeconfig)),
+		HarvesterNamespace:  "default",
+		VMProvider:          "harvester",
+		ClusterProvider:     "rancher",
+		NetworkProvider:     "kubeovn",
+		KubeOVNNamespace:    "kube-ovn",
+		RancherURL:          "https://rancher.example.com",
+		RancherToken:        "token-xyz",
+		LocalRegion:         "lk",
+		LocalZone:           "zone-1",
+	}
+}
+
+// TestNewRegistry_ZonesDisabled_EagerBuildsLocalSet asserts that with zones
+// disabled, the local zone is eager-built and cached, so For(local) is a cache
+// hit (no catalog needed) returning the same pointer.
+func TestNewRegistry_ZonesDisabled_EagerBuildsLocalSet(t *testing.T) {
+	r, err := NewRegistry(zonesTestConfig(false), nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRegistry(zones disabled) error: %v", err)
+	}
+	// The local set must be present in the cache without any catalog wired.
+	r.mu.RLock()
+	_, cached := r.set[registryKey("lk", "zone-1")]
+	r.mu.RUnlock()
+	if !cached {
+		t.Fatal("zones disabled must eager-build and cache the local set")
+	}
+	a, err := r.For("lk", "zone-1")
+	if err != nil {
+		t.Fatalf("For(local) must be a cache hit with no catalog: %v", err)
+	}
+	b, _ := r.For("lk", "zone-1")
+	if a != b {
+		t.Error("For(local) must return the same cached pointer (no rebuild)")
+	}
+	if a.Compute == nil || a.Cluster == nil || a.Network == nil {
+		t.Error("the eager-built local set must have non-nil direct providers")
+	}
+}
+
+// TestNewRegistry_ZonesEnabled_NoEagerLocalSet asserts that with zones enabled,
+// the local zone is NOT pre-built: For(local) misses and goes through the
+// catalog-gated agent-only build-on-miss path (identical to a remote zone).
+func TestNewRegistry_ZonesEnabled_NoEagerLocalSet(t *testing.T) {
+	r, err := NewRegistry(zonesTestConfig(true), nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRegistry(zones enabled) error: %v", err)
+	}
+	// The local set must NOT be pre-populated.
+	r.mu.RLock()
+	_, cached := r.set[registryKey("lk", "zone-1")]
+	r.mu.RUnlock()
+	if cached {
+		t.Fatal("zones enabled must NOT eager-build the local set")
+	}
+	// With no catalog wired, For(local) is a build-on-miss that fails closed —
+	// proving the local zone now takes the SAME path as a remote zone.
+	if _, err := r.For("lk", "zone-1"); err == nil {
+		t.Error("with zones enabled and no catalog, For(local) must fail closed (build-on-miss path), not return a direct set")
+	}
+	// With a catalog that knows the local zone, For(local) builds the agent-only
+	// set (no kubeconfig used) and caches it.
+	cat := fakeCatalog{known: map[string]bool{"lk/zone-1": true}}
+	r.WithZoneCatalog(cat)
+	set, err := r.For("lk", "zone-1")
+	if err != nil {
+		t.Fatalf("with a catalog, For(local) must build the agent-only set: %v", err)
+	}
+	if set == nil || set.Compute == nil || set.Network == nil {
+		t.Fatal("the agent-only local set must have non-nil providers")
+	}
+}
 
 // vmGVR is the onboarded VM family GVR — the decision closure is per-family
 // (Part A), so the tests must pass a GVR. All the pre-existing VM-behaviour tests

--- a/flux/platform/dc-api/base/configmap.yaml
+++ b/flux/platform/dc-api/base/configmap.yaml
@@ -13,6 +13,11 @@ data:
   DCAPI_HARVESTER_NAMESPACE: "default"
   DCAPI_VM_PROVIDER: "harvester"
   DCAPI_CLUSTER_PROVIDER: "rancher"
+  # Single-cluster (direct kubeconfig) is the default. A multi-zone overlay sets
+  # this to "true": every zone — including the control-plane-host zone — is
+  # agent-only, dc-api needs no kubeconfig, and the local F32/F15/F20 startup
+  # bootstrap is skipped.
+  DCAPI_ZONES_ENABLED: "false"
   # The ONLY IdP group dc-api interprets (platform admin). Tenant
   # membership lives in the role_assignments table, never in IdP groups.
   DCAPI_ADMIN_GROUP: "dc-admin"

--- a/flux/platform/dc-api/base/deployment.yaml
+++ b/flux/platform/dc-api/base/deployment.yaml
@@ -44,7 +44,9 @@ spec:
             - { name: DCAPI_OIDC_AUDIENCE,                valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_OIDC_AUDIENCE } } }
             - { name: DCAPI_RANCHER_TOKEN,                valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_RANCHER_TOKEN } } }
             - { name: DCAPI_RANCHER_HARVESTER_CREDENTIAL, valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_RANCHER_HARVESTER_CREDENTIAL } } }
-            - { name: DCAPI_HARVESTER_KUBECONFIG,         valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_HARVESTER_KUBECONFIG } } }
+            # Optional: required only in single-cluster mode (DCAPI_ZONES_ENABLED=false).
+            # When zones are enabled, agents provide cluster access and this key may be absent.
+            - { name: DCAPI_HARVESTER_KUBECONFIG,         valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_HARVESTER_KUBECONFIG, optional: true } } }
             - { name: DCAPI_BFF_CLIENT_ID,                valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_BFF_CLIENT_ID } } }
             - { name: DCAPI_BFF_CLIENT_SECRET,            valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_BFF_CLIENT_SECRET } } }
             - { name: DCAPI_BFF_SESSION_SECRET,           valueFrom: { secretKeyRef: { name: dc-api-secrets, key: DCAPI_BFF_SESSION_SECRET } } }


### PR DESCRIPTION
## What this changes

dc-api required a Harvester kubeconfig and always built a direct provider set for a "local" zone — treating one cluster as special and agents as an add-on. That's backwards: the control plane is independent of every Harvester cluster, and even the cluster that hosts it should be reached as a zone through its own agent. This adds `DCAPI_ZONES_ENABLED` to make the choice explicit, **defaulting to today's behavior**.

## The two modes

- **`false` (default — single-cluster):** the local zone uses the direct kubeconfig and the startup bootstrap (cluster-SA wiring, VPC NAT, per-VPC DNS) runs exactly as before. The kubeconfig requirement moved from a hard envconfig tag to a `ValidateZones()` check, but the behavior is **byte-identical** — the entire existing bootstrap is wrapped, unchanged, in `if !ZonesEnabled`.
- **`true` (multi-zone):** there is no local zone. Every zone, including the control-plane host, resolves through the same agent-only path as a remote zone, so dc-api needs **no kubeconfig**. A kubeconfig left in the environment is ignored (with one INFO at startup, so it isn't silent). The local startup bootstrap is skipped — there's no local cluster to run it against.

Remote-zone routing is untouched and works in both modes.

## Deliberately out of scope

The per-zone bootstrap operations multi-zone mode skips — cluster ServiceAccount bootstrap, VPC NAT, per-VPC DNS, image distribution — have no agent path yet and remain follow-up work. In multi-zone mode they're simply absent until that lands; VM and network CRUD already route through the agent and work today.

## How to verify

`go build`, `go vet`, and race-enabled unit tests pass. New config tests cover the flag default and the conditional kubeconfig requirement; new registry tests confirm the local zone is eager-built when the flag is off and resolves agent-only when it's on. The diff confirms the single-cluster path is unchanged. The live-cluster integration suite needs real infrastructure and wasn't run here.

## Deployment note

The Kubernetes manifest marks the kubeconfig secret `optional: true` so the pod can start in multi-zone mode without it. The default stays single-cluster, so existing deployments are unaffected unless they set the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new zone mode setting to support both single-cluster and multi-zone operation.
  * Updated deployment defaults to make Harvester kubeconfig optional when multi-zone access is enabled.

* **Bug Fixes**
  * Startup now validates zone settings earlier and provides clearer failure messages for invalid configurations.
  * Improved behavior in multi-zone mode so the app no longer falls back to local cluster access when an agent is unavailable.

* **Documentation**
  * Clarified environment variable guidance for when kubeconfig is required versus ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->