### PR TITLE
[Feature] Add a shared pre-PR scanner review gate

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -26,7 +26,7 @@ It auto-selects tools by changed file type (Go → golangci-lint + govulncheck; 
 
 ### Layer 2 — LLM multi-lens adversarial review (the judgment half)
 The scanners can't reason about intent, design, or cross-file contracts. For that, run the engine via the Workflow tool:
-```
+```text
 Workflow({ scriptPath: ".claude/skills/pr-review/review.js",
            args: { base: "<base, e.g. origin/controlplane>", repo: "." } })
 ```

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: pr-review
+description: Pre-PR self-review modeled on how CodeRabbit actually works — a deterministic scanner layer (the same OSS analyzers CodeRabbit runs) plus an LLM multi-lens adversarial review across CodeRabbit's six review categories. Run on the branch/staged diff before every commit and PR, so the external reviewer (CodeRabbit) has little to add. Drops false positives via adversarial verification; runs the real build/test.
+---
+
+# pr-review — review your diff the way CodeRabbit will, first
+
+Run this on the diff **before every commit + PR**. Goal: catch most of what CodeRabbit would post — *before* pushing — so it isn't publicly dismissing already-pushed code, and so the human reviewer sees a clean diff.
+
+## How CodeRabbit actually works (what we're replicating)
+CodeRabbit is **two layers**, not one LLM:
+1. **~56 OSS analyzers** run in a sandbox (golangci-lint, Semgrep, Gitleaks, OSV-Scanner, ast-grep, ESLint, Checkov/Trivy/TFLint, Hadolint, oasdiff, actionlint, LanguageTool, …).
+2. **A context-engineered LLM** that reads the diff + surrounding code + linked issues, then a **separate judge model** filters false positives before posting.
+
+Its findings are tagged **severity** (Critical · Major · Minor · Trivial · Info) and triaged **Security → Correctness → Performance → Reliability → Best-practice → Style**. Its documented review taxonomy is **six categories** (below). It is high-recall but only ~middling precision (≈50%) and tends to be verbose/nitpicky — so our edge is **running the same scanners deterministically** (no guesswork) **and adversarially verifying the LLM findings** (kill the nits).
+
+## Two layers, run in order
+
+### Layer 1 — deterministic scanners (the cheap, certain half)
+Run the same OSS tools CodeRabbit runs, locally, scoped to the diff:
+```bash
+make scan                 # from the repo root, or:
+bash scripts/pr-scan.sh   # optional first arg: a base ref (default: merge-base with origin/controlplane)
+```
+It auto-selects tools by changed file type (Go → golangci-lint + govulncheck; secrets → gitleaks; deps → osv-scanner; `openapi.yaml` → redocly lint + **oasdiff breaking-change**; cloud-ui → eslint + tsc; `.tf` → tflint/checkov; Dockerfile → hadolint; workflows → actionlint; shell/yaml/md → shellcheck/yamllint/markdownlint; SAST → semgrep). Fix everything it reports — these are exactly the comments CodeRabbit's tool layer would post. It names any tool it couldn't run (not installed) so coverage gaps are explicit; widen coverage by installing them (see `docs/pr-review-gate.md`).
+
+### Layer 2 — LLM multi-lens adversarial review (the judgment half)
+The scanners can't reason about intent, design, or cross-file contracts. For that, run the engine via the Workflow tool:
+```
+Workflow({ scriptPath: ".claude/skills/pr-review/review.js",
+           args: { base: "<base, e.g. origin/controlplane>", repo: "." } })
+```
+One reviewer per CodeRabbit category, each finding adversarially re-checked (try to *refute* it; drop if already-handled or uncertain), plus a real build/vet/test run. Returns `{ confirmed (by severity), build, droppedFalsePositives }`. **Don't have the LLM re-do what the scanners cover** (style, lint, known-vuln patterns) — it focuses on judgment.
+
+## The rubric — CodeRabbit's six categories (+ tests, docs)
+Each finding gets a **severity** (Critical/Major/Minor/Trivial/Info) and, where useful, an **effort** note (quick win / heavy lift).
+
+1. **Security & Privacy** — injection (SQL/command), XSS, SSRF, path traversal, insecure deserialization, hardcoded secrets, weak crypto, broken authn/authz/access-control, missing input validation, PII/data exposure (OWASP Top 10). *(Layer-1: gitleaks/semgrep; Layer-2: authz logic, tenant/data isolation, reasoning about exploitability.)*
+2. **Functional Correctness** — logic errors, wrong conditions, off-by-one, unhandled edge cases, null/None handling, **code that doesn't match its stated intent / the linked issue**.
+3. **Stability & Reliability** — crashes, unhandled or **swallowed errors**, **resource leaks** (files/conns/goroutines/memory), **concurrency** (races, deadlocks, thread-safety, reentrancy), missing timeouts/retries, **version-skew / backward-compat across components**.
+4. **Data Integrity & Integration** — data correctness, persistence/transaction bugs, schema mismatches, broken migrations, **API/schema contract breaks & backward-compat**. *(Layer-1: oasdiff for OpenAPI; Layer-2: semantic contract reasoning, cross-service effects the diff can't show.)*
+5. **Performance & Scalability** — N+1 queries, missing caching, unoptimized/unbounded loops & responses, algorithmic complexity, hot-path allocations.
+6. **Maintainability & Code Quality** — naming, structure/readability, **duplication/DRY**, complexity, **dead code / unused imports**, interface/API design — and **does a new method enforce the same preconditions/guards as its siblings?**
+7. **Tests** — new branches/error paths/edge cases covered? a **regression test for each fixed bug** (the exact reported case)? are assertions *real* (not just "no error")? do they run + pass?
+8. **Documentation & conventions** — stale comments/error-messages/helpers not updated to match the change; docs that now contradict the code; PR title/description quality; **plus every applicable rule from the repo's CLAUDE.md** (design patterns, layering, isolation, hard rules). Read CLAUDE.md first.
+
+*(Style/formatting/typos are delegated to Layer-1 linters + LanguageTool-class tools — don't hand-nitpick them.)*
+
+## Procedure
+1. Scope the diff (base branch / merge-base). Note new/changed public surface (APIs, CLI, wire protocols, RBAC, DB schema, IaC).
+2. **Layer 1:** run `make scan`; fix every real finding; note any uninstalled tool as a coverage gap.
+3. **Layer 2:** run `review.js` for a non-trivial diff (inline a few lenses for a tiny one). Always keep the adversarial-verify step — it's what beats CodeRabbit's precision.
+4. Triage confirmed findings **Security → Correctness → Performance → Reliability → Best-practice → Style**. Fix blockers + majors; decide minors/nits explicitly.
+5. Re-run the affected scanner/lens after a substantive fix, then open the PR.
+6. In the PR body, note "self-reviewed: scanners + N-lens review" so reviewers know the bar.
+
+## Scale & gaps
+Scale to the diff: a tiny change → `make scan` + a couple of lenses; a feature → the full set. Known CodeRabbit gaps to optionally cover yourself: i18n and license/SCA compliance. This is a **front-runner** for CodeRabbit, not a replacement — CodeRabbit still runs on the PR; see `docs/pr-review-gate.md` for how the two relate and how to enable the advisory pre-push hook (`make hooks`).

--- a/.claude/skills/pr-review/review.js
+++ b/.claude/skills/pr-review/review.js
@@ -10,7 +10,9 @@ export const meta = {
 // args.base = review base (PR base branch / merge-base). args.repo = repo path (default: repo root).
 const base = (args && args.base) || 'HEAD~1'
 const repo = (args && args.repo) || '.'
-const diffRef = `git -C ${repo} diff ${base}...HEAD`
+// Working tree vs base (committed + staged + unstaged) — the gate runs before commit,
+// so uncommitted changes must be in scope.
+const diffRef = `git -C ${repo} diff ${base}`
 
 const SEV = ['critical', 'major', 'minor', 'trivial', 'info']
 const FINDINGS = {
@@ -41,7 +43,7 @@ const LENSES = [
   { key: 'performance', focus: 'N+1 queries, missing caching, unoptimized or unbounded loops/responses, algorithmic complexity, hot-path allocations.' },
   { key: 'maintainability-design', focus: 'Naming, structure/readability, duplication/DRY, complexity, dead code, interface/API design — and especially: does a NEW method enforce the SAME preconditions/guards as its sibling methods?' },
   { key: 'tests', focus: 'Are new branches/error paths/edge cases covered? a regression test for EACH fixed bug (the exact reported case)? are assertions real (not just no-error)?' },
-  { key: 'docs-conventions', focus: 'Stale comments/error-messages/helpers not updated to match the change; docs now contradicting the code; PR title/description quality; PLUS every applicable rule from the repo CLAUDE.md (design patterns, layering, isolation, hard rules, scrub gate) — read CLAUDE.md in the repo first.' },
+  { key: 'docs-conventions', focus: 'Stale comments/error-messages/helpers not updated to match the change; docs now contradicting the code; PLUS every applicable rule from the repo CLAUDE.md (design patterns, layering, isolation, hard rules, scrub gate) — read CLAUDE.md in the repo first.' },
 ]
 
 phase('Review')

--- a/.claude/skills/pr-review/review.js
+++ b/.claude/skills/pr-review/review.js
@@ -1,0 +1,82 @@
+export const meta = {
+  name: 'pr-review',
+  description: 'LLM half of the pr-review gate: one reviewer per CodeRabbit review category (judgment, not lint), adversarial verification of each finding to drop false positives, a real build/vet/test, then synthesis. Pair with scripts/pr-scan.sh (the deterministic tool layer).',
+  phases: [
+    { title: 'Review', detail: 'one reviewer per category + a build/vet/test run' },
+    { title: 'Verify', detail: 'adversarially confirm or refute each candidate finding' },
+  ],
+}
+
+// args.base = review base (PR base branch / merge-base). args.repo = repo path (default: repo root).
+const base = (args && args.base) || 'HEAD~1'
+const repo = (args && args.repo) || '.'
+const diffRef = `git -C ${repo} diff ${base}...HEAD`
+
+const SEV = ['critical', 'major', 'minor', 'trivial', 'info']
+const FINDINGS = {
+  type: 'object', additionalProperties: false, required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['file', 'severity', 'category', 'title', 'detail'],
+        properties: {
+          file: { type: 'string' }, line: { type: 'string' },
+          severity: { enum: SEV }, category: { type: 'string' },
+          title: { type: 'string' }, detail: { type: 'string' }, fix: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const SCANNERS_NOTE = 'The deterministic scanner layer (golangci-lint, govulncheck, gitleaks, osv-scanner, semgrep, eslint, oasdiff, etc.) already covers style, formatting, lint rules, secrets, known-vuln patterns, and OpenAPI breaking changes — do NOT re-report those. Focus only on what a linter cannot judge.'
+
+const LENSES = [
+  { key: 'security-privacy', focus: 'Authn/authz & access-control logic, secret handling, injection/SSRF/path-traversal reachability, tenant/data isolation, PII exposure, exploitability reasoning (OWASP Top 10) — the judgment a SAST tool misses.' },
+  { key: 'correctness', focus: 'Logic errors, wrong conditions/boolean logic, off-by-one, unhandled edge cases, null/None handling, and code that does NOT match its stated intent or the linked issue.' },
+  { key: 'reliability', focus: 'Crashes, unhandled or swallowed errors, resource leaks (files/connections/goroutines/memory), concurrency (races, deadlocks, thread-safety, reentrancy), missing timeouts/retries, and version-skew / backward-compat across components (new client vs old server).' },
+  { key: 'data-integrity-contracts', focus: 'Data correctness, persistence/transaction bugs, schema mismatches, broken migrations, and API/schema contract breaks & backward-compat — including cross-service effects the diff alone cannot show. (oasdiff checks OpenAPI syntactically; you cover semantics + wire-compat across modules.)' },
+  { key: 'performance', focus: 'N+1 queries, missing caching, unoptimized or unbounded loops/responses, algorithmic complexity, hot-path allocations.' },
+  { key: 'maintainability-design', focus: 'Naming, structure/readability, duplication/DRY, complexity, dead code, interface/API design — and especially: does a NEW method enforce the SAME preconditions/guards as its sibling methods?' },
+  { key: 'tests', focus: 'Are new branches/error paths/edge cases covered? a regression test for EACH fixed bug (the exact reported case)? are assertions real (not just no-error)?' },
+  { key: 'docs-conventions', focus: 'Stale comments/error-messages/helpers not updated to match the change; docs now contradicting the code; PR title/description quality; PLUS every applicable rule from the repo CLAUDE.md (design patterns, layering, isolation, hard rules, scrub gate) — read CLAUDE.md in the repo first.' },
+]
+
+phase('Review')
+const reviews = (await parallel(LENSES.map(l => () =>
+  agent(
+    `You are a strict senior code reviewer (CodeRabbit-grade). Review ONLY the change in \`${diffRef}\` (read surrounding code in ${repo} for context) through ONE category: ${l.key}.\nFocus: ${l.focus}\n${SCANNERS_NOTE}\nReport concrete, line-anchored findings only — no vague advice, no praise. Severity: critical (ship-stopper), major (fix before merge), minor, trivial, info. Return an empty findings array if clean on this category.`,
+    { label: `lens:${l.key}`, phase: 'Review', schema: FINDINGS, agentType: 'Explore', effort: 'high' }
+  )
+))).filter(Boolean)
+
+const BUILD = { type: 'object', additionalProperties: false, required: ['pass', 'detail'], properties: { pass: { type: 'boolean' }, detail: { type: 'string' } } }
+const build = await agent(
+  `In ${repo}, build + vet + test the code touched by \`${diffRef}\`. Go: go build ./..., go vet ./..., and go test (-race where concurrency is involved) on the affected packages; do each touched module separately. Run any linter relevant to the changed files. Report verbatim pass/fail per package/module.`,
+  { label: 'build-test', phase: 'Review', schema: BUILD, agentType: 'Explore', effort: 'high' }
+)
+
+const candidates = reviews.flatMap(r => (r && r.findings) || [])
+const rank = { critical: 0, major: 1, minor: 2, trivial: 3, info: 4 }
+
+phase('Verify')
+const VERDICT = { type: 'object', additionalProperties: false, required: ['real', 'reason'], properties: { real: { type: 'boolean' }, severity: { enum: SEV }, reason: { type: 'string' } } }
+const verified = (await parallel(candidates.map(f => () =>
+  agent(
+    `Adversarially verify this review finding against the ACTUAL code in ${repo} (diff base ${base}). Try to REFUTE it: is it real, still valid, and NOT already handled elsewhere (a guard upstream, a caller-side check, an existing test, intentional design)? Read the cited file and its neighbours.\nFinding: ${f.severity} | ${f.category} | ${f.file}:${f.line || '?'} — ${f.title}\n${f.detail}\nDefault real=false when uncertain — a confident wrong finding costs more than a missed nit. Return {real, severity (your re-assessed severity), reason}.`,
+    { label: `verify:${f.file}`, phase: 'Verify', schema: VERDICT, agentType: 'Explore', effort: 'high' }
+  ).then(v => (v ? { ...f, verdict: v } : null))
+))).filter(Boolean)
+
+const confirmed = verified
+  .filter(f => f.verdict.real)
+  .map(f => ({ ...f, severity: f.verdict.severity || f.severity }))
+  .sort((a, b) => rank[a.severity] - rank[b.severity])
+
+return {
+  confirmed,
+  build,
+  droppedFalsePositives: verified.filter(f => !f.verdict.real).map(f => ({ title: f.title, file: f.file, why: f.verdict.reason })),
+}

--- a/.claude/skills/pr-review/review.js
+++ b/.claude/skills/pr-review/review.js
@@ -10,9 +10,10 @@ export const meta = {
 // args.base = review base (PR base branch / merge-base). args.repo = repo path (default: repo root).
 const base = (args && args.base) || 'HEAD~1'
 const repo = (args && args.repo) || '.'
-// Working tree vs base (committed + staged + unstaged) — the gate runs before commit,
-// so uncommitted changes must be in scope.
-const diffRef = `git -C ${repo} diff ${base}`
+// Working tree vs merge-base (committed + staged + unstaged) — the gate runs before
+// commit, so uncommitted changes must be in scope; the merge-base (matching Layer 1 /
+// scripts/pr-scan.sh) excludes base-only commits so we review only what this branch adds.
+const diffRef = `git -C ${repo} diff $(git -C ${repo} merge-base HEAD ${base})`
 
 const SEV = ['critical', 'major', 'minor', 'trivial', 'info']
 const FINDINGS = {

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,6 +25,9 @@ if [ ! -f "$SCAN" ]; then
   exit 0
 fi
 if command -v go >/dev/null 2>&1; then
+  # `go install` writes to $GOBIN when set, else $GOPATH/bin — prepend both.
+  GO_BIN_ENV="$(go env GOBIN 2>/dev/null)"
+  [ -n "$GO_BIN_ENV" ] && export PATH="$GO_BIN_ENV:$PATH"
   GOBIN_DIR="$(go env GOPATH 2>/dev/null)/bin"
   export PATH="$GOBIN_DIR:$PATH"
 fi
@@ -33,21 +36,53 @@ echo "[pre-push] pr-scan scanners — advisory, blocks only on secrets. Skip wit
 bash "$SCAN" 2>&1 || true
 
 # --- hard block: secrets only ---
-if command -v gitleaks >/dev/null 2>&1; then
-  base=""
-  for b in origin/controlplane upstream/controlplane origin/main; do
-    git rev-parse --verify --quiet "$b" >/dev/null 2>&1 && { base="$b"; break; }
+# Scan exactly the commits being pushed, read from the pre-push stdin protocol:
+#   <localref> <localsha> <remoteref> <remotesha>  (one line per ref)
+# Deletes (localsha all-zeros) are skipped; a new remote ref (remotesha all-zeros)
+# is scanned from the detected base's merge-base; otherwise we scan remotesha..localsha.
+# If stdin is empty (run manually), fall back to merge-base(HEAD, base)..HEAD.
+ZERO='^0\{7,\}$'   # all-zeros object id (any length)
+
+detect_mb() {  # echo the merge-base of $1 with the first available upstream base
+  _b=""
+  for _r in origin/controlplane upstream/controlplane origin/main; do
+    git rev-parse --verify --quiet "$_r" >/dev/null 2>&1 && { _b="$_r"; break; }
   done
-  mb="$(git merge-base HEAD "${base:-HEAD~1}" 2>/dev/null || echo HEAD~1)"
+  git merge-base "$1" "${_b:-HEAD~1}" 2>/dev/null || echo HEAD~1
+}
+
+scan_range() {  # $1=range (e.g. A..B); block on leaks, advisory otherwise
+  command -v gitleaks >/dev/null 2>&1 || return 0
   GL="$(mktemp)"
-  if ! gitleaks git --no-banner --redact --log-opts="$mb..HEAD" >"$GL" 2>&1; then
+  if ! gitleaks git --no-banner --redact --log-opts="$1" >"$GL" 2>&1; then
     echo
-    echo "[pre-push] BLOCKED — gitleaks flagged potential secret(s) in $mb..HEAD:"
+    echo "[pre-push] BLOCKED — gitleaks flagged potential secret(s) in $1:"
     tail -15 "$GL"
     echo "[pre-push] Remove the secret, or if it is a false positive: OCD_SKIP_PRESCAN=1 git push"
     rm -f "$GL"; exit 1
   fi
   rm -f "$GL"
+}
+
+if command -v gitleaks >/dev/null 2>&1; then
+  scanned_any=0
+  # Only consume stdin when it is piped/redirected; a manual run leaves it on the
+  # terminal, where `read` would block — fall through to the HEAD fallback instead.
+  if [ ! -t 0 ]; then
+    while read -r _localref localsha _remoteref remotesha; do
+      [ -n "${localsha:-}" ] || continue
+      # Skip branch/ref deletions — nothing local to scan.
+      expr "$localsha" : "$ZERO" >/dev/null && continue
+      if expr "${remotesha:-}" : "$ZERO" >/dev/null; then
+        scan_range "$(detect_mb "$localsha")..$localsha"   # new ref: vs merge-base
+      else
+        scan_range "$remotesha..$localsha"                 # existing ref: pushed commits
+      fi
+      scanned_any=1
+    done
+  fi
+  # Manual run / empty stdin / no non-delete refs: fall back to merge-base(HEAD)..HEAD.
+  [ "$scanned_any" -eq 0 ] && scan_range "$(detect_mb HEAD)..HEAD"
 fi
 
 echo "[pre-push] scan complete, no secrets — push proceeding."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# pre-push hook — run the pr-scan scanner gate before pushing.
+# Enable it once with:  make hooks   (sets core.hooksPath to .githooks)
+#
+# Behavior: ADVISORY — prints all scanner findings for triage; HARD-BLOCKS only
+# on secrets (gitleaks), which are clear-cut. Everything else (lint/vuln/etc.) is
+# printed but does not block, so a pre-existing dependency CVE can't stop a push.
+#
+# Skip once (e.g. you already ran the pr-review skill, or a confirmed false
+# positive):
+#     OCD_SKIP_PRESCAN=1 git push
+#
+# Args: $1=remote name  $2=remote URL.  Stdin: <localref> <localsha> <remoteref> <remotesha>.
+set -u
+
+if [ "${OCD_SKIP_PRESCAN:-0}" = "1" ]; then
+  echo "[pre-push] OCD_SKIP_PRESCAN=1 — pr-scan skipped"
+  exit 0
+fi
+
+REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+SCAN="$REPO/scripts/pr-scan.sh"
+if [ ! -f "$SCAN" ]; then
+  echo "[pre-push] scripts/pr-scan.sh not found — skipping (nothing to gate)"
+  exit 0
+fi
+if command -v go >/dev/null 2>&1; then
+  GOBIN_DIR="$(go env GOPATH 2>/dev/null)/bin"
+  export PATH="$GOBIN_DIR:$PATH"
+fi
+
+echo "[pre-push] pr-scan scanners — advisory, blocks only on secrets. Skip with: OCD_SKIP_PRESCAN=1 git push"
+bash "$SCAN" 2>&1 || true
+
+# --- hard block: secrets only ---
+if command -v gitleaks >/dev/null 2>&1; then
+  base=""
+  for b in origin/controlplane upstream/controlplane origin/main; do
+    git rev-parse --verify --quiet "$b" >/dev/null 2>&1 && { base="$b"; break; }
+  done
+  mb="$(git merge-base HEAD "${base:-HEAD~1}" 2>/dev/null || echo HEAD~1)"
+  GL="$(mktemp)"
+  if ! gitleaks git --no-banner --redact --log-opts="$mb..HEAD" >"$GL" 2>&1; then
+    echo
+    echo "[pre-push] BLOCKED — gitleaks flagged potential secret(s) in $mb..HEAD:"
+    tail -15 "$GL"
+    echo "[pre-push] Remove the secret, or if it is a false positive: OCD_SKIP_PRESCAN=1 git push"
+    rm -f "$GL"; exit 1
+  fi
+  rm -f "$GL"
+fi
+
+echo "[pre-push] scan complete, no secrets — push proceeding."
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -83,7 +83,10 @@ if command -v gitleaks >/dev/null 2>&1; then
   fi
   # Manual run / empty stdin / no non-delete refs: fall back to merge-base(HEAD)..HEAD.
   [ "$scanned_any" -eq 0 ] && scan_range "$(detect_mb HEAD)..HEAD"
+  # Reached only if scan_range never hit a leak (it exits 1 on a finding).
+  echo "[pre-push] scan complete, no secrets — push proceeding."
+else
+  echo "[pre-push] gitleaks not installed — secret scan SKIPPED (install: brew install gitleaks)"
 fi
 
-echo "[pre-push] scan complete, no secrets — push proceeding."
 exit 0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks configuration for this repository.
+#
+# Extends the bundled default ruleset and allowlists known non-secrets. gitleaks
+# auto-loads this file from the repo root, so the pre-PR scanner gate
+# (scripts/pr-scan.sh, .githooks/pre-push) and any manual `gitleaks` run pick it
+# up automatically.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known non-secrets in this repo."
+# OCD_SKIP_PRESCAN is the pre-PR gate's own escape-hatch env var; it appears in
+# help text, scripts, and docs as `OCD_SKIP_PRESCAN=1 git push`, which the
+# generic-api-key rule otherwise flags as a KEY=value secret (false positive).
+regexes = [
+  '''OCD_SKIP_PRESCAN''',
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,16 @@ KUBECONFIG=$HOME/.kube/config KUBE_CONTEXT=<your-harvester-context> \
 See `dc-api/test/integration/README.md` for coverage. For changes that don't touch
 those areas (CLI, docs, manifests), `go test ./...` (unit tests) is enough.
 
+**Self-review the diff before you push.** Run `make scan` — the deterministic
+scanner gate that runs the same open-source analyzers CodeRabbit runs
+(golangci-lint, gitleaks, osv-scanner, oasdiff, tflint/checkov, …), scoped to your
+diff. For a feature-sized change also run the `pr-review` skill (the LLM
+multi-lens review on top of the scanners). Fix what they flag *before* opening the
+PR, so the external review has little to add. One-time setup: `make scan-tools`
+installs the analyzers (best-effort brew + go), and `make hooks` wires an advisory
+pre-push hook (prints findings; blocks only on a detected secret — override with
+`OCD_SKIP_PRESCAN=1 git push`). See [`docs/pr-review-gate.md`](docs/pr-review-gate.md).
+
 **Spec-diff check for CR-building code.** Whenever dc-api generates a Kubernetes
 resource that mirrors a proven live object (Rancher `Cluster`, `HarvesterConfig`,
 KubeOVN `Vpc`/`Subnet`, `NetworkAttachmentDefinition`, per-VPC CoreDNS, …), the PR

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help bootstrap check up down db-reset build-api build-cli build run dev gen-agent-rbac
+.PHONY: help bootstrap check up down db-reset build-api build-cli build run dev gen-agent-rbac scan scan-tools hooks
 
 # Default target — print help
 help:
@@ -13,6 +13,9 @@ help:
 	@echo "  make build       Build both"
 	@echo "  make run         Source .env and run dc-api (postgres must be up)"
 	@echo "  make dev         up + build-api + run (one command for local dev)"
+	@echo "  make scan        Run the pre-PR scanner gate on your diff (OSS analyzers)"
+	@echo "  make scan-tools  Install the analyzers make scan uses (brew + go)"
+	@echo "  make hooks       Enable the advisory pre-push scanner hook (one-time)"
 
 # ── Bootstrap ─────────────────────────────────────────────────────────────────
 bootstrap:
@@ -55,6 +58,21 @@ build: build-api build-cli
 # the committed file is stale.
 gen-agent-rbac:
 	cd dc-api && go run ./cmd/gen-agent-rbac -out ../flux/platform/dc-agent/base/rbac.yaml
+
+# ── Pre-PR review gate ──────────────────────────────────────────────────────
+# Run the deterministic scanner layer (the OSS analyzers CodeRabbit runs) on your
+# diff before opening a PR; `make hooks` wires it as an advisory pre-push hook.
+scan:
+	bash scripts/pr-scan.sh
+
+# Opt-in, best-effort installer for the analyzers `make scan` runs (brew + go).
+# The scan never auto-installs; run this once to widen coverage.
+scan-tools:
+	bash scripts/install-scan-tools.sh
+
+hooks:
+	git config core.hooksPath .githooks
+	@echo "pre-push gate active — scripts/pr-scan.sh runs on push (skip once: OCD_SKIP_PRESCAN=1 git push)"
 
 # ── Run ───────────────────────────────────────────────────────────────────────
 run:

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -1,0 +1,132 @@
+# The pre-PR review gate
+
+A local, two-layer self-review you run **before opening a PR**. It front-runs the
+external reviewer (CodeRabbit): it runs the same open-source analyzers CodeRabbit
+runs and adds an LLM judgment pass, so most findings are fixed before the diff is
+ever pushed. It is **not** a replacement for CodeRabbit — CodeRabbit still runs on
+the PR — it just means there's little left for it to flag.
+
+## The two layers
+
+### Layer 1 — deterministic scanners (`make scan`)
+`scripts/pr-scan.sh` figures out what changed (the diff against the merge-base with
+`origin/controlplane`, falling back to `upstream/controlplane` then `origin/main`),
+then runs the analyzer matching each changed file type. Every tool is optional: if
+it's installed and relevant files changed it runs; otherwise it's skipped and named
+under "gaps" so coverage holes are explicit. A tool that prints findings (or exits
+nonzero) has flagged something to fix.
+
+| Tool | Runs when | Catches |
+|---|---|---|
+| **golangci-lint** | `*.go` changed | Go lint/vet/staticcheck issues (new findings vs base) |
+| **govulncheck** | `*.go` changed | Known vulnerabilities in Go deps actually reachable from your code |
+| **gitleaks** | always | Committed secrets/credentials (this is the only hard block in the hook) |
+| **osv-scanner** | `go.mod/go.sum`, `package.json`, lockfiles changed | Known-vulnerable dependency versions |
+| **redocly lint** + **oasdiff** | `openapi.yaml` changed | Spec lint errors; **breaking API changes** vs the base spec |
+| **eslint** + **tsc** | `cloud-ui/**` TS/JS changed | Lint errors and TypeScript type errors in the web app |
+| **terraform fmt** + **tflint** + **checkov** + **trivy** | `*.tf` changed | Terraform formatting, lint, and IaC security/misconfiguration (see [Terraform PRs](#terraform-prs)) |
+| **hadolint** | a `Dockerfile` changed | Dockerfile best-practice and correctness issues |
+| **actionlint** (+ **zizmor**) | `.github/workflows/*` changed | GitHub Actions workflow errors (and Actions security) |
+| **shellcheck** / **yamllint** / **markdownlint** | `*.sh` / `*.yaml` / `*.md` changed | Shell bugs, YAML errors, Markdown lint |
+| **semgrep** | `*.go/ts/tsx/js/py` changed | SAST patterns across languages |
+
+The script is macOS bash-3.2 safe and roots itself at the repo top level, so you can
+run it from any subdirectory.
+
+#### Terraform PRs
+
+Terraform is first-class here because most PRs on this stack are Terraform. When the
+diff touches any `*.tf` file, the scan runs four best-effort, init-free checks (each
+only if the tool is installed; otherwise it is named under "gaps"):
+
+| Check | What it does |
+|---|---|
+| `terraform fmt -check -recursive -diff` | Fails on unformatted HCL and prints the diff. No `terraform init` needed. |
+| `tflint --recursive` | Terraform linter — provider-aware best-practice and correctness rules. |
+| `checkov -d . --compact --quiet` | IaC security/compliance policy scan. |
+| `trivy config --quiet .` | IaC misconfiguration scan (a second, complementary policy engine). |
+
+It deliberately does **not** run `terraform validate`: that needs `terraform init`
+and provider downloads, which are environment-specific and out of scope for a local
+pre-PR diff check. Install all four with `make scan-tools` (or `brew install
+terraform tflint checkov trivy`).
+
+#### Beyond controlplane
+
+This gate lives on the **controlplane** branch (the control-plane monorepo). The
+shared Terraform module catalog lives on the **terraform** branch, and each
+environment lives in a separate consumer repo — and that is where most Terraform
+PRs are actually raised. The gate is plain files with no controlplane-specific
+dependencies, so to cover those PRs too, copy these same files into the target
+repo/branch and commit them there:
+
+- `scripts/pr-scan.sh`
+- `scripts/install-scan-tools.sh`
+- `.githooks/pre-push`
+- the `scan`, `scan-tools`, and `hooks` targets from the `Makefile` (plus their
+  `.PHONY` and `help` entries)
+
+Then run `make hooks` once in that checkout. The Terraform checks above will run on
+every `*.tf` diff there exactly as they do here.
+
+### Layer 2 — LLM multi-lens review (the `pr-review` skill)
+Scanners can't reason about intent, design, or cross-file contracts. The `pr-review`
+skill (`.claude/skills/pr-review/`) adds that: one reviewer per CodeRabbit review
+category (security, correctness, reliability, data-integrity/contracts, performance,
+maintainability, tests, docs), then an **adversarial verification** pass that tries
+to refute each finding and drops false positives, plus a real build/vet/test. It's
+told to skip anything the scanners already cover.
+
+## How to use it
+
+- **One-time install (recommended first):** run `make scan-tools` to install the
+  analyzers (best-effort via Homebrew + `go install`; it tolerates already-installed
+  tools and prints an OK/MISSING list at the end). The scan never auto-installs — it
+  only names what is missing — so do this once up front, and again whenever you start
+  touching a new file type.
+- **Every push, automatically (recommended):** run `make hooks` once. This sets
+  `git config core.hooksPath .githooks`, enabling `.githooks/pre-push`. On every
+  `git push` it runs the scanners as **advisory** output (prints findings) and
+  **hard-blocks only on a detected secret**. Skip a single push (e.g. you already
+  reviewed, or a confirmed false positive) with `OCD_SKIP_PRESCAN=1 git push`.
+- **On demand:** `make scan` (or `bash scripts/pr-scan.sh [base-ref]`) anytime.
+- **In Claude Code:** invoke the `pr-review` skill, which runs Layer 1 and then the
+  Layer-2 engine via the Workflow tool:
+  `Workflow({ scriptPath: ".claude/skills/pr-review/review.js", args: { base: "origin/controlplane", repo: "." } })`.
+
+Fix what the gate flags, then open the PR — and note in the description that you
+self-reviewed (scanners + N-lens review) so reviewers know the bar.
+
+## How it relates to CodeRabbit
+
+CodeRabbit is itself two layers: ~56 OSS analyzers in a sandbox, plus a
+context-engineered LLM with a separate judge model that filters false positives.
+This gate mirrors that locally — the same analyzers, the same multi-category LLM
+review with adversarial verification — so it acts as a **front-runner**: it catches
+most of what CodeRabbit would post, before the code is pushed. CodeRabbit still runs
+on the PR as the backstop; the goal is simply that it finds little to add.
+
+## Widen coverage
+
+`make scan` names any analyzer it couldn't run because it isn't installed, and points
+you at `make scan-tools`. The simplest path is to run that installer — it covers
+everything below in one shot (best-effort, tolerating already-installed tools):
+
+```bash
+make scan-tools
+```
+
+To install by hand instead (or on a machine without Homebrew), the equivalent set is:
+
+```bash
+# Homebrew
+brew install golangci-lint gitleaks osv-scanner actionlint shellcheck tflint \
+  checkov hadolint yamllint markdownlint-cli semgrep trivy terraform
+
+# Go-installed (resolved via $(go env GOPATH)/bin, which the script adds to PATH)
+go install github.com/oasdiff/oasdiff@latest
+go install golang.org/x/vuln/cmd/govulncheck@latest
+```
+
+Known CodeRabbit gaps you may want to cover by hand: i18n and license/SCA
+compliance.

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -6,6 +6,29 @@ runs and adds an LLM judgment pass, so most findings are fixed before the diff i
 ever pushed. It is **not** a replacement for CodeRabbit — CodeRabbit still runs on
 the PR — it just means there's little left for it to flag.
 
+## Quick start
+
+**Using Claude Code?** Just work as normal. This repo's `CLAUDE.md` tells the agent
+to run this gate against your diff before pushing, and the `pr-review` skill gives
+it the procedure — so it runs `make scan` (and, for a feature-sized change, the LLM
+review) against your changes on its own. One-time: `make scan-tools` installs the
+analyzers; `make hooks` adds a hard pre-push backstop.
+
+**Reviewing by hand (no Claude needed):**
+
+1. **One-time:** `make scan-tools` (install the analyzers via brew + go) and,
+   recommended, `make hooks` (turn on the automatic pre-push scan).
+2. **Before every PR:** `make scan` — runs the analyzers on your changed files;
+   read what it flags and fix it.
+3. **Push.** With `make hooks` on, the scan runs automatically and **blocks only on
+   a detected secret** (everything else is advisory). Override once with
+   `OCD_SKIP_PRESCAN=1 git push`.
+
+**Terraform PRs** (any `.tf` change): `make scan` runs `terraform fmt -check`,
+tflint, checkov, and trivy. If your Terraform work is on the `terraform` branch (or
+a consumer repo), the gate must be present there too — see
+[Beyond controlplane](#beyond-controlplane) below.
+
 ## The two layers
 
 ### Layer 1 — deterministic scanners (`make scan`)

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -86,6 +86,8 @@ repo/branch and commit them there:
 - `scripts/pr-scan.sh`
 - `scripts/install-scan-tools.sh`
 - `.githooks/pre-push`
+- `.gitleaks.toml` (allowlists the gate's own `OCD_SKIP_PRESCAN` escape-hatch string
+  so gitleaks doesn't flag it in help text/scripts/docs)
 - the `scan`, `scan-tools`, and `hooks` targets from the `Makefile` (plus their
   `.PHONY` and `help` entries)
 

--- a/scripts/install-scan-tools.sh
+++ b/scripts/install-scan-tools.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# install-scan-tools — opt-in, best-effort installer for the analyzers that
+# scripts/pr-scan.sh runs. The scan itself NEVER auto-installs anything; you run
+# this once (or whenever you start touching a new file type) to widen coverage.
+#
+# Usage:  scripts/install-scan-tools.sh   (or: make scan-tools)
+#
+# It installs via Homebrew (if present) and `go install` (if Go is present),
+# tolerating tools that are already installed and continuing past any single
+# failure. At the end it prints a one-line OK/MISSING availability check for every
+# tool so you can see what is ready. Portable to macOS bash 3.2 (no associative
+# arrays, no mapfile).
+set -u
+
+# Brew formulae the scanners use. terraform is here for `terraform fmt -check`.
+BREW_TOOLS="golangci-lint gitleaks osv-scanner actionlint shellcheck tflint checkov hadolint yamllint markdownlint-cli semgrep trivy terraform"
+
+# go install targets (module@version).
+GO_TOOLS="github.com/oasdiff/oasdiff@latest golang.org/x/vuln/cmd/govulncheck@latest"
+
+# Every command we ultimately want on PATH (for the final availability check).
+CHECK_CMDS="golangci-lint gitleaks osv-scanner actionlint shellcheck tflint checkov hadolint yamllint markdownlint semgrep trivy terraform oasdiff govulncheck"
+
+echo "== install-scan-tools =="
+
+# ---- Homebrew formulae ----
+if command -v brew >/dev/null 2>&1; then
+  echo
+  echo "-- brew install (tolerating already-installed) --"
+  for t in $BREW_TOOLS; do
+    echo ">> brew install $t"
+    brew install "$t" || echo "   (skipped: brew install $t failed — continuing)"
+  done
+else
+  echo
+  echo "Homebrew (brew) not found — skipping the brew tools. Install them manually with"
+  echo "your package manager. The full list is:"
+  echo "  $BREW_TOOLS"
+fi
+
+# ---- go install targets ----
+if command -v go >/dev/null 2>&1; then
+  echo
+  echo "-- go install --"
+  for g in $GO_TOOLS; do
+    echo ">> go install $g"
+    go install "$g" || echo "   (skipped: go install $g failed — continuing)"
+  done
+  # Make freshly go-installed tools discoverable for the availability check below.
+  GOBIN_DIR="$(go env GOPATH 2>/dev/null)/bin"
+  case ":$PATH:" in *":$GOBIN_DIR:"*) :;; *) PATH="$GOBIN_DIR:$PATH";; esac
+else
+  echo
+  echo "Go (go) not found — skipping the go-installed tools (oasdiff, govulncheck)."
+  echo "Install Go, then re-run, or run manually:"
+  for g in $GO_TOOLS; do echo "  go install $g"; done
+fi
+
+# ---- availability check ----
+echo
+echo "-- availability (what pr-scan can use now) --"
+missing=0
+for c in $CHECK_CMDS; do
+  if command -v "$c" >/dev/null 2>&1; then
+    echo "  OK       $c"
+  else
+    echo "  MISSING  $c"
+    missing=$((missing + 1))
+  fi
+done
+
+echo
+if [ "$missing" -eq 0 ]; then
+  echo "All scan tools are available."
+else
+  echo "$missing tool(s) still MISSING above — re-run after installing them, or install by hand."
+fi
+exit 0

--- a/scripts/install-scan-tools.sh
+++ b/scripts/install-scan-tools.sh
@@ -47,6 +47,9 @@ if command -v go >/dev/null 2>&1; then
     go install "$g" || echo "   (skipped: go install $g failed — continuing)"
   done
   # Make freshly go-installed tools discoverable for the availability check below.
+  # `go install` writes to $GOBIN when set, else $GOPATH/bin — add both.
+  GO_BIN_ENV="$(go env GOBIN 2>/dev/null)"
+  [ -n "$GO_BIN_ENV" ] && case ":$PATH:" in *":$GO_BIN_ENV:"*) :;; *) PATH="$GO_BIN_ENV:$PATH";; esac
   GOBIN_DIR="$(go env GOPATH 2>/dev/null)/bin"
   case ":$PATH:" in *":$GOBIN_DIR:"*) :;; *) PATH="$GOBIN_DIR:$PATH";; esac
 else

--- a/scripts/pr-scan.sh
+++ b/scripts/pr-scan.sh
@@ -10,8 +10,10 @@
 #
 # Usage:  scripts/pr-scan.sh [base-ref]
 #   base-ref  defaults to the first available of origin/controlplane,
-#             upstream/controlplane, origin/main, else HEAD~1. The diff is taken
-#             from the merge-base of HEAD with that ref.
+#             upstream/controlplane, origin/main, else HEAD~1. The changed-file set
+#             is the WORKING TREE (committed + staged + unstaged) diffed against the
+#             merge-base of HEAD with that ref — so it reflects what you're about to
+#             push/commit, not just committed history.
 #
 # Run it from anywhere in the repo — it roots itself at the repo top level.
 # Portable to macOS bash 3.2 (no mapfile / no associative arrays).
@@ -21,8 +23,11 @@ set -u
 REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "pr-scan: not inside a git repo"; exit 2; }
 cd "$REPO" || { echo "pr-scan: cannot cd to $REPO"; exit 2; }
 
-# Make go-installed tools (oasdiff, govulncheck) discoverable.
+# Make go-installed tools (oasdiff, govulncheck) discoverable. `go install` writes
+# to $GOBIN when set, else to $GOPATH/bin — prepend both so either layout works.
 if command -v go >/dev/null 2>&1; then
+  GO_BIN_ENV="$(go env GOBIN 2>/dev/null)"
+  [ -n "$GO_BIN_ENV" ] && case ":$PATH:" in *":$GO_BIN_ENV:"*) :;; *) PATH="$GO_BIN_ENV:$PATH";; esac
   GOBIN_DIR="$(go env GOPATH 2>/dev/null)/bin"
   case ":$PATH:" in *":$GOBIN_DIR:"*) :;; *) PATH="$GOBIN_DIR:$PATH";; esac
 fi
@@ -37,7 +42,9 @@ fi
 MB="$(git merge-base HEAD "$BASE" 2>/dev/null || echo "$BASE")"
 
 FL="$(mktemp)"; OASB="$(mktemp)"; trap 'rm -f "$FL" "$OASB"' EXIT
-git diff --name-only "$MB"...HEAD > "$FL" 2>/dev/null
+# Scan the WORKING TREE vs the merge-base (committed + staged + unstaged), since the
+# gate is meant to run before commit. Base versions are read with `git show $MB:...`.
+git diff --name-only "$MB" > "$FL" 2>/dev/null
 N=$(grep -c . "$FL" 2>/dev/null || echo 0)
 echo "== pr-scan scanners ==  base=$BASE  merge-base=${MB:0:12}  changed-files=$N"
 [ "$N" -eq 0 ] && { echo "nothing changed vs base — nothing to scan"; exit 0; }
@@ -76,14 +83,19 @@ if match 'go\.(mod|sum)$|package\.json$|pnpm-lock|yarn\.lock$'; then
   else gap "osv-scanner" "brew install osv-scanner"; fi
 fi
 
-# ---- OpenAPI: lint + breaking-change vs base ----
+# ---- OpenAPI: lint + breaking-change vs base (every changed spec, not just one) ----
 if match 'openapi\.ya?ml$'; then
-  SPEC="$(grep -iE 'openapi\.ya?ml$' "$FL" | head -1)"
-  sec "redocly lint ($SPEC)"; npx --yes @redocly/cli lint "$SPEC" 2>&1 | tail -20
-  if have oasdiff; then sec "oasdiff (OpenAPI breaking changes)"
-    if git show "$MB:$SPEC" > "$OASB" 2>/dev/null; then oasdiff breaking "$OASB" "$SPEC" 2>&1 | head -40
-    else echo "(no base version of $SPEC — treated as new)"; fi
-  else gap "oasdiff" "go install github.com/oasdiff/oasdiff@latest"; fi
+  # Record coverage gaps once, at top level (a `grep | while` body is a subshell and
+  # would lose GAPS mutations). The per-spec loop below only runs the tools.
+  have npx     || gap "redocly lint" "needs npx/node"
+  have oasdiff || gap "oasdiff" "go install github.com/oasdiff/oasdiff@latest"
+  grep -iE 'openapi\.ya?ml$' "$FL" | while IFS= read -r SPEC; do [ -n "$SPEC" ] || continue
+    if have npx; then sec "redocly lint ($SPEC)"; npx --yes @redocly/cli lint "$SPEC" 2>&1 | tail -20; fi
+    if have oasdiff; then sec "oasdiff ($SPEC, breaking changes)"
+      if git show "$MB:$SPEC" > "$OASB" 2>/dev/null; then oasdiff breaking "$OASB" "$SPEC" 2>&1 | head -40
+      else echo "(no base version of $SPEC — treated as new)"; fi
+    fi
+  done
 fi
 
 # ---- cloud-ui TS (project-local eslint + tsc) ----

--- a/scripts/pr-scan.sh
+++ b/scripts/pr-scan.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# pr-scan — the deterministic scanner layer of the pre-PR review gate. Runs the
+# same open-source analyzers CodeRabbit runs in its sandbox, locally, scoped to
+# your diff, BEFORE you push — so its tool-based comments are pre-empted.
+#
+# Every tool is optional: installed + relevant files changed -> run; otherwise it
+# is skipped and named under "gaps" so coverage holes are explicit. A tool
+# printing findings (or exiting nonzero) means it FLAGGED something — read that
+# section and fix it before opening the PR.
+#
+# Usage:  scripts/pr-scan.sh [base-ref]
+#   base-ref  defaults to the first available of origin/controlplane,
+#             upstream/controlplane, origin/main, else HEAD~1. The diff is taken
+#             from the merge-base of HEAD with that ref.
+#
+# Run it from anywhere in the repo — it roots itself at the repo top level.
+# Portable to macOS bash 3.2 (no mapfile / no associative arrays).
+set -u
+
+# Root at the repo top level regardless of where we were invoked from.
+REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "pr-scan: not inside a git repo"; exit 2; }
+cd "$REPO" || { echo "pr-scan: cannot cd to $REPO"; exit 2; }
+
+# Make go-installed tools (oasdiff, govulncheck) discoverable.
+if command -v go >/dev/null 2>&1; then
+  GOBIN_DIR="$(go env GOPATH 2>/dev/null)/bin"
+  case ":$PATH:" in *":$GOBIN_DIR:"*) :;; *) PATH="$GOBIN_DIR:$PATH";; esac
+fi
+
+BASE="${1:-}"
+if [ -z "$BASE" ]; then
+  for b in origin/controlplane upstream/controlplane origin/main; do
+    git rev-parse --verify --quiet "$b" >/dev/null 2>&1 && { BASE="$b"; break; }
+  done
+  [ -z "$BASE" ] && BASE="HEAD~1"
+fi
+MB="$(git merge-base HEAD "$BASE" 2>/dev/null || echo "$BASE")"
+
+FL="$(mktemp)"; OASB="$(mktemp)"; trap 'rm -f "$FL" "$OASB"' EXIT
+git diff --name-only "$MB"...HEAD > "$FL" 2>/dev/null
+N=$(grep -c . "$FL" 2>/dev/null || echo 0)
+echo "== pr-scan scanners ==  base=$BASE  merge-base=${MB:0:12}  changed-files=$N"
+[ "$N" -eq 0 ] && { echo "nothing changed vs base — nothing to scan"; exit 0; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+match(){ grep -qiE "$1" "$FL"; }
+sec(){ echo; echo "### $1"; }
+GAPS=""
+gap(){ GAPS="$GAPS
+  - $1  ($2)"; }
+
+# ---- Go (multi-module: run in each module root that owns a changed .go file) ----
+if match '\.go$'; then
+  MODS="$(grep -iE '\.go$' "$FL" | while IFS= read -r f; do
+            d="$(dirname "$f")"
+            while [ "$d" != "." ] && [ "$d" != "/" ] && [ ! -f "$d/go.mod" ]; do d="$(dirname "$d")"; done
+            [ -f "$d/go.mod" ] && echo "$d"
+          done | sort -u)"
+  if have golangci-lint; then
+    echo "$MODS" | while IFS= read -r m; do [ -n "$m" ] || continue
+      sec "golangci-lint ($m)"; ( cd "$m" && golangci-lint run --new-from-rev "$MB" ./... 2>&1 | head -80 ); done
+  else gap "golangci-lint" "brew install golangci-lint"; fi
+  if have govulncheck; then
+    echo "$MODS" | while IFS= read -r m; do [ -n "$m" ] || continue
+      sec "govulncheck ($m)"; ( cd "$m" && govulncheck ./... 2>&1 | head -40 ); done
+  else gap "govulncheck" "go install golang.org/x/vuln/cmd/govulncheck@latest"; fi
+fi
+
+# ---- secrets (always; scoped to the new commits) ----
+if have gitleaks; then sec "gitleaks (secrets)"; gitleaks git --no-banner --redact --log-opts="$MB..HEAD" 2>&1 | tail -30
+else gap "gitleaks" "brew install gitleaks"; fi
+
+# ---- dependency vulns ----
+if match 'go\.(mod|sum)$|package\.json$|pnpm-lock|yarn\.lock$'; then
+  if have osv-scanner; then sec "osv-scanner (deps)"; osv-scanner scan source -r . 2>&1 | tail -40
+  else gap "osv-scanner" "brew install osv-scanner"; fi
+fi
+
+# ---- OpenAPI: lint + breaking-change vs base ----
+if match 'openapi\.ya?ml$'; then
+  SPEC="$(grep -iE 'openapi\.ya?ml$' "$FL" | head -1)"
+  sec "redocly lint ($SPEC)"; npx --yes @redocly/cli lint "$SPEC" 2>&1 | tail -20
+  if have oasdiff; then sec "oasdiff (OpenAPI breaking changes)"
+    if git show "$MB:$SPEC" > "$OASB" 2>/dev/null; then oasdiff breaking "$OASB" "$SPEC" 2>&1 | head -40
+    else echo "(no base version of $SPEC — treated as new)"; fi
+  else gap "oasdiff" "go install github.com/oasdiff/oasdiff@latest"; fi
+fi
+
+# ---- cloud-ui TS (project-local eslint + tsc) ----
+if match 'cloud-ui/.*\.(ts|tsx|js|jsx)$'; then
+  if [ -d cloud-ui ] && have pnpm; then
+    sec "eslint + tsc (cloud-ui)"; ( cd cloud-ui && pnpm exec eslint . 2>&1 | tail -50; pnpm exec tsc --noEmit 2>&1 | tail -20 )
+  else gap "cloud-ui lint" "corepack enable && pnpm -C cloud-ui install"; fi
+fi
+
+# ---- Terraform (first-class: the team mostly sends TF PRs) ----
+# All best-effort and init-free; we deliberately do NOT run `terraform validate`
+# (it needs `terraform init`/providers, which is environment-specific).
+if match '\.tf$'; then
+  if have terraform; then sec "terraform fmt -check"; terraform fmt -check -recursive -diff 2>&1 | head -60
+  else gap "terraform fmt" "brew install terraform"; fi
+  if have tflint; then sec "tflint"; tflint --recursive 2>&1 | head -40; else gap "tflint" "brew install tflint"; fi
+  if have checkov; then sec "checkov (IaC security)"; checkov -d . --compact --quiet 2>&1 | tail -40; else gap "checkov" "brew install checkov"; fi
+  if have trivy; then sec "trivy config (IaC misconfig)"; trivy config --quiet . 2>&1 | tail -40; else gap "trivy" "brew install trivy"; fi
+fi
+
+# ---- Dockerfiles ----
+if match '(^|/)Dockerfile'; then
+  if have hadolint; then sec "hadolint"; grep -iE '(^|/)Dockerfile' "$FL" | while IFS= read -r f; do [ -f "$f" ] && { echo "-- $f"; hadolint "$f"; }; done 2>&1 | head -40
+  else gap "hadolint" "brew install hadolint"; fi
+fi
+
+# ---- GitHub Actions ----
+if match '\.github/workflows/.*\.ya?ml$'; then
+  if have actionlint; then sec "actionlint"; actionlint 2>&1 | head -40; else gap "actionlint" "brew install actionlint"; fi
+  have zizmor && { sec "zizmor (Actions security)"; zizmor .github/workflows 2>&1 | tail -30; }
+fi
+
+# ---- shell / yaml / markdown ----
+if match '\.sh$'; then
+  if have shellcheck; then sec "shellcheck"; grep -iE '\.sh$' "$FL" | while IFS= read -r f; do [ -f "$f" ] && shellcheck "$f"; done 2>&1 | head -60
+  else gap "shellcheck" "brew install shellcheck"; fi
+fi
+if match '\.ya?ml$'; then
+  if have yamllint; then sec "yamllint"; grep -iE '\.ya?ml$' "$FL" | while IFS= read -r f; do [ -f "$f" ] && yamllint -f parsable "$f"; done 2>&1 | head -60
+  else gap "yamllint" "brew install yamllint"; fi
+fi
+if match '\.md$'; then
+  if have markdownlint; then sec "markdownlint"; grep -iE '\.md$' "$FL" | while IFS= read -r f; do [ -f "$f" ] && markdownlint "$f"; done 2>&1 | head -40
+  else gap "markdownlint" "npm i -g markdownlint-cli"; fi
+fi
+
+# ---- SAST (multi-language) ----
+if match '\.(go|ts|tsx|js|py)$'; then
+  if have semgrep; then sec "semgrep (SAST)"; semgrep --config auto --error -q 2>&1 | tail -60
+  else gap "semgrep" "brew install semgrep"; fi
+fi
+
+echo
+echo "== summary =="
+echo "Read each section above. Findings (or a nonzero tool exit) = something to address."
+if [ -n "$GAPS" ]; then
+  echo "not installed for files in this diff (install to widen coverage):$GAPS"
+  echo
+  echo "Install them all at once:  make scan-tools  (best-effort brew + go installer)"
+else
+  echo "all applicable scanners were available."
+fi

--- a/scripts/pr-scan.sh
+++ b/scripts/pr-scan.sh
@@ -125,7 +125,7 @@ fi
 # ---- GitHub Actions ----
 if match '\.github/workflows/.*\.ya?ml$'; then
   if have actionlint; then sec "actionlint"; actionlint 2>&1 | head -40; else gap "actionlint" "brew install actionlint"; fi
-  have zizmor && { sec "zizmor (Actions security)"; zizmor .github/workflows 2>&1 | tail -30; }
+  if have zizmor; then sec "zizmor (Actions security)"; zizmor .github/workflows 2>&1 | tail -30; else gap "zizmor" "brew install zizmor"; fi
 fi
 
 # ---- shell / yaml / markdown ----


### PR DESCRIPTION
## What this adds

A local, pre-PR review gate so contributors catch most issues **before** opening a PR — leaving less for CodeRabbit to publicly flag. It mirrors how CodeRabbit works: a deterministic layer of real OSS analyzers, plus an optional LLM review for Claude Code users.

## Two layers

- **Deterministic — `make scan`** (`scripts/pr-scan.sh`): runs the same open-source analyzers CodeRabbit runs, scoped to your diff and auto-selected by changed file type. Advisory; prints findings and **names any analyzer it couldn't run** so coverage gaps are explicit.
  - **Terraform is first-class** (most of our PRs are TF): on any `.tf` change it runs `terraform fmt -check`, **tflint**, **checkov** (IaC security), and **trivy config** (IaC misconfig) — all static, no `terraform init` needed.
  - Plus: golangci-lint + govulncheck (Go), gitleaks (secrets), osv-scanner (deps), oasdiff + redocly (OpenAPI breaking-change + lint), eslint + tsc (cloud-ui), actionlint, shellcheck, hadolint, and more.
- **LLM (Claude Code) — the `pr-review` skill** (`.claude/skills/pr-review/`): a multi-lens review across the standard categories (security, correctness, reliability, data/contracts, performance, maintainability, tests, docs) with adversarial verification. For feature-sized diffs.

## Setup & usage

- **`make scan-tools`** — one-time, opt-in installer (`brew` + `go install`) for the whole analyzer set, including the Terraform tools. The scan never auto-installs; it points here when something's missing.
- **`make scan`** — run the deterministic layer on your diff.
- **`make hooks`** — one-time: wire it as an advisory **pre-push hook** (prints findings; blocks only on a detected secret; override a false positive with `OCD_SKIP_PRESCAN=1 git push`).
- Claude Code users: the `pr-review` skill runs both layers.
- [`docs/pr-review-gate.md`](docs/pr-review-gate.md) covers the tools, the Terraform coverage, and usage.

## Beyond controlplane

This gate lives on `controlplane`. TF PRs that target the `terraform` branch or the consumer repos need the same files copied there too (`scripts/pr-scan.sh`, `scripts/install-scan-tools.sh`, `.githooks/pre-push`, and the `scan`/`scan-tools`/`hooks` Makefile targets) — a quick follow-up, documented in the doc.

## Why

CodeRabbit is high-recall but verbose; running its tool layer ourselves first (deterministic, no guesswork) plus a quick LLM pass means fewer public review cycles and cleaner PRs. **A front-runner, not a replacement** — CodeRabbit still runs on every PR.

## Notes

No application code changes — only `scripts/`, `.githooks/`, `Makefile`, `docs/`, `.claude/skills/`, and a `CLAUDE.md` note. Scanners are optional/best-effort (run only if installed and relevant files changed), so this adds no hard dependency; the hook is advisory and opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local review gate that can scan changes before push and flag potential secrets.
  * Added a guided PR-review workflow for deeper change checks.

* **Documentation**
  * Added setup and usage guidance for running scans, enabling hooks, and using the new review workflow.
  * Updated contributor instructions to include a self-review checklist before pushing changes.

* **Chores**
  * Added helper commands and scripts to install scan tools and wire the pre-push hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->