### PR TITLE
Add tenant cloud config module

### DIFF
--- a/modules/tenancy/tenant-cloud-config/main.tf
+++ b/modules/tenancy/tenant-cloud-config/main.tf
@@ -1,0 +1,23 @@
+resource "random_password" "node_password" {
+  length  = 20
+  special = false
+}
+
+resource "kubernetes_config_map_v1" "k8s_node_with_storage" {
+
+  metadata {
+    name      = "k8s-cluster-node-with-storage-network"
+    namespace = var.namespace
+    labels = {
+      "harvesterhci.io/cloud-init-template" = "user"
+    }
+  }
+
+  data = {
+    cloudInit = templatefile("${path.module}/templates/k8s-cluster-node-with-storage-network.tpl", {
+      node_password       = random_password.node_password.result
+      ntp_server          = var.ntp_server
+      ssh_authorized_keys = var.ssh_authorized_keys
+    })
+  }
+}

--- a/modules/tenancy/tenant-cloud-config/outputs.tf
+++ b/modules/tenancy/tenant-cloud-config/outputs.tf
@@ -1,0 +1,5 @@
+output "node_password" {
+  value       = random_password.node_password.result
+  sensitive   = true
+  description = "Random password set for the ubuntu user in the k8s-cluster-node-with-storage-network cloud-init template. Distribute to tenant teams via a combined credentials output."
+}

--- a/modules/tenancy/tenant-cloud-config/templates/k8s-cluster-node-with-storage-network.tpl
+++ b/modules/tenancy/tenant-cloud-config/templates/k8s-cluster-node-with-storage-network.tpl
@@ -1,0 +1,70 @@
+#cloud-config
+password: ${node_password}
+chpasswd: { expire: False }
+ssh_pwauth: True
+package_update: true
+packages:
+  - qemu-guest-agent
+  - nfs-common
+  - net-tools
+  - ipvsadm
+write_files:
+%{~ if ntp_server != null }
+  - path: /etc/systemd/timesyncd.conf
+    content: |
+      [Time]
+      NTP=${ntp_server}
+    owner: root:root
+    permissions: '0644'
+%{~ endif }
+  - path: /etc/sysctl.d/99-inotify.conf
+    content: |
+      fs.inotify.max_user_watches=524288
+      fs.inotify.max_user_instances=8192
+      fs.inotify.max_queued_events=65536
+    owner: root:root
+    permissions: '0644'
+  - path: /etc/modules-load.d/ipvs.conf
+    content: |
+      ip_vs
+      ip_vs_rr
+      ip_vs_wrr
+      ip_vs_sh
+      nf_conntrack
+    owner: root:root
+    permissions: '0644'
+  - path: /etc/netplan/60-storage-network.yaml
+    owner: root:root
+    permissions: '0600'
+    content: |
+      network:
+        version: 2
+        ethernets:
+          enp2s0:
+            dhcp4: true
+            dhcp4-overrides:
+              use-routes: false
+              route-metric: 500
+runcmd:
+  - - systemctl
+    - enable
+    - --now
+    - qemu-guest-agent.service
+  - modprobe ip_vs
+  - modprobe ip_vs_rr
+  - modprobe ip_vs_wrr
+  - modprobe ip_vs_sh
+  - modprobe nf_conntrack
+  - sysctl --system
+%{~ if ntp_server != null }
+  - systemctl restart systemd-timesyncd
+  - timedatectl set-ntp false
+  - timedatectl set-ntp true
+%{~ endif }
+  - netplan apply
+%{~ if length(ssh_authorized_keys) > 0 }
+ssh_authorized_keys:
+%{~ for key in ssh_authorized_keys }
+  - ${key}
+%{~ endfor }
+%{~ endif }

--- a/modules/tenancy/tenant-cloud-config/variables.tf
+++ b/modules/tenancy/tenant-cloud-config/variables.tf
@@ -1,0 +1,24 @@
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace in the Harvester cluster where the cloud-init ConfigMap is created. Typically the common namespace output from the tenant-space module (e.g. <project_name>-common)."
+  validation {
+    condition     = trimspace(var.namespace) != ""
+    error_message = "namespace must be a non-empty string."
+  }
+}
+
+variable "ssh_authorized_keys" {
+  type        = list(string)
+  description = "SSH public keys to inject into the cloud-init template's ssh_authorized_keys field. Defaults to an empty list (no keys injected)."
+  default     = []
+}
+
+variable "ntp_server" {
+  type        = string
+  description = "NTP server address written into /etc/systemd/timesyncd.conf. When null (default), the timesyncd config file and NTP runcmds are omitted. Set per-environment via a local (e.g. 192.168.8.254 for LK, pool.ntp.org for US)."
+  default     = null
+  validation {
+    condition     = var.ntp_server == null || trimspace(var.ntp_server) != ""
+    error_message = "ntp_server must be null or a non-empty string."
+  }
+}

--- a/modules/tenancy/tenant-cloud-config/versions.tf
+++ b/modules/tenancy/tenant-cloud-config/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -4,10 +4,21 @@ locals {
   namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
   namespaces              = var.namespaces != null ? (var.create_default_namespace ? distinct(concat([var.project_name], var.namespaces)) : var.namespaces) : (var.create_default_namespace ? [var.project_name] : [])
 
-  # create_net_ns is true when explicitly requested, when any VLAN variable is set
-  # (all NADs live in the network namespace regardless of traffic type).
-  create_net_ns     = var.create_network_namespace || (var.vlan_id != null && length(var.vlan_id) > 0) || var.vm_network_vlan_id != null || var.storage_network_vlan_id != null
+  # Common namespace path — mutually exclusive with the network namespace path.
+  # When enabled, all network resources land here instead of the -net namespace.
+  create_common_ns    = var.create_common_namespace
+  common_namespace    = local.create_common_ns ? coalesce(var.common_namespace_name, "${var.project_name}-common") : null
+  create_cloud_config = local.create_common_ns && var.create_node_cloud_config
+
+  # create_net_ns is true when explicitly requested OR when any VLAN variable is
+  # set AND the common namespace path is NOT active. All NADs live in the active
+  # network namespace regardless of traffic type.
+  create_net_ns     = !local.create_common_ns && (var.create_network_namespace || (var.vlan_id != null && length(var.vlan_id) > 0) || var.vm_network_vlan_id != null || var.storage_network_vlan_id != null)
   network_namespace = local.create_net_ns ? coalesce(var.network_namespace_name, "${var.project_name}-net") : null
+
+  # Resolved namespace name for all harvester_network resources.
+  # Common namespace takes precedence; falls back to the -net namespace.
+  active_net_ns_name = coalesce(local.common_namespace, local.network_namespace)
 
   # VyOS path: compute a deterministic /23 subnet from 10.0.0.0/8 using the VLAN
   # index. Only relevant when vyos_endpoint is set and exactly one VLAN is given.
@@ -67,8 +78,16 @@ resource "rancher2_project" "this" {
       error_message = "VyOS IPAM uses VLAN IDs >= 1000 (index = vlan_id - 1000). Set vyos_endpoint = null for VLANs below 1000."
     }
     precondition {
-      condition     = var.vlan_id == null || length(var.vlan_id) == 0 || local.create_net_ns
-      error_message = "vlan_id requires the network namespace to exist. This should never happen since create_net_ns is always true when vlan_id is set — if you see this, do not set create_network_namespace = false alongside vlan_id."
+      condition     = var.vlan_id == null || length(var.vlan_id) == 0 || local.create_net_ns || local.create_common_ns
+      error_message = "vlan_id requires either the network namespace or the common namespace to exist. Do not set create_network_namespace = false alongside vlan_id unless create_common_namespace = true."
+    }
+    precondition {
+      condition     = !(var.create_common_namespace && var.create_network_namespace)
+      error_message = "create_common_namespace and create_network_namespace are mutually exclusive. Enable one or the other, not both."
+    }
+    precondition {
+      condition     = !var.create_node_cloud_config || var.create_common_namespace
+      error_message = "create_node_cloud_config requires create_common_namespace = true."
     }
   }
 }
@@ -128,6 +147,38 @@ resource "rancher2_namespace" "network" {
   depends_on = [rancher2_namespace.this]
 }
 
+# ── Common namespace ──────────────────────────────────────────────────────────
+# Created when create_common_namespace = true. Hosts all network resources
+# (harvester_network resources) and cloud-init templates. Mutually exclusive
+# with the -net network namespace — both cannot be active simultaneously.
+
+resource "rancher2_namespace" "common" {
+  count            = local.create_common_ns ? 1 : 0
+  name             = local.common_namespace
+  project_id       = rancher2_project.this.id
+  wait_for_cluster = false
+
+  # Zero-limit quota prevents VM workloads from being scheduled in this namespace.
+  resource_quota {
+    limit {
+      limits_cpu       = "0"
+      limits_memory    = "0Mi"
+      requests_storage = "0Gi"
+    }
+  }
+
+  labels = {
+    "field.cattle.io/projectId" = split(":", rancher2_project.this.id)[1]
+    "platform.wso2.com/role"    = "common-namespace"
+  }
+
+  lifecycle {
+    ignore_changes = [description, labels["kubernetes.io/metadata.name"]]
+  }
+
+  depends_on = [rancher2_namespace.this]
+}
+
 # ── Harvester network (whenever vlan_id is set, with or without VyOS) ─────────
 # Created directly here so it exists regardless of whether VyOS is configured.
 # Environments using physical switch VLAN assignment skip VyOS but still need
@@ -136,7 +187,7 @@ resource "rancher2_namespace" "network" {
 resource "harvester_network" "tenant" {
   for_each             = var.vlan_id != null ? toset([for id in var.vlan_id : tostring(id)]) : toset([])
   name                 = lookup(var.vlan_network_names, each.value, "${var.project_name}-vlan${each.value}")
-  namespace            = rancher2_namespace.network[0].name
+  namespace            = local.active_net_ns_name
   vlan_id              = tonumber(each.value)
   cluster_network_name = var.cluster_network_name
 
@@ -149,7 +200,7 @@ resource "harvester_network" "tenant" {
 
   # When VyOS is configured, wait for the vif/DHCP to be provisioned before
   # the network is visible to tenant VMs. for_each with empty set is a no-op.
-  depends_on = [rancher2_namespace.network, module.vyos_tenant]
+  depends_on = [rancher2_namespace.network, rancher2_namespace.common, module.vyos_tenant]
 }
 
 # ── VM network (simple path: vm_vlan_id) ──────────────────────────────────────
@@ -160,12 +211,12 @@ resource "harvester_network" "tenant" {
 resource "harvester_network" "vm" {
   count                = var.vm_network_vlan_id != null ? 1 : 0
   name                 = coalesce(var.vm_network_name, "${var.project_name}-vlan${var.vm_network_vlan_id}")
-  namespace            = rancher2_namespace.network[0].name
+  namespace            = local.active_net_ns_name
   vlan_id              = var.vm_network_vlan_id
   cluster_network_name = var.cluster_network_name
   route_mode           = "auto"
 
-  depends_on = [rancher2_namespace.network]
+  depends_on = [rancher2_namespace.network, rancher2_namespace.common]
 }
 
 # ── Storage network (only when storage_vlan_id is set) ────────────────────────
@@ -178,12 +229,12 @@ resource "harvester_network" "vm" {
 resource "harvester_network" "storage" {
   count                = var.storage_network_vlan_id != null ? 1 : 0
   name                 = coalesce(var.storage_network_name, "${var.project_name}-strg-vlan${var.storage_network_vlan_id}")
-  namespace            = rancher2_namespace.network[0].name
+  namespace            = local.active_net_ns_name
   vlan_id              = var.storage_network_vlan_id
   cluster_network_name = var.storage_cluster_network_name
   route_mode           = "auto"
 
-  depends_on = [rancher2_namespace.network]
+  depends_on = [rancher2_namespace.network, rancher2_namespace.common]
 }
 
 # ── VyOS configuration (only when vyos_endpoint is also set) ──────────────────
@@ -273,11 +324,27 @@ resource "rancher2_project_role_template_binding" "shared_image_access" {
   user_id            = each.value.user_id
 }
 
+# ── Node cloud-init template ──────────────────────────────────────────────────
+# Instantiated when create_common_namespace = true AND create_node_cloud_config = true.
+# Delegates to the tenant-cloud-config sub-module which owns the kubernetes provider.
+# The root module must configure a default `provider "kubernetes"` pointed at the
+# Harvester cluster kubeconfig — no aliased provider or providers meta-argument needed.
+
+module "cloud_config" {
+  count  = local.create_cloud_config ? 1 : 0
+  source = "../tenant-cloud-config"
+
+  namespace           = local.common_namespace
+  ntp_server          = var.cloud_config_ntp_server
+  ssh_authorized_keys = var.cloud_config_ssh_authorized_keys
+
+  depends_on = [rancher2_namespace.common]
+}
+
 # ── CI/CD bot users ───────────────────────────────────────────────────────────
 # Optional per-tenant machine identities for Terraform/CI pipelines.
 # Only instantiated when bot_users is non-empty — all existing tenant spaces
 # that omit this variable are completely unaffected.
-# Uses only the unaliased rancher2 and random providers — no kubernetes needed.
 
 module "bot_user" {
   for_each = { for b in var.bot_users : b.name => b }

--- a/modules/tenancy/tenant-space/outputs.tf
+++ b/modules/tenancy/tenant-space/outputs.tf
@@ -23,6 +23,23 @@ output "network_namespace_id" {
   description = "Rancher namespace ID of the network namespace. Non-null when create_network_namespace = true or vlan_id is set."
 }
 
+output "common_namespace" {
+  value       = local.create_common_ns ? rancher2_namespace.common[0].name : null
+  description = "Name of the common namespace (<project_name>-common). Non-null when create_common_namespace = true."
+}
+
+output "common_namespace_id" {
+  value       = local.create_common_ns ? rancher2_namespace.common[0].id : null
+  description = "Rancher namespace ID of the common namespace. Non-null when create_common_namespace = true."
+}
+
+output "node_cloud_config_password" {
+  value       = local.create_cloud_config ? module.cloud_config[0].node_password : null
+  sensitive   = true
+  description = "Random password for the ubuntu user in the k8s-cluster-node-with-storage-network cloud-init template. Non-null when create_node_cloud_config = true."
+}
+
+
 output "network_names" {
   value       = { for id, r in harvester_network.tenant : id => "${r.namespace}/${r.name}" }
   description = "Map of VLAN ID (string) → full harvester_network reference (<namespace>/<name>) for attaching tenant VMs. Empty map when vlan_id is null or empty."

--- a/modules/tenancy/tenant-space/variables.tf
+++ b/modules/tenancy/tenant-space/variables.tf
@@ -355,3 +355,48 @@ variable "storage_network_name" {
     error_message = "storage_network_name must be null or a non-empty string."
   }
 }
+
+# ── Common namespace — mutually exclusive with create_network_namespace ────────
+# When enabled, a <project_name>-common namespace is created for network
+# resources and cloud-init templates instead of the <project_name>-net namespace.
+# All harvester_network resources (VM, storage, VLAN) land in this namespace.
+# Cannot be combined with create_network_namespace = true.
+
+variable "create_common_namespace" {
+  type        = bool
+  description = "When true, creates a <project_name>-common namespace that hosts all network resources and cloud-init templates. Mutually exclusive with create_network_namespace. All VLAN-triggered network resources are placed here instead of the -net namespace."
+  default     = false
+}
+
+variable "common_namespace_name" {
+  type        = string
+  description = "Override the name of the common namespace. Defaults to <project_name>-common. Use when importing a brownfield namespace whose name differs from this convention."
+  default     = null
+  validation {
+    condition     = var.common_namespace_name == null ? true : trimspace(var.common_namespace_name) != ""
+    error_message = "common_namespace_name must be null or a non-empty string."
+  }
+}
+
+variable "create_node_cloud_config" {
+  type        = bool
+  description = "When true, creates a Harvester cloud-init ConfigMap (k8s-cluster-node-with-storage-network) in the common namespace via the tenant-cloud-config sub-module. Requires create_common_namespace = true. The root module must configure a default kubernetes provider pointed at the Harvester cluster."
+  default     = false
+}
+
+variable "cloud_config_ssh_authorized_keys" {
+  type        = list(string)
+  description = "SSH public keys injected into the node cloud-init template. Only used when create_node_cloud_config = true. Defaults to an empty list."
+  default     = []
+}
+
+variable "cloud_config_ntp_server" {
+  type        = string
+  description = "NTP server written into /etc/systemd/timesyncd.conf by the node cloud-init template. Only used when create_node_cloud_config = true. When null (default), the NTP section is omitted. Set per-environment via a local."
+  default     = null
+  validation {
+    condition     = var.cloud_config_ntp_server == null || trimspace(var.cloud_config_ntp_server) != ""
+    error_message = "cloud_config_ntp_server must be null or a non-empty string."
+  }
+}
+

--- a/modules/tenancy/tenant-space/versions.tf
+++ b/modules/tenancy/tenant-space/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

### New module: `tenant-cloud-config`

Adds a standalone `modules/tenancy/tenant-cloud-config` module that provisions a Harvester **Cloud Config Template** (a `v1/ConfigMap` with label `harvesterhci.io/cloud-init-template: user`) in a given namespace.

- Generates a per-tenant 20-character random password for the `ubuntu` user
- Renders the cloud-init template from `templates/k8s-cluster-node-with-storage-network.tpl`, which configures:
  - IPVS kernel modules (`ip_vs`, `ip_vs_rr`, `ip_vs_wrr`, `ip_vs_sh`, `nf_conntrack`)
  - inotify sysctl tuning (`fs.inotify.max_user_watches`, `max_user_instances`, `max_queued_events`)
  - Storage NIC (`enp2s0`) via netplan at `/etc/netplan/60-storage-network.yaml` with `use-routes: false` and `route-metric: 500`
  - Optional NTP config in `/etc/systemd/timesyncd.conf` (omitted when `ntp_server = null`)
  - Optional `ssh_authorized_keys` block (omitted when list is empty)
- Uses the default (unaliased) `kubernetes` provider — no `configuration_aliases`, no `providers = {}` required on module calls
- Inputs: `namespace`, `ntp_server` (nullable), `ssh_authorized_keys` (default `[]`)
- Output: `node_password` (sensitive)

### Updated module: `tenant-space`

#### Common namespace (`create_common_namespace`)

Adds an alternative to the existing `-net` network namespace. When enabled:

- Creates a `<project_name>-common` namespace with a zero-limit resource quota and label `platform.wso2.com/role=common-namespace`
- All `harvester_network` resources (VM, storage, legacy VLAN) are placed in the common namespace instead of the `-net` namespace via a new `active_net_ns_name` local
- Mutually exclusive with `create_network_namespace` — enforced by a lifecycle precondition

New variables:
| Variable | Default | Description |
|---|---|---|
| `create_common_namespace` | `false` | Create `<project_name>-common` instead of `<project_name>-net` |
| `common_namespace_name` | `null` | Override the common namespace name (brownfield import) |

New outputs: `common_namespace`, `common_namespace_id`

#### Node cloud-init template (`create_node_cloud_config`)

When `create_common_namespace = true`, the `tenant-cloud-config` sub-module can be instantiated by setting `create_node_cloud_config = true`. The root module must configure a default `provider "kubernetes"` pointed at the Harvester kubeconfig — no provider alias or `providers` meta-argument needed on the module call.

New variables:
| Variable | Default | Description |
|---|---|---|
| `create_node_cloud_config` | `false` | Instantiate the `tenant-cloud-config` sub-module |
| `cloud_config_ntp_server` | `null` | NTP server; set per-environment via a local |
| `cloud_config_ssh_authorized_keys` | `[]` | SSH public keys to inject |

New output: `node_cloud_config_password` (sensitive)

#### Backward compatibility

All new variables default to `false` / `null` / `[]`. Existing tenant space configurations are completely unaffected.

## Usage

```hcl
module "my_tenant" {
  source = "../modules/open-cloud-datacenter/modules/tenancy/tenant-space"

  cluster_id   = local.harvester_cluster_id
  project_name = "my-team"

  create_common_namespace  = true
  create_node_cloud_config = true

  cloud_config_ntp_server          = local.ntp_server   # set per-environment
  cloud_config_ssh_authorized_keys = ["ssh-rsa AAAA..."]

  vm_network_vlan_id      = 604
  storage_network_vlan_id = 603
  # ...
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a shared “common” namespace for tenant networking resources.
  * Introduced optional node cloud-init configuration with support for SSH keys, NTP settings, and generated credentials.
  * Added outputs for the common namespace details and node cloud-config password.

* **Bug Fixes**
  * Improved validation around namespace creation and VLAN placement.
  * Updated network resource placement so it follows the selected namespace path more reliably.
  * Added safer handling for optional configuration values by returning null when not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->