### PR TITLE
[Feature] Add a full-object Get op to the agent protocol

### DIFF
--- a/dc-agent/internal/executor/executor.go
+++ b/dc-agent/internal/executor/executor.go
@@ -31,6 +31,14 @@ const (
 	// selector, returning the whole collection. It is the generic analogue of the
 	// hard-coded get_inventory collection read, addressable for any GVK.
 	OpList = "list" // list objects of a GVK in a namespace, optional selector
+
+	// OpGetObject is the generic full-object GET verb: read ONE object of a GVK by
+	// namespace + name and return it VERBATIM (the whole object, spec + status +
+	// metadata), unlike get_status which returns only the .status subobject. It is
+	// the read primitive the read-modify-patch write ops (NAT/DNS/cloud-provider
+	// SA) need — they read .spec/.data to modify it. Additive and sibling to
+	// get_status; both use the same on-cluster k8s `get`.
+	OpGetObject = "get_object"
 )
 
 // Inventory is a snapshot of the zone cluster's capacity, returned by
@@ -80,6 +88,19 @@ type ListRef struct {
 // client returned it). dc-api re-hydrates them into an *unstructured.UnstructuredList.
 type ListResult struct {
 	Items []json.RawMessage `json:"items"`
+}
+
+// GetObjectResult is the result of a get_object op: the matched object
+// serialized VERBATIM as JSON (the whole object — spec, status, metadata — as
+// the dynamic client returned it), or Found=false when the object is absent.
+// dc-api re-hydrates Object into an *unstructured.Unstructured. Mirrors how
+// ListResult carries raw object JSON, but for a single object. A missing object
+// is success (Found=false, Object omitted) — the same not-found-is-success
+// contract get_status uses, so a poller can ask "gone yet?" without treating a
+// 404 as a failure.
+type GetObjectResult struct {
+	Found  bool            `json:"found"`
+	Object json.RawMessage `json:"object,omitempty"`
 }
 
 // ApplyResult is the result of a server-side apply: the applied object's
@@ -136,6 +157,12 @@ type Executor interface {
 	// returned (no paging) — the generic analogue of get_inventory's VM list.
 	List(ctx context.Context, ref ListRef) (ListResult, error)
 
+	// GetObject reads ONE referenced object and returns it VERBATIM (spec +
+	// status + metadata), unlike GetStatus which returns only .status. A missing
+	// object is success (GetObjectResult{Found:false}). It is the full-object read
+	// the read-modify-patch write ops need.
+	GetObject(ctx context.Context, ref ResourceRef) (GetObjectResult, error)
+
 	// Apply server-side-applies manifest (a complete Kubernetes object) to the
 	// agent's own cluster, owned by fieldManager (defaults to "dc-api" when
 	// empty). force takes ownership of conflicting fields.
@@ -185,12 +212,13 @@ type Stub struct {
 	Inv Inventory
 	Err error
 
-	ListRes    ListResult
-	ApplyRes   ApplyResult
-	DeleteRes  DeleteResult
-	StatusRes  StatusSnapshot
-	WatchRes   WatchResult
-	WatchEmits []StatusSnapshot // emitted in order (stage "modified") before WatchRes
+	ListRes      ListResult
+	GetObjectRes GetObjectResult
+	ApplyRes     ApplyResult
+	DeleteRes    DeleteResult
+	StatusRes    StatusSnapshot
+	WatchRes     WatchResult
+	WatchEmits   []StatusSnapshot // emitted in order (stage "modified") before WatchRes
 }
 
 // GetInventory returns the stub's configured inventory or error.
@@ -201,6 +229,11 @@ func (s Stub) GetInventory(_ context.Context) (Inventory, error) {
 // List returns the stub's configured ListRes/Err.
 func (s Stub) List(_ context.Context, _ ListRef) (ListResult, error) {
 	return s.ListRes, s.Err
+}
+
+// GetObject returns the stub's configured GetObjectRes/Err.
+func (s Stub) GetObject(_ context.Context, _ ResourceRef) (GetObjectResult, error) {
+	return s.GetObjectRes, s.Err
 }
 
 // Apply returns the stub's configured ApplyRes/Err.

--- a/dc-agent/internal/executor/kube.go
+++ b/dc-agent/internal/executor/kube.go
@@ -337,6 +337,31 @@ func (k *KubeExecutor) GetStatus(ctx context.Context, ref ResourceRef) (StatusSn
 	return snapshotOf(obj)
 }
 
+// GetObject reads the referenced object once and returns it VERBATIM (the whole
+// object — spec, status, metadata — serialized exactly as the dynamic client
+// returned it), unlike GetStatus which returns only the .status subobject. A
+// missing object is success (Found=false), matching get_status's
+// not-found-is-success contract. It shares the resolve path the other
+// single-object verbs use, so a GVK NoMatch / missing name is a BAD_REQUEST.
+func (k *KubeExecutor) GetObject(ctx context.Context, ref ResourceRef) (GetObjectResult, error) {
+	ri, err := k.resolve(ref)
+	if err != nil {
+		return GetObjectResult{}, err
+	}
+	obj, err := ri.Get(ctx, ref.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return GetObjectResult{Found: false}, nil
+		}
+		return GetObjectResult{}, fmt.Errorf("get %s/%s/%s: %w", ref.Kind, ref.Namespace, ref.Name, err)
+	}
+	raw, err := obj.MarshalJSON()
+	if err != nil {
+		return GetObjectResult{}, fmt.Errorf("marshal %s/%s/%s object: %w", ref.Kind, ref.Namespace, ref.Name, err)
+	}
+	return GetObjectResult{Found: true, Object: raw}, nil
+}
+
 // WatchStatus opens a watch on the single named object and calls emit once per
 // observed Added/Modified event, stopping after maxSnapshots events, on
 // ctx.Done(), or when the watch channel closes/errors. It never touches the

--- a/dc-agent/internal/executor/kube_test.go
+++ b/dc-agent/internal/executor/kube_test.go
@@ -601,6 +601,93 @@ func TestKubeExecutorGetStatus_ClusterScoped(t *testing.T) {
 	}
 }
 
+// ── GetObject ───────────────────────────────────────────────────────────────
+
+// TestKubeExecutorGetObject_Found reads a seeded object and asserts the WHOLE
+// object (spec + status + metadata) round-trips verbatim — not just .status.
+func TestKubeExecutorGetObject_Found(t *testing.T) {
+	seed := configMap("cm-1", "tenant-abc", "Running")
+	seed.SetResourceVersion("12345")
+	_ = unstructured.SetNestedField(seed.Object, "value-1", "data", "key-1")
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), seed)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	res, err := k.GetObject(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "cm-1"})
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if !res.Found {
+		t.Fatal("GetObject Found = false, want true")
+	}
+
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(res.Object); err != nil {
+		t.Fatalf("object did not round-trip: %v", err)
+	}
+	if obj.GetName() != "cm-1" || obj.GetNamespace() != "tenant-abc" {
+		t.Errorf("object name/ns = %s/%s, want cm-1/tenant-abc", obj.GetName(), obj.GetNamespace())
+	}
+	if obj.GetResourceVersion() != "12345" {
+		t.Errorf("object resourceVersion = %q, want 12345", obj.GetResourceVersion())
+	}
+	// The full object carries .status AND .data — the spec-equivalent fields a
+	// read-modify-patch op needs. get_status would have dropped .data.
+	if phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase"); phase != "Running" {
+		t.Errorf("object status.phase = %q, want Running", phase)
+	}
+	if val, found, _ := unstructured.NestedString(obj.Object, "data", "key-1"); !found || val != "value-1" {
+		t.Errorf("object data.key-1 = %q (found=%v), want value-1 — full object must carry non-status fields", val, found)
+	}
+}
+
+// TestKubeExecutorGetObject_Absent reads a missing object and asserts the
+// not-found-is-success contract: Found:false, nil error (mirrors get_status).
+func TestKubeExecutorGetObject_Absent(t *testing.T) {
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds())
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	res, err := k.GetObject(context.Background(), ResourceRef{APIVersion: "v1", Kind: "ConfigMap", Namespace: "tenant-abc", Name: "ghost"})
+	if err != nil {
+		t.Fatalf("GetObject of absent object returned error %v, want nil", err)
+	}
+	if res.Found {
+		t.Error("Found = true for an absent object, want false")
+	}
+	if res.Object != nil {
+		t.Errorf("absent result carries an object %s, want nil", res.Object)
+	}
+}
+
+// TestKubeExecutorGetObject_ClusterScoped reads a cluster-scoped object (namespace
+// ignored) — proves the RESTMapper scope branch on the full-object read.
+func TestKubeExecutorGetObject_ClusterScoped(t *testing.T) {
+	vpc := &unstructured.Unstructured{}
+	vpc.SetAPIVersion("kubeovn.io/v1")
+	vpc.SetKind("Vpc")
+	vpc.SetName("vpc-1")
+	_ = unstructured.SetNestedSlice(vpc.Object, []interface{}{"10.0.0.0/16"}, "spec", "namespaces")
+	dc := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), mbListKinds(), vpc)
+	k := NewKubeExecutorWithMapper(fake.NewSimpleClientset(), dc, mbMapper())
+
+	res, err := k.GetObject(context.Background(), ResourceRef{APIVersion: "kubeovn.io/v1", Kind: "Vpc", Namespace: "should-be-ignored", Name: "vpc-1"})
+	if err != nil {
+		t.Fatalf("GetObject cluster-scoped: %v", err)
+	}
+	if !res.Found {
+		t.Fatal("Found = false, want true for cluster-scoped object")
+	}
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(res.Object); err != nil {
+		t.Fatalf("object did not round-trip: %v", err)
+	}
+	if obj.GetName() != "vpc-1" {
+		t.Errorf("object name = %q, want vpc-1", obj.GetName())
+	}
+	if ns, found, _ := unstructured.NestedSlice(obj.Object, "spec", "namespaces"); !found || len(ns) != 1 {
+		t.Errorf("object spec.namespaces = %v (found=%v), want one entry", ns, found)
+	}
+}
+
 // ── List ─────────────────────────────────────────────────────────────────────
 
 // TestKubeExecutorList_Namespaced lists objects of a namespaced kind in one
@@ -743,6 +830,11 @@ func TestKubeExecutor_UnknownKind(t *testing.T) {
 	t.Run("get_status", func(t *testing.T) {
 		if _, err := k.GetStatus(context.Background(), ref); err == nil || !isBadRequestFault(err) {
 			t.Errorf("GetStatus unknown kind err = %v, want BAD_REQUEST fault", err)
+		}
+	})
+	t.Run("get_object", func(t *testing.T) {
+		if _, err := k.GetObject(context.Background(), ref); err == nil || !isBadRequestFault(err) {
+			t.Errorf("GetObject unknown kind err = %v, want BAD_REQUEST fault", err)
 		}
 	})
 	t.Run("watch_status", func(t *testing.T) {

--- a/dc-agent/main.go
+++ b/dc-agent/main.go
@@ -169,7 +169,7 @@ func main() {
 	} else {
 		dispatcher, streamDispatcher = buildDispatchers(exec, logger)
 		logger.Info().
-			Strs("ops", []string{executor.OpGetInventory, executor.OpList, executor.OpApply, executor.OpDelete, executor.OpGetStatus, executor.OpWatchStatus}).
+			Strs("ops", []string{executor.OpGetInventory, executor.OpList, executor.OpGetObject, executor.OpApply, executor.OpDelete, executor.OpGetStatus, executor.OpWatchStatus}).
 			Msg("local-cluster executor ready")
 	}
 
@@ -225,6 +225,23 @@ func buildDispatchers(exec executor.Executor, logger zerolog.Logger) (conn.Dispa
 				Str("label_selector", ref.LabelSelector).
 				Int("items", len(res.Items)).
 				Msg("listed objects")
+			return json.Marshal(res)
+		},
+		executor.OpGetObject: func(ctx context.Context, params json.RawMessage) (json.RawMessage, error) {
+			var ref executor.ResourceRef
+			if err := json.Unmarshal(params, &ref); err != nil {
+				return nil, conn.BadRequest(fmt.Errorf("get_object params: %w", err))
+			}
+			res, err := exec.GetObject(ctx, ref)
+			if err != nil {
+				return nil, err
+			}
+			logger.Info().
+				Str("op", executor.OpGetObject).
+				Str("gvk", ref.APIVersion+"/"+ref.Kind).
+				Str("object", ref.Namespace+"/"+ref.Name).
+				Bool("found", res.Found).
+				Msg("read object")
 			return json.Marshal(res)
 		},
 		executor.OpApply: func(ctx context.Context, params json.RawMessage) (json.RawMessage, error) {

--- a/dc-agent/main.go
+++ b/dc-agent/main.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -168,8 +169,18 @@ func main() {
 		logger.Warn().Err(err).Msg("no local-cluster access; running presence-only (set DCAGENT_KUBECONFIG for local dev)")
 	} else {
 		dispatcher, streamDispatcher = buildDispatchers(exec, logger)
+		// Derive the advertised op list from the registered dispatchers so the log
+		// can't drift from what buildDispatchers actually wired up.
+		ops := make([]string, 0, len(dispatcher)+len(streamDispatcher))
+		for op := range dispatcher {
+			ops = append(ops, op)
+		}
+		for op := range streamDispatcher {
+			ops = append(ops, op)
+		}
+		sort.Strings(ops)
 		logger.Info().
-			Strs("ops", []string{executor.OpGetInventory, executor.OpList, executor.OpGetObject, executor.OpApply, executor.OpDelete, executor.OpGetStatus, executor.OpWatchStatus}).
+			Strs("ops", ops).
 			Msg("local-cluster executor ready")
 	}
 

--- a/dc-agent/main_test.go
+++ b/dc-agent/main_test.go
@@ -33,6 +33,8 @@ type recordingExecutor struct {
 
 	statusRef executor.ResourceRef
 
+	getObjectRef executor.ResourceRef
+
 	watchRef executor.ResourceRef
 	watchMax int
 
@@ -42,6 +44,11 @@ type recordingExecutor struct {
 func (r *recordingExecutor) List(ctx context.Context, ref executor.ListRef) (executor.ListResult, error) {
 	r.listRef = ref
 	return r.Stub.List(ctx, ref)
+}
+
+func (r *recordingExecutor) GetObject(ctx context.Context, ref executor.ResourceRef) (executor.GetObjectResult, error) {
+	r.getObjectRef = ref
+	return r.Stub.GetObject(ctx, ref)
 }
 
 func (r *recordingExecutor) Apply(ctx context.Context, manifest json.RawMessage, fm string, force bool) (executor.ApplyResult, error) {
@@ -257,6 +264,47 @@ func TestBuildDispatchers_GetStatus(t *testing.T) {
 	}
 }
 
+// TestBuildDispatchers_GetObject drives the generic full-object get op end to
+// end: the server sends a get_object req with a GVK/namespace/name, and the test
+// asserts the stub's whole-object result comes back as the res result AND that
+// the executor saw the ResourceRef decoded from the wire field names.
+func TestBuildDispatchers_GetObject(t *testing.T) {
+	object := json.RawMessage(`{"apiVersion":"kubevirt.io/v1","kind":"VirtualMachine","metadata":{"name":"vm-1","namespace":"tenant-abc"},"spec":{"running":true},"status":{"printableStatus":"Running"}}`)
+	exec := &recordingExecutor{Stub: executor.Stub{GetObjectRes: executor.GetObjectResult{Found: true, Object: object}}}
+
+	dispatchHarness(t, exec, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		params := json.RawMessage(`{"api_version":"kubevirt.io/v1","kind":"VirtualMachine","namespace":"tenant-abc","name":"vm-1"}`)
+		res := sendReq(t, ctx, c, "id-getobj", executor.OpGetObject, params)
+		if !res.Ok {
+			t.Fatalf("get_object res not ok: %+v", res)
+		}
+		var got executor.GetObjectResult
+		if err := json.Unmarshal(res.Result, &got); err != nil {
+			t.Fatalf("unmarshal get_object result: %v", err)
+		}
+		if !got.Found {
+			t.Fatalf("get_object result Found = false, want true")
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(got.Object, &obj); err != nil {
+			t.Fatalf("returned object not valid JSON: %v", err)
+		}
+		if obj["kind"] != "VirtualMachine" {
+			t.Errorf("returned object kind = %v, want VirtualMachine", obj["kind"])
+		}
+		// The whole object came back: .spec is present, not just .status.
+		spec, ok := obj["spec"].(map[string]any)
+		if !ok || spec["running"] != true {
+			t.Errorf("returned object spec = %v, want {running:true} — full object, not status-only", obj["spec"])
+		}
+	})
+
+	want := executor.ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "tenant-abc", Name: "vm-1"}
+	if exec.getObjectRef != want {
+		t.Errorf("executor get_object ref = %+v, want %+v", exec.getObjectRef, want)
+	}
+}
+
 // TestBuildDispatchers_List drives the generic list op end to end: the server
 // sends a list req with a GVK/namespace/label selector, and the test asserts the
 // stub's collection comes back as the res result AND that the executor saw the
@@ -375,7 +423,7 @@ func TestBuildDispatchers_BadParams(t *testing.T) {
 
 	dispatchHarness(t, exec, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		bad := json.RawMessage(`"not an object"`)
-		for _, op := range []string{executor.OpList, executor.OpApply, executor.OpDelete, executor.OpGetStatus, executor.OpWatchStatus} {
+		for _, op := range []string{executor.OpList, executor.OpGetObject, executor.OpApply, executor.OpDelete, executor.OpGetStatus, executor.OpWatchStatus} {
 			res := sendReq(t, ctx, c, "id-"+op, op, bad)
 			if res.Ok || res.Error == nil || res.Error.Code != protocol.ErrCodeBadRequest {
 				t.Errorf("%s with bad params res = %+v, want BAD_REQUEST", op, res)
@@ -449,14 +497,14 @@ func TestLoadConfig_TokenStillRequired(t *testing.T) {
 }
 
 // TestBuildDispatchers_RegistersAllOps asserts buildDispatchers wires exactly the
-// five M-B ops: the four request/response verbs in Dispatcher and watch_status in
-// StreamDispatcher. The hello advertisement (the merge of these two maps, sorted)
-// is covered in the conn package's TestAdvertisedOps; here we pin the registration
-// so a verb added to the executor without a handler is caught.
+// request/response verbs in Dispatcher and watch_status in StreamDispatcher. The
+// hello advertisement (the merge of these two maps, sorted) is covered in the
+// conn package's TestAdvertisedOps; here we pin the registration so a verb added
+// to the executor without a handler is caught.
 func TestBuildDispatchers_RegistersAllOps(t *testing.T) {
 	disp, stream := buildDispatchers(&recordingExecutor{}, zerolog.Nop())
 
-	wantRR := []string{executor.OpApply, executor.OpDelete, executor.OpGetInventory, executor.OpGetStatus, executor.OpList}
+	wantRR := []string{executor.OpApply, executor.OpDelete, executor.OpGetInventory, executor.OpGetObject, executor.OpGetStatus, executor.OpList}
 	for _, op := range wantRR {
 		if _, ok := disp[op]; !ok {
 			t.Errorf("Dispatcher missing request/response op %q", op)

--- a/dc-api/internal/agentgw/agentgw.go
+++ b/dc-api/internal/agentgw/agentgw.go
@@ -33,6 +33,12 @@ type Session interface {
 	// selector. The whole collection is returned as raw object JSON for the
 	// caller to re-hydrate into an *unstructured.UnstructuredList.
 	List(ctx context.Context, ref ListRef) (ListResult, error)
+	// GetObject reads the referenced object and returns it VERBATIM (the whole
+	// object — spec + status + metadata) as raw JSON for the caller to re-hydrate
+	// into an *unstructured.Unstructured. A missing object is success
+	// (GetObjectResult.Found == false), not an error. It is the full-object read
+	// (vs GetStatus's status-only read) the read-modify-patch write ops need.
+	GetObject(ctx context.Context, ref ResourceRef) (GetObjectResult, error)
 	// Apply server-side-applies manifest in the agent's zone cluster.
 	Apply(ctx context.Context, manifest json.RawMessage, fieldManager string, force bool) (ApplyResult, error)
 	// Delete removes the referenced object (a missing object is a successful,
@@ -82,6 +88,17 @@ type ListRef struct {
 // *unstructured.UnstructuredList.
 type ListResult struct {
 	Items []json.RawMessage `json:"items"`
+}
+
+// GetObjectResult is the get_object op's result: the matched object serialized
+// VERBATIM as JSON (the whole object — spec, status, metadata), or Found=false
+// when the object is absent (a 404 is success, not an error — the same
+// not-found-is-success contract get_status uses). dc-api re-hydrates Object into
+// an *unstructured.Unstructured. JSON tags are byte-identical to dc-agent's
+// executor.GetObjectResult.
+type GetObjectResult struct {
+	Found  bool            `json:"found"`
+	Object json.RawMessage `json:"object,omitempty"`
 }
 
 // ApplyResult is the apply op's result: the applied object's identity and its

--- a/dc-api/internal/api/handlers/agentchannel.go
+++ b/dc-api/internal/api/handlers/agentchannel.go
@@ -56,6 +56,12 @@ const (
 	// strings are the wire contract with dc-agent; the two are separate Go modules.
 	opList = "list"
 
+	// opGetObject is the generic full-object GET verb: read ONE object by GVK +
+	// namespace/name and return it VERBATIM (spec + status + metadata), unlike
+	// opGetStatus which returns only .status. This exact string is the wire
+	// contract with dc-agent; the two are separate Go modules.
+	opGetObject = "get_object"
+
 	// M-B mutating/status verbs (protocol v1). These exact strings are the wire
 	// contract with dc-agent; the two are separate Go modules.
 	opApply       = "apply"
@@ -123,6 +129,10 @@ type ListRef = agentgw.ListRef
 
 // ListResult is the list op's result: the matched objects as raw object JSON.
 type ListResult = agentgw.ListResult
+
+// GetObjectResult is the get_object op's result: ONE object serialized verbatim
+// as raw JSON (the whole object), or Found=false when the object is absent.
+type GetObjectResult = agentgw.GetObjectResult
 
 // ApplyResult is the apply op's result: the applied object's identity and its
 // post-apply version.
@@ -290,6 +300,27 @@ func (s *Session) List(ctx context.Context, ref ListRef) (ListResult, error) {
 	}
 	if err := json.Unmarshal(raw, &res); err != nil {
 		return ListResult{}, err
+	}
+	return res, nil
+}
+
+// GetObject reads ONE referenced object and returns it VERBATIM (the whole
+// object — spec + status + metadata) as raw JSON, vs GetStatus's status-only
+// read. A missing object yields GetObjectResult{Found: false}, not an error. It
+// mirrors GetStatus's drive pattern: marshal the ResourceRef → Call → unmarshal
+// the raw-object result.
+func (s *Session) GetObject(ctx context.Context, ref ResourceRef) (GetObjectResult, error) {
+	var res GetObjectResult
+	params, err := json.Marshal(ref)
+	if err != nil {
+		return res, err
+	}
+	raw, err := s.Call(ctx, opGetObject, params)
+	if err != nil {
+		return res, err
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return GetObjectResult{}, err
 	}
 	return res, nil
 }

--- a/dc-api/internal/api/handlers/agentchannel_getobject_test.go
+++ b/dc-api/internal/api/handlers/agentchannel_getobject_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+// agentchannel_getobject_test.go — unit tests for the protocol-v1 generic
+// full-object GET verb on the dc-api side: Session.GetObject. Reuses the
+// in-process channel harness from agentchannel_test.go (newTestChannel +
+// runAgent): the test drives the agent end of the socket and returns a crafted
+// res carrying one object (verbatim). No live cluster, no dc-agent package —
+// only the JSON wire contract.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSessionGetObject_Found(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+
+	type seen struct {
+		op  string
+		ref ResourceRef
+	}
+	got := make(chan seen, 1)
+	// The agent returns the whole object (spec + status + metadata), wrapped in a
+	// get_object result with found=true.
+	const result = `{"found":true,"object":` +
+		`{"apiVersion":"kubevirt.io/v1","kind":"VirtualMachine",` +
+		`"metadata":{"name":"vm-1","namespace":"dc-t-p","resourceVersion":"42"},` +
+		`"spec":{"running":true},"status":{"printableStatus":"Running"}}}`
+	tc.runAgent(func(req wsReq) string {
+		var ref ResourceRef
+		_ = json.Unmarshal(req.Params, &ref)
+		got <- seen{op: req.Op, ref: ref}
+		return resOK(req.ID, result)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "dc-t-p", Name: "vm-1"}
+	res, err := tc.sess.GetObject(ctx, ref)
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if !res.Found {
+		t.Fatal("Found = false, want true")
+	}
+
+	// The whole object round-tripped: spec AND status are present.
+	var obj struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Spec   map[string]any `json:"spec"`
+		Status struct {
+			PrintableStatus string `json:"printableStatus"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(res.Object, &obj); err != nil {
+		t.Fatalf("object did not round-trip: %v", err)
+	}
+	if obj.Metadata.Name != "vm-1" {
+		t.Errorf("object name = %q, want vm-1", obj.Metadata.Name)
+	}
+	if obj.Spec["running"] != true {
+		t.Errorf("object spec.running = %v, want true (full object must carry .spec)", obj.Spec["running"])
+	}
+	if obj.Status.PrintableStatus != "Running" {
+		t.Errorf("object status.printableStatus = %q, want Running", obj.Status.PrintableStatus)
+	}
+
+	// The agent saw op=="get_object" with the full ResourceRef (GVK + ns/name).
+	s := <-got
+	if s.op != opGetObject {
+		t.Errorf("agent saw op %q, want %q", s.op, opGetObject)
+	}
+	if s.ref != ref {
+		t.Errorf("ref = %+v, want %+v", s.ref, ref)
+	}
+}
+
+func TestSessionGetObject_Absent(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resOK(req.ID, `{"found":false}`)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "dc-t-p", Name: "ghost"}
+	res, err := tc.sess.GetObject(ctx, ref)
+	if err != nil {
+		t.Fatalf("GetObject of absent object returned error %v, want nil (not-found-is-success)", err)
+	}
+	if res.Found {
+		t.Errorf("Found = true for an absent object, want false")
+	}
+	if len(res.Object) != 0 {
+		t.Errorf("absent result carries an object %s, want none", res.Object)
+	}
+}
+
+func TestSessionGetObject_AgentError(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resErr(req.ID, errCodeExecError, "get failed")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "dc-t-p", Name: "vm-1"}
+	_, err := tc.sess.GetObject(ctx, ref)
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeExecError {
+		t.Errorf("code = %q, want %q", ae.Code, errCodeExecError)
+	}
+}
+
+// TestSessionGetObject_OpUnsupported confirms an older agent that doesn't
+// advertise "get_object" replies ok=false/OP_UNSUPPORTED and the driver surfaces
+// *AgentError with that code — this is the signal AgentBacked.Get keys on to fall
+// back to the status-only get_status during a rolling deploy.
+func TestSessionGetObject_OpUnsupported(t *testing.T) {
+	tc := newTestChannel(t)
+	defer tc.close()
+	tc.runAgent(func(req wsReq) string {
+		return resErr(req.ID, errCodeOpUnsupported, "unknown op")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ref := ResourceRef{APIVersion: "kubevirt.io/v1", Kind: "VirtualMachine", Namespace: "dc-t-p", Name: "vm-1"}
+	_, err := tc.sess.GetObject(ctx, ref)
+	var ae *AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *AgentError, got %v", err)
+	}
+	if ae.Code != errCodeOpUnsupported {
+		t.Errorf("code = %q, want %q", ae.Code, errCodeOpUnsupported)
+	}
+}

--- a/dc-api/internal/api/handlers/agentgw_adapter.go
+++ b/dc-api/internal/api/handlers/agentgw_adapter.go
@@ -7,9 +7,9 @@
 // dependency graph (handlers → agentgw ← clusteraccess ← providers).
 //
 // The widening from *Session to agentgw.Session is free: *Session already
-// satisfies agentgw.Session structurally (its Apply/Delete/GetStatus/
-// WatchStatus signatures match). The only work is turning the concrete return
-// of Registry.Session into the interface type.
+// satisfies agentgw.Session structurally (its List/GetObject/Apply/Delete/
+// GetStatus/WatchStatus signatures match). The only work is turning the concrete
+// return of Registry.Session into the interface type.
 package handlers
 
 import "github.com/wso2/dc-api/internal/agentgw"

--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -150,7 +150,8 @@ func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, 
 		// which translateErr maps to ErrOpNotRoutable. In that one case fall back to
 		// the status-only read so a rolling deploy never errors. Any other error
 		// (agent unavailable, RBAC, timeout) propagates.
-		if errors.Is(a.translateErr(err), agentgw.ErrOpNotRoutable) {
+		terr := a.translateErr(err)
+		if errors.Is(terr, agentgw.ErrOpNotRoutable) {
 			a.log.Info().
 				Str("seam", "agent").
 				Str("region", a.region).Str("zone", a.zone).
@@ -159,7 +160,7 @@ func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, 
 				Msg("agent does not support get_object; falling back to status-only get_status")
 			return a.getStatusFallback(ctx, gvr, ref, ns, name)
 		}
-		return nil, a.translateErr(err)
+		return nil, terr
 	}
 
 	// One INFO log per routed read, at the moment the agent path is chosen — the

--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -129,6 +129,13 @@ func (a *AgentBacked) ref(gvr schema.GroupVersionResource, ns, name string) (age
 // error so callers' existing IsNotFound / "not found" checks fire unchanged on
 // both seams.
 func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	// Routability guard FIRST (mirrors List): a GVR can be GVK-mapped yet not be a
+	// routable family for Get — e.g. the pre-seeded virtualmachineinstances, which
+	// has no RouteVerbs. Refuse rather than issue a read the agent's SA may not be
+	// permitted to serve; the caller falls back to the direct path.
+	if verbs, ok := RoutableVerbs(gvr); !ok || !verbs[VerbGet] {
+		return nil, fmt.Errorf("clusteraccess: get of %s not routable: %w", gvr.String(), agentgw.ErrOpNotRoutable)
+	}
 	ref, err := a.ref(gvr, ns, name)
 	if err != nil {
 		return nil, err

--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -29,10 +29,14 @@ const agentCallTimeout = 30 * time.Second
 // depends on the neutral agentgw.Session interface, never on package handlers,
 // so there is no import cycle.
 //
-// Op coverage: the status-shaped Get maps onto Session.GetStatus (read slice);
-// Create/Update/Apply all map onto Session.Apply and Delete onto Session.Delete
-// (write slice 1 — VM create/delete); List maps onto Session.List (M-D — the
-// generic collection read). All of these verbs are IMPLEMENTED, not stubbed.
+// Op coverage: Get maps onto Session.GetObject (the full-object read — the whole
+// object, spec + status + metadata), with an OP_UNSUPPORTED fallback to
+// Session.GetStatus so an OLDER agent that predates get_object degrades to the
+// prior status-only read instead of erroring (non-breaking during a rolling
+// deploy). Create/Update/Apply all map onto Session.Apply and Delete onto
+// Session.Delete (write slice 1 — VM create/delete); List maps onto Session.List
+// (M-D — the generic collection read). All of these verbs are IMPLEMENTED, not
+// stubbed.
 //
 // NOTE on Create: the agent exposes only server-side apply (Session.Apply) as its
 // create mechanism, so AgentBacked.Create is an SSA, NOT a POST. This is the one
@@ -107,16 +111,23 @@ func (a *AgentBacked) ref(gvr schema.GroupVersionResource, ns, name string) (age
 	return agentgw.ResourceRef{APIVersion: apiVersion, Kind: kind, Namespace: ns, Name: name}, nil
 }
 
-// Get routes a STATUS-only read to Session.GetStatus and synthesizes a partial
-// *unstructured.Unstructured carrying apiVersion, kind, metadata.name/namespace,
-// metadata.resourceVersion, metadata.generation, and status.
+// Get routes a FULL-object read to Session.GetObject and re-hydrates the raw
+// object JSON the agent returns into an *unstructured.Unstructured — the whole
+// object (spec + status + metadata), the same shape Direct.Get returns. This is
+// what the read-modify-patch write ops (NAT/DNS/cloud-provider SA) need: they
+// read .spec/.data to modify it.
 //
-// IMPORTANT: this is sufficient ONLY for callers that read status (e.g. the VM
-// read slice, which reads status.printableStatus). A caller needing spec or
-// metadata beyond name/ns/rv/generation must NOT route via this accessor until a
-// full-object agent read op exists. Found==false is translated to a
-// k8serrors.NewNotFound-shaped error so callers' existing IsNotFound /
-// "not found" string checks fire unchanged on both seams.
+// COMPAT: an OLDER agent that predates get_object replies OP_UNSUPPORTED; this
+// FALLS BACK to Session.GetStatus and synthesizes the prior status-only partial
+// object (apiVersion, kind, metadata.name/namespace, resourceVersion,
+// generation, status). The behavior degrades to the prior status-only read
+// rather than erroring, keeping the change non-breaking during a rolling deploy.
+// Callers that only read status (e.g. the VM read slice's
+// status.printableStatus) are unaffected by which path served them.
+//
+// Found==false (on either path) is translated to a k8serrors.NewNotFound-shaped
+// error so callers' existing IsNotFound / "not found" checks fire unchanged on
+// both seams.
 func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
 	ref, err := a.ref(gvr, ns, name)
 	if err != nil {
@@ -126,8 +137,21 @@ func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, 
 	ctx, cancel := a.bound(ctx)
 	defer cancel()
 
-	snap, err := a.sess.GetStatus(ctx, ref)
+	res, err := a.sess.GetObject(ctx, ref)
 	if err != nil {
+		// An older agent that doesn't implement get_object replies OP_UNSUPPORTED,
+		// which translateErr maps to ErrOpNotRoutable. In that one case fall back to
+		// the status-only read so a rolling deploy never errors. Any other error
+		// (agent unavailable, RBAC, timeout) propagates.
+		if errors.Is(a.translateErr(err), agentgw.ErrOpNotRoutable) {
+			a.log.Info().
+				Str("seam", "agent").
+				Str("region", a.region).Str("zone", a.zone).
+				Str("api_version", ref.APIVersion).Str("kind", ref.Kind).
+				Str("namespace", ref.Namespace).Str("name", ref.Name).
+				Msg("agent does not support get_object; falling back to status-only get_status")
+			return a.getStatusFallback(ctx, gvr, ref, ns, name)
+		}
 		return nil, a.translateErr(err)
 	}
 
@@ -138,15 +162,35 @@ func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, 
 		Str("region", a.region).Str("zone", a.zone).
 		Str("api_version", ref.APIVersion).Str("kind", ref.Kind).
 		Str("namespace", ref.Namespace).Str("name", ref.Name).
-		Bool("found", snap.Found).
+		Bool("found", res.Found).
 		Msg("provider read routed through agent")
 
-	if !snap.Found {
+	if !res.Found {
 		// Shape a NotFound so reconciler delete/fail branches and providers'
 		// idempotent-delete checks fire exactly as on the direct path.
 		return nil, k8serrors.NewNotFound(gvr.GroupResource(), name)
 	}
 
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(res.Object); err != nil {
+		return nil, fmt.Errorf("clusteraccess: decode agent object for %s/%s: %w", ns, name, err)
+	}
+	return obj, nil
+}
+
+// getStatusFallback is the back-compat path Get takes when an older agent does
+// not implement get_object: it issues Session.GetStatus and synthesizes the
+// prior status-only partial object (apiVersion, kind, metadata.name/namespace,
+// resourceVersion, generation, status). It is intentionally the exact shape the
+// pre-get_object Get returned, so a caller that only reads status sees no change.
+func (a *AgentBacked) getStatusFallback(ctx context.Context, gvr schema.GroupVersionResource, ref agentgw.ResourceRef, ns, name string) (*unstructured.Unstructured, error) {
+	snap, err := a.sess.GetStatus(ctx, ref)
+	if err != nil {
+		return nil, a.translateErr(err)
+	}
+	if !snap.Found {
+		return nil, k8serrors.NewNotFound(gvr.GroupResource(), name)
+	}
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": ref.APIVersion,
 		"kind":       ref.Kind,

--- a/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
@@ -23,20 +23,35 @@ var vmGVR = schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Res
 // fakeSession is a hand-written agentgw.Session that returns canned results.
 // Plain interface, no websocket harness needed.
 type fakeSession struct {
+	getObject func(ref agentgw.ResourceRef) (agentgw.GetObjectResult, error)
 	getStatus func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error)
 	list      func(ref agentgw.ListRef) (agentgw.ListResult, error)
 	apply     func(manifest json.RawMessage, fm string, force bool) (agentgw.ApplyResult, error)
 	del       func(ref agentgw.ResourceRef, policy string) (agentgw.DeleteResult, error)
 
-	// block, when true, makes GetStatus wait on ctx.Done() and return ctx.Err()
+	// block, when true, makes GetObject wait on ctx.Done() and return ctx.Err()
 	// — modelling a connected-but-unresponsive agent (the real Session.Call only
 	// returns on a reply or ctx cancellation). Used to prove the accessor bounds
 	// every call with its own deadline.
 	block bool
 
-	lastRef     agentgw.ResourceRef // captured by GetStatus/Delete
+	lastRef     agentgw.ResourceRef // captured by GetObject/GetStatus/Delete
 	lastListRef agentgw.ListRef     // captured by List
 	listCalled  bool                // set true the moment List is invoked
+
+	getStatusCalled bool // set by GetStatus, asserts the OP_UNSUPPORTED fallback fired
+}
+
+func (f *fakeSession) GetObject(ctx context.Context, ref agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+	f.lastRef = ref
+	if f.block {
+		<-ctx.Done()
+		return agentgw.GetObjectResult{}, ctx.Err()
+	}
+	if f.getObject != nil {
+		return f.getObject(ref)
+	}
+	return agentgw.GetObjectResult{}, nil
 }
 
 func (f *fakeSession) List(_ context.Context, ref agentgw.ListRef) (agentgw.ListResult, error) {
@@ -48,12 +63,9 @@ func (f *fakeSession) List(_ context.Context, ref agentgw.ListRef) (agentgw.List
 	return agentgw.ListResult{}, nil
 }
 
-func (f *fakeSession) GetStatus(ctx context.Context, ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+func (f *fakeSession) GetStatus(_ context.Context, ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
 	f.lastRef = ref
-	if f.block {
-		<-ctx.Done()
-		return agentgw.StatusSnapshot{}, ctx.Err()
-	}
+	f.getStatusCalled = true
 	if f.getStatus != nil {
 		return f.getStatus(ref)
 	}
@@ -194,17 +206,19 @@ func TestAgentBackedList_AgentUnavailableIsRetryable(t *testing.T) {
 	}
 }
 
-// ── AgentBacked.Get: status synthesis ─────────────────────────────────────────
+// ── AgentBacked.Get: full-object read (get_object) ────────────────────────────
 
-func TestAgentBackedGet_SynthesizesStatus(t *testing.T) {
+// fullVMObject is a complete VM object JSON (spec + status + metadata) — the
+// shape get_object returns and the read-modify-patch write ops need.
+const fullVMObject = `{"apiVersion":"kubevirt.io/v1","kind":"VirtualMachine",` +
+	`"metadata":{"name":"vm-1","namespace":"dc-t-p","resourceVersion":"12345","generation":7,"uid":"u-1"},` +
+	`"spec":{"running":true,"template":{"spec":{"domain":{"cpu":{"cores":2}}}}},` +
+	`"status":{"printableStatus":"Running"}}`
+
+func TestAgentBackedGet_ReturnsFullObject(t *testing.T) {
 	sess := &fakeSession{
-		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
-			return agentgw.StatusSnapshot{
-				Found:           true,
-				ResourceVersion: "12345",
-				Generation:      7,
-				Status:          json.RawMessage(`{"printableStatus":"Running"}`),
-			}, nil
+		getObject: func(ref agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+			return agentgw.GetObjectResult{Found: true, Object: json.RawMessage(fullVMObject)}, nil
 		},
 	}
 	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
@@ -221,11 +235,20 @@ func TestAgentBackedGet_SynthesizesStatus(t *testing.T) {
 	if sess.lastRef.Namespace != "dc-t-p" || sess.lastRef.Name != "vm-1" {
 		t.Errorf("agent ref ns/name = %s/%s, want dc-t-p/vm-1", sess.lastRef.Namespace, sess.lastRef.Name)
 	}
+	// The full object path must NOT have called GetStatus (no fallback).
+	if sess.getStatusCalled {
+		t.Error("Get fell back to GetStatus when get_object succeeded; it must use the full object")
+	}
 
-	// The synthesized object must carry the status the harvester driver reads.
+	// The full object round-trips: status (as before) AND spec (the new capability
+	// the read-modify-patch ops need).
 	printable, found, _ := unstructured.NestedString(obj.Object, "status", "printableStatus")
 	if !found || printable != "Running" {
 		t.Errorf("status.printableStatus = %q (found=%v), want Running", printable, found)
+	}
+	cores, found, _ := unstructured.NestedInt64(obj.Object, "spec", "template", "spec", "domain", "cpu", "cores")
+	if !found || cores != 2 {
+		t.Errorf("spec.template.spec.domain.cpu.cores = %d (found=%v), want 2 — full object must carry .spec", cores, found)
 	}
 	if rv := obj.GetResourceVersion(); rv != "12345" {
 		t.Errorf("resourceVersion = %q, want 12345", rv)
@@ -238,10 +261,52 @@ func TestAgentBackedGet_SynthesizesStatus(t *testing.T) {
 	}
 }
 
+// TestAgentBackedGet_FallsBackToStatusOnUnsupported proves the rolling-deploy
+// compat path: an OLDER agent that replies OP_UNSUPPORTED to get_object must make
+// Get fall back to GetStatus and return the prior status-only partial object —
+// not error.
+func TestAgentBackedGet_FallsBackToStatusOnUnsupported(t *testing.T) {
+	sess := &fakeSession{
+		getObject: func(ref agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+			return agentgw.GetObjectResult{}, &agentgw.AgentError{Code: agentgw.CodeOpUnsupported, Message: "unknown op"}
+		},
+		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+			return agentgw.StatusSnapshot{
+				Found:           true,
+				ResourceVersion: "999",
+				Generation:      3,
+				Status:          json.RawMessage(`{"printableStatus":"Running"}`),
+			}, nil
+		},
+	}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	obj, err := a.Get(context.Background(), vmGVR, "dc-t-p", "vm-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get must fall back to status-only on OP_UNSUPPORTED, got error: %v", err)
+	}
+	if !sess.getStatusCalled {
+		t.Error("Get did not fall back to GetStatus on OP_UNSUPPORTED")
+	}
+	// The status-only partial object still serves a status-reading caller.
+	printable, found, _ := unstructured.NestedString(obj.Object, "status", "printableStatus")
+	if !found || printable != "Running" {
+		t.Errorf("fallback status.printableStatus = %q (found=%v), want Running", printable, found)
+	}
+	if rv := obj.GetResourceVersion(); rv != "999" {
+		t.Errorf("fallback resourceVersion = %q, want 999", rv)
+	}
+	// The synthesized partial carries no .spec (status-only) — that is expected on
+	// the degraded path.
+	if _, found, _ := unstructured.NestedMap(obj.Object, "spec"); found {
+		t.Error("status-only fallback object unexpectedly carries .spec")
+	}
+}
+
 func TestAgentBackedGet_NotFoundIsK8sNotFound(t *testing.T) {
 	sess := &fakeSession{
-		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
-			return agentgw.StatusSnapshot{Found: false}, nil
+		getObject: func(ref agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+			return agentgw.GetObjectResult{Found: false}, nil
 		},
 	}
 	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
@@ -257,8 +322,8 @@ func TestAgentBackedGet_NotFoundIsK8sNotFound(t *testing.T) {
 
 func TestAgentBackedGet_AgentUnavailableIsRetryable(t *testing.T) {
 	sess := &fakeSession{
-		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
-			return agentgw.StatusSnapshot{}, agentgw.ErrAgentUnavailable
+		getObject: func(ref agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+			return agentgw.GetObjectResult{}, agentgw.ErrAgentUnavailable
 		},
 	}
 	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())

--- a/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
@@ -40,9 +40,11 @@ type fakeSession struct {
 	listCalled  bool                // set true the moment List is invoked
 
 	getStatusCalled bool // set by GetStatus, asserts the OP_UNSUPPORTED fallback fired
+	getObjectCalled bool // set by GetObject, asserts the routability guard fired first
 }
 
 func (f *fakeSession) GetObject(ctx context.Context, ref agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+	f.getObjectCalled = true
 	f.lastRef = ref
 	if f.block {
 		<-ctx.Done()
@@ -189,6 +191,27 @@ func TestAgentBackedList_PreSeededGVKNotRoutable(t *testing.T) {
 	}
 	if sess.listCalled {
 		t.Error("agent List must NOT be invoked for a non-routable family")
+	}
+}
+
+// TestAgentBackedGet_PreSeededGVKNotRoutable mirrors the List guard for Get: the
+// pre-seeded virtualmachineinstances GVR is GVK-mapped but has no RouteVerbs, so
+// Get must be REFUSED with ErrOpNotRoutable and the agent's GetObject never invoked.
+func TestAgentBackedGet_PreSeededGVKNotRoutable(t *testing.T) {
+	vmiGVR := schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstances"}
+	if _, _, ok := DefaultGVKMapper().GVK(vmiGVR); !ok {
+		t.Fatalf("precondition: VMI GVR %s must be GVK-mapped", vmiGVR)
+	}
+
+	sess := &fakeSession{}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	_, err := a.Get(context.Background(), vmiGVR, "dc-t-p", "vmi-1", metav1.GetOptions{})
+	if !errors.Is(err, agentgw.ErrOpNotRoutable) {
+		t.Errorf("mapped-but-not-routable GVR must yield ErrOpNotRoutable for Get, got %v", err)
+	}
+	if sess.getObjectCalled {
+		t.Error("agent GetObject must NOT be invoked for a non-routable family")
 	}
 }
 

--- a/dc-api/internal/providers/harvester/getvm_seam_test.go
+++ b/dc-api/internal/providers/harvester/getvm_seam_test.go
@@ -19,8 +19,8 @@ import (
 
 // This test proves the M-C equivalence guarantee: GetVM returns the SAME
 // models.Resource.Status whether its primary VirtualMachine read goes through
-// the Direct seam (fake dynamic object) or the agent seam (Session.GetStatus
-// returning the equivalent status snapshot). The VMI read stays Direct on both
+// the Direct seam (fake dynamic object) or the agent seam (Session.GetObject
+// returning the equivalent full object). The VMI read stays Direct on both
 // paths (no VMI object present → empty IP, which is fine for the status check).
 
 const (
@@ -53,18 +53,33 @@ func newFakeDynamicWithVM(t *testing.T, printableStatus string) *dynamicfake.Fak
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, vm)
 }
 
-// statusSnapshotFor builds the agent StatusSnapshot equivalent to the fake VM's
-// status — the same printableStatus the Direct path would read off the object.
-func statusSnapshotFor(printableStatus string) agentgw.StatusSnapshot {
-	status, _ := json.Marshal(map[string]interface{}{"printableStatus": printableStatus})
-	return agentgw.StatusSnapshot{Found: true, ResourceVersion: "1", Status: status}
+// fullVMObjectFor builds the full agent GetObjectResult equivalent to the fake
+// VM — the same printableStatus the Direct path reads off the object, carried in
+// a complete VM object (the shape get_object returns).
+func fullVMObjectFor(printableStatus string) agentgw.GetObjectResult {
+	obj, _ := json.Marshal(map[string]interface{}{
+		"apiVersion": "kubevirt.io/v1",
+		"kind":       "VirtualMachine",
+		"metadata": map[string]interface{}{
+			"name":            testVMName,
+			"namespace":       testVMNamespace,
+			"resourceVersion": "1",
+		},
+		"spec":   map[string]interface{}{"running": true},
+		"status": map[string]interface{}{"printableStatus": printableStatus},
+	})
+	return agentgw.GetObjectResult{Found: true, Object: obj}
 }
 
-// seamStubSession returns the given snapshot from GetStatus.
-type seamStubSession struct{ snap agentgw.StatusSnapshot }
+// seamStubSession returns the given full object from GetObject (the primary read
+// path GetVM-via-agent now takes).
+type seamStubSession struct{ obj agentgw.GetObjectResult }
 
+func (s seamStubSession) GetObject(context.Context, agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+	return s.obj, nil
+}
 func (s seamStubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
-	return s.snap, nil
+	return agentgw.StatusSnapshot{}, nil
 }
 func (s seamStubSession) List(context.Context, agentgw.ListRef) (agentgw.ListResult, error) {
 	return agentgw.ListResult{}, nil
@@ -108,7 +123,7 @@ func TestGetVM_DirectAndAgentSeamsAgreeOnStatus(t *testing.T) {
 			// primary VM read is routed to a stub agent Session via a Routed
 			// accessor whose decision always allows VerbGet.
 			dynAgent := newFakeDynamicWithVM(t, tc.printable)
-			sess := seamStubSession{snap: statusSnapshotFor(tc.printable)}
+			sess := seamStubSession{obj: fullVMObjectFor(tc.printable)}
 			agentAccessor := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
 			routed := clusteraccess.NewRouted(
 				clusteraccess.NewDirect(dynAgent),

--- a/dc-api/internal/providers/harvester/list_seam_test.go
+++ b/dc-api/internal/providers/harvester/list_seam_test.go
@@ -40,6 +40,9 @@ func (s *listStubSession) List(_ context.Context, ref agentgw.ListRef) (agentgw.
 	s.lastRef = ref
 	return agentgw.ListResult{Items: s.items}, nil
 }
+func (s *listStubSession) GetObject(context.Context, agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+	return agentgw.GetObjectResult{}, nil
+}
 func (s *listStubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
 	return agentgw.StatusSnapshot{}, nil
 }

--- a/dc-api/internal/providers/harvester/vmwrite_seam_test.go
+++ b/dc-api/internal/providers/harvester/vmwrite_seam_test.go
@@ -59,6 +59,10 @@ type writeStubSession struct {
 	deleteErr    error
 }
 
+func (s *writeStubSession) GetObject(context.Context, agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+	return agentgw.GetObjectResult{}, nil
+}
+
 func (s *writeStubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
 	return agentgw.StatusSnapshot{}, nil
 }

--- a/dc-api/internal/providers/kubeovn/network_seam_test.go
+++ b/dc-api/internal/providers/kubeovn/network_seam_test.go
@@ -55,6 +55,10 @@ type netStubSession struct {
 	deleteErr    error
 }
 
+func (s *netStubSession) GetObject(context.Context, agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+	return agentgw.GetObjectResult{}, nil
+}
+
 func (s *netStubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
 	return agentgw.StatusSnapshot{}, nil
 }

--- a/dc-api/internal/providers/registry_test.go
+++ b/dc-api/internal/providers/registry_test.go
@@ -143,6 +143,9 @@ func (stubSession) Apply(context.Context, json.RawMessage, string, bool) (agentg
 func (stubSession) Delete(context.Context, agentgw.ResourceRef, string) (agentgw.DeleteResult, error) {
 	return agentgw.DeleteResult{}, nil
 }
+func (stubSession) GetObject(context.Context, agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+	return agentgw.GetObjectResult{}, nil
+}
 func (stubSession) GetStatus(context.Context, agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
 	return agentgw.StatusSnapshot{}, nil
 }


### PR DESCRIPTION
## What this changes

The agent's only read op was `get_status`, which returns a status-only partial. But the cluster-access seam's `Get` is contractually a full-object read (the direct client returns the whole object) — so `AgentBacked.Get` was quietly mapping a full read onto a status-only one. The upcoming read-modify-patch write ops (per-VPC NAT and DNS, the cloud-provider service account) read `.spec`/`.data` to modify it, so they need a real full-object read through the agent. This adds one.

## End to end

- **dc-agent:** `Executor.GetObject` (dynamic get of one object, returned verbatim — spec + status + metadata) and an `opGetObject` dispatch handler.
- **dc-api:** a matching `opGetObject` wire frame, `Session.GetObject`, and `AgentBacked.Get` repointed at it — re-hydrating the response into the same full `Unstructured` the direct client returns, so provider code is identical across the direct and agent seams.
- **No RBAC change:** a full read uses the same `get` permission the agent already holds for `get_status`; the request reuses the existing `ResourceRef` shape.

## Rolling-deploy safety

If a newer dc-api talks to an older agent that predates `get_object`, `Get` falls back to `get_status` (the prior status-only read) instead of erroring — so a rolling deploy never hard-fails a read. `get_status` and `watch_status` (the async status poll/stream) are untouched; a status-only caller (the VM read flow) sees the identical shape on the fallback path.

## Why now

This is the second protocol prerequisite of the remaining-ops work (after the `list` op in the parent PR). With full reads in place, the remaining slices — image, cloud-provider SA, NAT, DNS — are capability onboarding plus a raw-Patch → server-side-apply refactor, no new read primitives.

## Verification

Both modules build, vet, and pass race-enabled unit tests. New tests cover the executor get, the `opGetObject` wire round-trip, the full-object re-hydration, the `OP_UNSUPPORTED` → `get_status` fallback, and the existing VM read flow. The live-cluster suites need a real connected agent and weren't run here — one live full read through a connected agent is the remaining check before relying on it.

## Stacked on #199

Branches off `feat/agent-list-op` (#199, the `list` op). Review/merge that first; this PR's base retargets to `controlplane` once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `get_object` protocol operation to retrieve full Kubernetes objects (metadata, spec, status) as raw JSON.
  * Agent-backed reads now prefer the full-object path, with transparent fallback behavior when full reads aren’t supported.

* **Bug Fixes**
  * Improved “object not found” handling to consistently return success with `Found=false`.

* **Tests**
  * Added and expanded unit and end-to-end coverage for `get_object`, including found/absent, cluster-scoped refs, and error/unsupported-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->