### PR TITLE
[Feature] Route remote-zone network CRUD through the agent

### DIFF
--- a/dc-api/internal/providers/kubeovn/client.go
+++ b/dc-api/internal/providers/kubeovn/client.go
@@ -155,34 +155,47 @@ type Client struct {
 	dnsConf *DNSConfig
 
 	// remoteRegion/remoteZone are non-empty ONLY for a credential-free REMOTE
-	// client built by NewRemoteClient. For such a client c.dynamic is nil and the
-	// network CRD lifecycle is NOT yet routed through the agent (the network
-	// plumbing — NAD creation, ACL/route patches, NAT/CoreDNS — has no agent
-	// path), so every NetworkProvider method returns a clear local-only error
-	// naming the zone instead of dereferencing a nil dynamic client. Empty for the
-	// LOCAL client → today's behaviour. This is the documented boundary of the
-	// remote-zone build: VPC networking for a remote zone is deferred behind this
-	// explicit error rather than silently misrouting to the local cluster.
+	// client built by NewRemoteClient. For such a client c.dynamic is nil but the
+	// access seam is an agent-only Routed accessor, so the ONBOARDED CRD lifecycle
+	// (VPC/Subnet/NAD create/get/delete) DOES route through the zone's agent —
+	// every such method runs its k8s I/O through c.access, never c.dynamic. Only
+	// the VPC network plumbing (NAT/per-VPC DNS/CoreDNS, ACL/route/peering patches,
+	// NSG, namespace/quota provisioning, stuck-finalizer recovery) remains
+	// local-only for a remote zone and returns a clear localOnlyErr instead of
+	// dereferencing the nil dynamic client. Empty for the LOCAL client → today's
+	// behaviour. This is the documented boundary of the remote-zone build: the CRD
+	// lifecycle reaches the agent; the plumbing is deferred behind an explicit
+	// error rather than silently misrouting to the local cluster.
 	remoteRegion, remoteZone string
 }
 
-// localOnlyErr is returned by a REMOTE client's NetworkProvider methods. dc-api
-// holds no kubeconfig for a remote zone, and the kubeovn lifecycle still leans on
-// c.dynamic for the NAD/ACL/route/NAT/DNS plumbing that has no agent path. Per
-// the design, remote-zone VPC networking is deferred behind this clear error.
+// localOnlyErr is returned by a REMOTE client's PLUMBING methods (NAT, per-VPC
+// DNS/CoreDNS, ACL/route/peering patches, NSG, namespace/quota provisioning,
+// stuck-finalizer recovery). dc-api holds no kubeconfig for a remote zone and
+// those operations lean on c.dynamic for GVRs that the agent's mapper/RBAC do
+// not onboard. The onboarded CRD lifecycle (VPC/Subnet/NAD create/get/delete)
+// does NOT use this — it routes through c.access to the zone's agent.
 func (c *Client) localOnlyErr(op string) error {
 	return fmt.Errorf(
-		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct KubeOVN credentials there and the VPC network plumbing (NAD/ACL/route/NAT/DNS) is local-only for now",
+		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct KubeOVN credentials there and the VPC network plumbing (NAT/DNS/ACL/route/peering) is local-only for now (the VPC/Subnet/NAD CRD lifecycle does route through the zone's agent)",
 		op, c.remoteRegion, c.remoteZone)
 }
 
 // NewRemoteClient builds a credential-free KubeOVN client for a REMOTE zone. It
-// has NO kubeconfig and NO dynamic client; every NetworkProvider method returns
-// localOnlyErr. region/zone are carried only for clear error messages. This
-// keeps the per-zone resolver uniform (every zone yields a *ProviderSet) while
-// remote-zone networking stays explicitly gated rather than misrouted.
-func NewRemoteClient(region, zone string) *Client {
-	return &Client{remoteRegion: region, remoteZone: zone}
+// has NO kubeconfig and NO dynamic client; the onboarded CRD lifecycle
+// (CreateVNet/GetVNet/DeleteVNet, CreateSubnet/GetSubnet/DeleteSubnet and the
+// NAD create/get/delete inside them) runs through the supplied agent-only
+// Accessor (a clusteraccess.Routed whose Direct fallback is a clusteraccess.
+// NoCreds, so a missing agent fails clearly rather than hitting the local
+// cluster). The VPC network-plumbing methods return localOnlyErr. region/zone
+// are carried only for clear error messages. Mirrors harvester.NewRemoteClient.
+func NewRemoteClient(access clusteraccess.Accessor, region, zone string) *Client {
+	return &Client{
+		// dynamic + restConfig deliberately nil — guarded on plumbing methods.
+		access:       access,
+		remoteRegion: region,
+		remoteZone:   zone,
+	}
 }
 
 // New creates a KubeOVN Client.
@@ -263,6 +276,24 @@ func (c *Client) WithRoutedAccessor(build func(direct clusteraccess.Accessor) cl
 // cluster without re-parsing the kubeconfig.
 func (c *Client) RESTConfig() *rest.Config { return c.restConfig }
 
+// readObj reads an onboarded-CRD object for the readiness/wait polls inside the
+// CRD lifecycle (the NAD-ready poll in CreateSubnet, the subnet-gone poll in
+// DeleteSubnet). For the LOCAL client (c.dynamic != nil) it reads the dynamic
+// client DIRECTLY — byte-identical to the pre-seam behaviour, never inflating the
+// agent traffic with a tight readiness poll. For a REMOTE client (c.dynamic ==
+// nil) there is no local kubeconfig, so it routes the read through c.access (the
+// agent-only accessor). gvr must be an onboarded family (vpc/subnet/nad) so the
+// remote path is routable; the namespace is "" for cluster-scoped resources.
+func (c *Client) readObj(ctx context.Context, gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+	if c.dynamic != nil {
+		if ns == "" {
+			return c.dynamic.Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+		}
+		return c.dynamic.Resource(gvr).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	}
+	return c.access.Get(ctx, gvr, ns, name, metav1.GetOptions{})
+}
+
 // ── VNet ─────────────────────────────────────────────────────────────────────
 
 // CreateVNet provisions a KubeOVN Vpc CRD.
@@ -277,9 +308,8 @@ func (c *Client) RESTConfig() *rest.Config { return c.restConfig }
 // determines the Kubernetes namespace: "dc-<tenant>-<project>". The namespace
 // must already exist (created by the project handler via EnsureProjectNamespace).
 func (c *Client) CreateVNet(ctx context.Context, tenantID, projectID string, spec models.VNetSpec) (*models.VNetResource, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("CreateVNet")
-	}
+	// No c.dynamic guard: the only k8s I/O below is c.access.Create on the
+	// onboarded vpcGVR, which routes to the agent on a remote client.
 	ns := common.NamespaceForProject(tenantID, projectID)
 
 	vpc := &unstructured.Unstructured{
@@ -336,9 +366,8 @@ func (c *Client) CreateVNet(ctx context.Context, tenantID, projectID string, spe
 
 // GetVNet returns the current provider state of a VNet.
 func (c *Client) GetVNet(ctx context.Context, backendUID string) (*models.VNetResource, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("GetVNet")
-	}
+	// No c.dynamic guard: the only k8s I/O is c.access.Get on the onboarded
+	// vpcGVR, which routes to the agent on a remote client.
 	// Cluster-scoped → ns="". Routes via the agent only under DCAPI_AGENT_ROUTE_READS
 	// + a live agent; otherwise the byte-identical Direct Get.
 	obj, err := c.access.Get(ctx, vpcGVR, "", backendUID, metav1.GetOptions{})
@@ -362,9 +391,8 @@ func (c *Client) GetVNet(ctx context.Context, backendUID string) (*models.VNetRe
 // delete child subnets before calling DeleteVNet.  This driver does NOT
 // force-remove finalizers.
 func (c *Client) DeleteVNet(ctx context.Context, backendUID string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("DeleteVNet")
-	}
+	// No c.dynamic guard: the only k8s I/O is c.access.Delete on the onboarded
+	// vpcGVR, which routes to the agent on a remote client.
 	// Cluster-scoped → ns="". Routes via the agent only under DCAPI_AGENT_ROUTE_WRITES
 	// + a live agent; otherwise the byte-identical Direct Delete.
 	err := c.access.Delete(ctx, vpcGVR, "", backendUID, metav1.DeleteOptions{})
@@ -393,12 +421,14 @@ func (c *Client) DeleteVNet(ctx context.Context, backendUID string) error {
 //
 // vnetUID is the KubeOVN Vpc CRD name (the backendUID of the parent VNet row).
 func (c *Client) CreateSubnet(ctx context.Context, vnetUID string, spec models.SubnetSpec) (*models.SubnetResource, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("CreateSubnet")
-	}
+	// No c.dynamic guard: every k8s op in the create lifecycle (parent VPC read,
+	// NAD create + readiness wait, Subnet create, rollback deletes) goes through
+	// c.access on an onboarded GVR (vpc/nad/subnet), so it routes to the agent on
+	// a remote client.
 	// Derive tenant namespace from the Vpc name ("vnet-<name>-<tenantID>" → extract tenantID).
-	// The Vpc CRD holds a dc-api/tenant label — fetch it rather than parsing.
-	vpcObj, err := c.dynamic.Resource(vpcGVR).Get(ctx, vnetUID, metav1.GetOptions{})
+	// The Vpc CRD holds a dc-api/tenant label — fetch it rather than parsing. Use
+	// c.access (vpcGVR is onboarded) so the remote client routes this read.
+	vpcObj, err := c.access.Get(ctx, vpcGVR, "", vnetUID, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("create subnet: fetch parent vpc %q: %w", vnetUID, err)
 	}
@@ -525,9 +555,8 @@ func (c *Client) CreateSubnet(ctx context.Context, vnetUID string, spec models.S
 
 // GetSubnet returns the current provider state of a Subnet.
 func (c *Client) GetSubnet(ctx context.Context, backendUID string) (*models.SubnetResource, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("GetSubnet")
-	}
+	// No c.dynamic guard: the only k8s I/O is c.access.Get on the onboarded
+	// subnetGVR, which routes to the agent on a remote client.
 	// Cluster-scoped → ns="". Routes via the agent under DCAPI_AGENT_ROUTE_READS
 	// + a live agent; otherwise the byte-identical Direct Get.
 	obj, err := c.access.Get(ctx, subnetGVR, "", backendUID, metav1.GetOptions{})
@@ -550,9 +579,12 @@ func (c *Client) GetSubnet(ctx context.Context, backendUID string) (*models.Subn
 // finalizer blocks deletion while consumers exist).  The caller ensures VMs
 // detach first; the driver patches ACLs to empty before issuing the delete.
 func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("DeleteSubnet")
-	}
+	// No c.dynamic guard: the Subnet/NAD delete lifecycle (subnet read, subnet
+	// delete, NAD delete) runs through c.access on onboarded GVRs, so it routes to
+	// the agent on a remote client. The local-only plumbing within (ACL clear and
+	// the stuck-finalizer self-heal, which need non-onboarded ips/pods verbs and
+	// raw Patch) is each individually guarded by `c.dynamic != nil` below and is
+	// simply skipped for a remote zone.
 	// First: fetch the subnet to find the tenant namespace (for the NAD).
 	// Cluster-scoped → ns="". This Get is the leading read of the delete lifecycle,
 	// so it routes with the same accessor as the Delete below (under the reads
@@ -572,7 +604,8 @@ func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
 		// Read the parent VPC to get the project label.
 		parentVnet, _, _ := unstructured.NestedString(obj.Object, "metadata", "labels", "dc-api/parent-vnet")
 		if parentVnet != "" {
-			if vpcObj, err2 := c.dynamic.Resource(vpcGVR).Get(ctx, parentVnet, metav1.GetOptions{}); err2 == nil {
+			// vpcGVR is onboarded → use c.access so the remote client routes this read.
+			if vpcObj, err2 := c.access.Get(ctx, vpcGVR, "", parentVnet, metav1.GetOptions{}); err2 == nil {
 				projectID, _, _ = unstructured.NestedString(vpcObj.Object, "metadata", "labels", "dc-api/project")
 			}
 		}
@@ -585,9 +618,14 @@ func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
 		}
 	}
 
-	// Clear ACLs before deleting to avoid finalizer deadlock (gotcha 4).
-	if err := c.patchSubnetACLs(ctx, backendUID, []interface{}{}); err != nil {
-		log.Warn().Err(err).Str("subnet", backendUID).Msg("kubeovn: failed to clear ACLs before subnet delete; proceeding anyway")
+	// Clear ACLs before deleting to avoid finalizer deadlock (gotcha 4). This is a
+	// local-only plumbing patch (ACL Patch on the Subnet is not a routed verb), so
+	// skip it on a remote client (c.dynamic == nil) — the agent-side delete of an
+	// onboarded Subnet handles its own finalizers.
+	if c.dynamic != nil {
+		if err := c.patchSubnetACLs(ctx, backendUID, []interface{}{}); err != nil {
+			log.Warn().Err(err).Str("subnet", backendUID).Msg("kubeovn: failed to clear ACLs before subnet delete; proceeding anyway")
+		}
 	}
 
 	// Delete the Subnet CRD. Cluster-scoped → ns="". This is the PRIMARY delete verb
@@ -607,7 +645,9 @@ func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
 	defer cancel()
 	stuck := false
 	for {
-		_, err := c.dynamic.Resource(subnetGVR).Get(ctx, backendUID, metav1.GetOptions{})
+		// readObj: DIRECT on the local client (byte-identical), routed through the
+		// agent on a remote client (c.dynamic == nil).
+		_, err := c.readObj(ctx, subnetGVR, "", backendUID)
 		if k8serrors.IsNotFound(err) {
 			break
 		}
@@ -634,7 +674,12 @@ func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
 	// When the pre-check passes, the trade is debuggable orphan logical
 	// switch (scrub via `kubectl ko nbctl ls-del`) vs permanently wedged
 	// tenant namespace. We pick orphan switch.
-	if stuck {
+	//
+	// Local-only: the recovery lists ips (ipGVR, not onboarded) and raw-Patches
+	// the Subnet finalizers (Patch is not a routed verb), so it needs c.dynamic.
+	// A remote client (c.dynamic == nil) skips it; the agent-side Subnet delete is
+	// responsible for its own finalizer convergence in that zone.
+	if stuck && c.dynamic != nil {
 		// Ownership guard: only force-remove finalizers on a Subnet we created.
 		// The caller's chain (handler reads DB row, passes BackendUID) already
 		// ensures this — but a hand-crafted name collision or a future
@@ -695,11 +740,18 @@ func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
 	// then force-remove the NAD finalizer only when (1) the NAD didn't
 	// drain on its own, (2) it carries the dc-api/managed=true ownership
 	// label, and (3) no pod still references it via Multus annotation.
-	if err := c.forceRemoveNADFinalizerIfStuck(ctx, ns, backendUID); err != nil {
-		// Log only — primary subnet/NAD delete already issued; the namespace
-		// teardown caller will surface this if it actually blocks.
-		log.Warn().Err(err).Str("nad", backendUID).Str("ns", ns).
-			Msg("kubeovn: NAD finalizer cleanup encountered an issue")
+	//
+	// Local-only: this self-heal lists pods (podGVR, not onboarded) and raw-
+	// Patches the NAD finalizers, so it needs c.dynamic. A remote client
+	// (c.dynamic == nil) skips it; the agent-side NAD delete converges finalizers
+	// in that zone.
+	if c.dynamic != nil {
+		if err := c.forceRemoveNADFinalizerIfStuck(ctx, ns, backendUID); err != nil {
+			// Log only — primary subnet/NAD delete already issued; the namespace
+			// teardown caller will surface this if it actually blocks.
+			log.Warn().Err(err).Str("nad", backendUID).Str("ns", ns).
+				Msg("kubeovn: NAD finalizer cleanup encountered an issue")
+		}
 	}
 
 	return nil
@@ -1431,7 +1483,9 @@ func (c *Client) waitForNADReady(ctx context.Context, ns, nadName string) error 
 	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	for {
-		obj, err := c.dynamic.Resource(nadGVR).Namespace(ns).Get(ctx, nadName, metav1.GetOptions{})
+		// readObj: DIRECT on the local client (byte-identical readiness poll),
+		// routed through the agent on a remote client (c.dynamic == nil).
+		obj, err := c.readObj(ctx, nadGVR, ns, nadName)
 		if err != nil {
 			return fmt.Errorf("get NAD %s/%s: %w", ns, nadName, err)
 		}

--- a/dc-api/internal/providers/kubeovn/remote_client_test.go
+++ b/dc-api/internal/providers/kubeovn/remote_client_test.go
@@ -1,0 +1,313 @@
+package kubeovn
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+	"github.com/wso2/dc-api/internal/providers/common"
+)
+
+// This file proves the GAP this slice closes: a REMOTE kubeovn client
+// (NewRemoteClient, c.dynamic == nil) routes the ONBOARDED CRD lifecycle
+// (Vpc/Subnet/NAD create/get/delete) through its agent-only Accessor instead of
+// returning a local-only error — while the VPC network PLUMBING (NAT/DNS/ACL/
+// route/peering) still returns localOnlyErr. It also proves a remote client built
+// with a NoCreds-only accessor (no agent) fails CLOSED with a clear "no agent
+// connected" error rather than nil-dereferencing c.dynamic.
+//
+// The remote client has c.dynamic == nil by construction, so these tests are the
+// regression guard against re-introducing a `c.dynamic == nil` guard on a routed
+// CRD method (which would re-open the gap) AND against a stray c.dynamic.Resource
+// call on the routed path (which would panic on the nil client).
+
+// ── A GVR-aware fake agent accessor for the remote-client path ───────────────
+//
+// Unlike netCountingAccessor (which always returns a Subnet shape), this accessor
+// returns the object shape the routed CRD lifecycle reads: a Vpc with the
+// tenant/project labels for CreateSubnet's parent fetch, a NAD already stamped
+// network.harvesterhci.io/ready=true so waitForNADReady returns immediately, and
+// a labelled Subnet for the DeleteSubnet leading read. Create/Delete just count.
+type remoteAgentAccessor struct {
+	mu          sync.Mutex
+	getCalls    int
+	createCalls int
+	deleteCalls int
+
+	// getGVRs records the GVRs Get was called with, so a test can assert the
+	// routed reads (e.g. the onboarded vpc/subnet/nad) actually went through here.
+	getGVRs []schema.GroupVersionResource
+
+	// deleted records names the agent has deleted, so a subsequent Get on that
+	// name returns NotFound — letting DeleteSubnet's "wait for subnet gone" loop
+	// exit immediately instead of timing out (the agent honours the webhook
+	// finalizer ordering, but for the unit test the delete is synchronous).
+	deleted map[string]bool
+}
+
+var _ clusteraccess.Accessor = (*remoteAgentAccessor)(nil)
+
+func (a *remoteAgentAccessor) Get(_ context.Context, gvr schema.GroupVersionResource, ns, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	a.mu.Lock()
+	a.getCalls++
+	a.getGVRs = append(a.getGVRs, gvr)
+	gone := a.deleted[name]
+	a.mu.Unlock()
+
+	if gone {
+		return nil, k8serrors.NewNotFound(gvr.GroupResource(), name)
+	}
+
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": name, "namespace": ns,
+			"labels": map[string]interface{}{
+				"dc-api/managed": "true",
+				"dc-api/tenant":  "tenant",
+				"dc-api/project": "proj",
+			},
+		},
+	}
+	switch gvr {
+	case vpcGVR:
+		obj["apiVersion"] = "kubeovn.io/v1"
+		obj["kind"] = "Vpc"
+	case subnetGVR:
+		obj["apiVersion"] = "kubeovn.io/v1"
+		obj["kind"] = "Subnet"
+	case nadGVR:
+		obj["apiVersion"] = "k8s.cni.cncf.io/v1"
+		obj["kind"] = "NetworkAttachmentDefinition"
+		// waitForNADReady polls for this label — stamp it so the wait returns now.
+		labels := obj["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
+		labels["network.harvesterhci.io/ready"] = "true"
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
+}
+
+func (a *remoteAgentAccessor) List(_ context.Context, _ schema.GroupVersionResource, _ string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+
+func (a *remoteAgentAccessor) Create(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	a.mu.Lock()
+	a.createCalls++
+	a.mu.Unlock()
+	return obj, nil
+}
+
+func (a *remoteAgentAccessor) Apply(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ string, _ bool) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *remoteAgentAccessor) Update(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *remoteAgentAccessor) Delete(_ context.Context, _ schema.GroupVersionResource, _, name string, _ metav1.DeleteOptions) error {
+	a.mu.Lock()
+	a.deleteCalls++
+	if a.deleted == nil {
+		a.deleted = map[string]bool{}
+	}
+	a.deleted[name] = true
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *remoteAgentAccessor) getCount() int    { a.mu.Lock(); defer a.mu.Unlock(); return a.getCalls }
+func (a *remoteAgentAccessor) createCount() int { a.mu.Lock(); defer a.mu.Unlock(); return a.createCalls }
+func (a *remoteAgentAccessor) deleteCount() int { a.mu.Lock(); defer a.mu.Unlock(); return a.deleteCalls }
+
+func (a *remoteAgentAccessor) sawGet(gvr schema.GroupVersionResource) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, g := range a.getGVRs {
+		if g == gvr {
+			return true
+		}
+	}
+	return false
+}
+
+// ── Remote CRD lifecycle routes through the agent accessor ───────────────────
+
+func TestRemoteClient_CreateVNet_RoutesThroughAgent(t *testing.T) {
+	agent := &remoteAgentAccessor{}
+	c := NewRemoteClient(agent, "lk", "laptop")
+	if c.dynamic != nil {
+		t.Fatal("remote client must have a nil dynamic client")
+	}
+
+	res, err := c.CreateVNet(context.Background(), "tenant", "proj", sampleVNetSpec())
+	if err != nil {
+		t.Fatalf("CreateVNet error: %v", err)
+	}
+	if res.Status != models.StatusPending {
+		t.Errorf("status = %q, want PENDING", res.Status)
+	}
+	if got := agent.createCount(); got != 1 {
+		t.Errorf("agent Create called %d times, want 1 (the Vpc create)", got)
+	}
+}
+
+func TestRemoteClient_GetVNet_RoutesThroughAgent(t *testing.T) {
+	agent := &remoteAgentAccessor{}
+	c := NewRemoteClient(agent, "lk", "laptop")
+
+	res, err := c.GetVNet(context.Background(), "vnet-tenant-proj-app")
+	if err != nil {
+		t.Fatalf("GetVNet error: %v", err)
+	}
+	if res.BackendUID != "vnet-tenant-proj-app" {
+		t.Errorf("BackendUID = %q, want vnet-tenant-proj-app", res.BackendUID)
+	}
+	if !agent.sawGet(vpcGVR) {
+		t.Error("agent Get was not called with vpcGVR — the VNet read did not route")
+	}
+}
+
+func TestRemoteClient_DeleteVNet_RoutesThroughAgent(t *testing.T) {
+	agent := &remoteAgentAccessor{}
+	c := NewRemoteClient(agent, "lk", "laptop")
+
+	if err := c.DeleteVNet(context.Background(), "vnet-tenant-proj-app"); err != nil {
+		t.Fatalf("DeleteVNet error: %v", err)
+	}
+	if got := agent.deleteCount(); got != 1 {
+		t.Errorf("agent Delete called %d times, want 1 (the Vpc delete)", got)
+	}
+}
+
+func TestRemoteClient_CreateSubnet_RoutesThroughAgent(t *testing.T) {
+	agent := &remoteAgentAccessor{}
+	c := NewRemoteClient(agent, "lk", "laptop")
+
+	vnetUID := vpcName("app", "tenant", "proj")
+	res, err := c.CreateSubnet(context.Background(), vnetUID, sampleSubnetSpec())
+	if err != nil {
+		t.Fatalf("CreateSubnet error: %v", err)
+	}
+	if res.Status != models.StatusPending {
+		t.Errorf("status = %q, want PENDING", res.Status)
+	}
+	// Parent-VPC fetch (vpcGVR Get) and NAD-ready poll (nadGVR Get) must route.
+	if !agent.sawGet(vpcGVR) {
+		t.Error("parent VPC fetch did not route through the agent (vpcGVR Get missing)")
+	}
+	if !agent.sawGet(nadGVR) {
+		t.Error("NAD readiness poll did not route through the agent (nadGVR Get missing)")
+	}
+	// NAD create + Subnet create both route through the agent.
+	if got := agent.createCount(); got != 2 {
+		t.Errorf("agent Create called %d times, want 2 (NAD + Subnet)", got)
+	}
+}
+
+func TestRemoteClient_DeleteSubnet_RoutesThroughAgent(t *testing.T) {
+	agent := &remoteAgentAccessor{}
+	c := NewRemoteClient(agent, "lk", "laptop")
+
+	if err := c.DeleteSubnet(context.Background(), "subnet-tenant-proj-app-sub"); err != nil {
+		t.Fatalf("DeleteSubnet error: %v", err)
+	}
+	// Leading Subnet read + the post-delete wait-loop read both route.
+	if !agent.sawGet(subnetGVR) {
+		t.Error("Subnet read did not route through the agent (subnetGVR Get missing)")
+	}
+	// Subnet delete + NAD delete both route through the agent; the local-only ACL
+	// clear and stuck-finalizer recovery (c.dynamic) are skipped for a remote zone.
+	if got := agent.deleteCount(); got != 2 {
+		t.Errorf("agent Delete called %d times, want 2 (Subnet + NAD)", got)
+	}
+}
+
+// ── Remote PLUMBING methods stay local-only ──────────────────────────────────
+
+func TestRemoteClient_PlumbingMethods_ReturnLocalOnlyErr(t *testing.T) {
+	agent := &remoteAgentAccessor{}
+	c := NewRemoteClient(agent, "lk", "laptop")
+	ctx := context.Background()
+
+	t.Run("CreateRouteTable", func(t *testing.T) {
+		_, err := c.CreateRouteTable(ctx, "vnet-tenant-proj-app", models.RouteTableSpec{
+			Routes: []models.RouteRule{{Name: "default", DestinationCIDR: "0.0.0.0/0", NextHopType: "virtual_appliance", NextHopIP: "10.0.0.1"}},
+		})
+		assertLocalOnlyErr(t, err, "lk", "laptop")
+	})
+	t.Run("UpdateRouteTableRoutes", func(t *testing.T) {
+		err := c.UpdateRouteTableRoutes(ctx, "vnet-tenant-proj-app/rt-uuid", nil)
+		assertLocalOnlyErr(t, err, "lk", "laptop")
+	})
+	t.Run("CreatePeering", func(t *testing.T) {
+		_, err := c.CreatePeering(ctx, "vnet-a", "vnet-b", models.PeeringSpec{})
+		assertLocalOnlyErr(t, err, "lk", "laptop")
+	})
+	t.Run("CreatePrivateDnsZone", func(t *testing.T) {
+		_, err := c.CreatePrivateDnsZone(ctx, "vnet-tenant-proj-app", models.DnsZoneSpec{})
+		assertLocalOnlyErr(t, err, "lk", "laptop")
+	})
+	t.Run("UpsertDnsRecord", func(t *testing.T) {
+		err := c.UpsertDnsRecord(ctx, "zone-uuid", models.DnsRecord{})
+		assertLocalOnlyErr(t, err, "lk", "laptop")
+	})
+
+	// None of the plumbing methods should have touched the agent.
+	if got := agent.createCount() + agent.deleteCount() + agent.getCount(); got != 0 {
+		t.Errorf("plumbing methods touched the agent %d times, want 0", got)
+	}
+}
+
+// ── Remote client with NO agent fails closed (NoCreds) ───────────────────────
+
+func TestRemoteClient_NoAgent_FailsClosedOnCRDOp(t *testing.T) {
+	// Mirror buildRemoteSet with NO live agent: the Routed decision always declines,
+	// so the accessor falls back to NoCreds — which must error clearly, never panic.
+	noCreds := clusteraccess.NewNoCreds("lk", "laptop")
+	routed := clusteraccess.NewRouted(noCreds, func(clusteraccess.Verb, schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
+		return nil, false // no agent connected
+	})
+	c := NewRemoteClient(routed, "lk", "laptop")
+
+	_, err := c.CreateVNet(context.Background(), "tenant", "proj", sampleVNetSpec())
+	if err == nil {
+		t.Fatal("CreateVNet returned nil error with no agent; it must fail closed")
+	}
+	if !strings.Contains(err.Error(), "no agent connected for zone lk/laptop") {
+		t.Errorf("error = %q, want it to name the zone and the no-agent cause", err.Error())
+	}
+
+	if err := c.DeleteVNet(context.Background(), "vnet-tenant-proj-app"); err == nil {
+		t.Fatal("DeleteVNet returned nil error with no agent; it must fail closed")
+	}
+
+	if _, err := c.GetVNet(context.Background(), "vnet-tenant-proj-app"); err == nil {
+		t.Fatal("GetVNet returned nil error with no agent; it must fail closed")
+	}
+}
+
+func assertLocalOnlyErr(t *testing.T, err error, region, zone string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a local-only error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, region+"/"+zone) {
+		t.Errorf("error = %q, want it to name the zone %s/%s", msg, region, zone)
+	}
+	if !strings.Contains(msg, "remote zone") {
+		t.Errorf("error = %q, want it to be a remote-zone local-only error", msg)
+	}
+}
+
+// Keep common imported (used by sibling seam tests via shared helpers); referenced
+// here to document the namespace convention the remote agent shape mirrors.
+var _ = common.NamespaceForProject

--- a/dc-api/internal/providers/registry.go
+++ b/dc-api/internal/providers/registry.go
@@ -308,12 +308,13 @@ func (r *Registry) buildLocalSet(cfg *config.Config) (*ProviderSet, error) {
 // kubeconfig for the zone, so:
 //
 //   - Compute/Network are credential-free clients (harvester.NewRemoteClient /
-//     kubeovn.NewRemoteClient). The harvester client routes the VM-object CRUD
-//     lifecycle through a Routed accessor bound to THIS zone, whose Direct
-//     fallback is a clusteraccess.NoCreds — so a missing agent yields a clear
-//     "no agent connected for zone" error, never a silent hit on the LOCAL
-//     cluster. The kubeovn remote client defers networking behind a clear
-//     local-only error (the network plumbing has no agent path yet).
+//     kubeovn.NewRemoteClient). Both are given a Routed accessor bound to THIS
+//     zone whose Direct fallback is a clusteraccess.NoCreds — so a missing agent
+//     yields a clear "no agent connected for zone" error, never a silent hit on
+//     the LOCAL cluster. The harvester client routes the VM-object CRUD lifecycle
+//     through it; the kubeovn client routes the onboarded CRD lifecycle (VPC/
+//     Subnet/NAD create/get/delete) through it, while the VPC network plumbing
+//     (NAT/DNS/ACL/route/peering) stays local-only behind a clear error.
 //   - Cluster is the SAME global Rancher client every zone shares.
 //
 // buildRemoteSet performs NO network I/O (no kubeconfig to dial), so it is safe
@@ -327,7 +328,7 @@ func (r *Registry) buildRemoteSet(region, zone string) *ProviderSet {
 	return &ProviderSet{
 		Compute: harvester.NewRemoteClient(remoteAccessor, region, zone),
 		Cluster: r.cluster, // global Rancher
-		Network: kubeovn.NewRemoteClient(region, zone),
+		Network: kubeovn.NewRemoteClient(remoteAccessor, region, zone),
 	}
 }
 


### PR DESCRIPTION
## What this changes

The Harvester remote client routes VM CRUD through a per-zone agent accessor, but the KubeOVN remote client took no accessor — every `NetworkProvider` method returned a local-only error. So for any non-local zone (and the local zone in multi-zone mode), VPC/Subnet/NAD operations all failed even though the agent can carry them. This gives the remote KubeOVN client the same agent accessor the Harvester client already gets, and routes the onboarded CRD lifecycle (VPC/Subnet/NAD create/get/delete) through it.

This is the follow-up flagged on the zones-enabled change: it completes the network half of remote-zone routing, so multi-zone mode can create networks, not just VMs.

## What routes vs what stays local-only

- **Routes through the agent now:** the VPC/Subnet/NAD CRD lifecycle — create, get, delete (the verbs the agent's RBAC and mapper already onboard). On a remote client these go through the access seam, which reaches the zone's agent or fails closed with a clear "no agent connected for zone" error — never a silent hit on the local cluster.
- **Stays local-only (deferred):** the VPC network *plumbing* — NAT, per-VPC DNS, ACL/route/peering patches, NSG, and the stuck-finalizer self-heal. These use verbs the agent doesn't onboard yet, so each is guarded to run only when the direct client is present and is skipped for a remote zone (the agent-side delete converges its own finalizers there).

## Single-cluster path is byte-identical

The guard that was removed was already false for a local (direct) client, so removing it changes nothing locally. The readiness polls (NAD-ready, subnet-gone) now go through a small helper that reads the direct client unchanged when it's present and only routes when it's absent — so the local poll behavior is identical. Two existing toggle-off seam tests confirm this.

## How to verify

`go build`, `go vet`, and race-enabled provider tests pass. New remote-client tests cover routed CRD CRUD reaching a fake agent, plumbing methods still returning a clear local-only error, and a fail-closed error when no agent is connected. The live integration suite needs a real second-zone agent and wasn't run here — a live provisioning check through an actual agent is the remaining gate before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote-zone networking actions now work through the agent-backed path, allowing VPC, Subnet, and NAD lifecycle operations to complete remotely.
  * Readiness checks and delete polling now behave correctly for remote clients.

* **Bug Fixes**
  * Improved remote-client behavior when local dynamic access is unavailable, avoiding failures for supported CRD operations.
  * Remote operations now fail with clearer errors when no agent is connected, instead of breaking unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->