### PR TITLE
[Feature] Add the pre-PR scanner gate + CLAUDE.md for terraform

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -26,7 +26,7 @@ It auto-selects tools by changed file type (`.tf` → terraform fmt + tflint + c
 
 ### Layer 2 — LLM multi-lens adversarial review (the judgment half)
 The scanners can't reason about intent, design, or cross-module contracts. For that, run the engine via the Workflow tool:
-```
+```text
 Workflow({ scriptPath: ".claude/skills/pr-review/review.js",
            args: { base: "<base, e.g. origin/terraform>", repo: "." } })
 ```

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: pr-review
+description: Pre-PR self-review modeled on how CodeRabbit actually works — a deterministic scanner layer (the same OSS analyzers CodeRabbit runs) plus an LLM multi-lens adversarial review across CodeRabbit's six review categories. Run on the branch/staged diff before every commit and PR, so the external reviewer (CodeRabbit) has little to add. Drops false positives via adversarial verification; runs the real validate/lint.
+---
+
+# pr-review — review your diff the way CodeRabbit will, first
+
+Run this on the diff **before every commit + PR**. Goal: catch most of what CodeRabbit would post — *before* pushing — so it isn't publicly dismissing already-pushed code, and so the human reviewer sees a clean diff. This is the Terraform module catalog, so the gate is **Terraform-first**.
+
+## How CodeRabbit actually works (what we're replicating)
+CodeRabbit is **two layers**, not one LLM:
+1. **~56 OSS analyzers** run in a sandbox (Checkov/Trivy/TFLint for IaC, Gitleaks, Semgrep, ast-grep, actionlint, ShellCheck, yamllint, LanguageTool, …).
+2. **A context-engineered LLM** that reads the diff + surrounding code + linked issues, then a **separate judge model** filters false positives before posting.
+
+Its findings are tagged **severity** (Critical · Major · Minor · Trivial · Info) and triaged **Security → Correctness → Performance → Reliability → Best-practice → Style**. Its documented review taxonomy is **six categories** (below). It is high-recall but only ~middling precision (≈50%) and tends to be verbose/nitpicky — so our edge is **running the same scanners deterministically** (no guesswork) **and adversarially verifying the LLM findings** (kill the nits).
+
+## Two layers, run in order
+
+### Layer 1 — deterministic scanners (the cheap, certain half)
+Run the same OSS tools CodeRabbit runs, locally, scoped to the diff:
+```bash
+make scan                 # from the repo root, or:
+bash scripts/pr-scan.sh   # optional first arg: a base ref (default: merge-base with origin/terraform)
+```
+It auto-selects tools by changed file type (`.tf` → terraform fmt + tflint + checkov + trivy; secrets → gitleaks; Dockerfile → hadolint; workflows → actionlint; shell/yaml/md → shellcheck/yamllint/markdownlint; SAST → semgrep). Checkov picks up the repo's `.checkov.yaml` automatically. Fix everything it reports — these are exactly the comments CodeRabbit's tool layer would post. It names any tool it couldn't run (not installed) so coverage gaps are explicit; widen coverage by installing them (see `docs/pr-review-gate.md`).
+
+### Layer 2 — LLM multi-lens adversarial review (the judgment half)
+The scanners can't reason about intent, design, or cross-module contracts. For that, run the engine via the Workflow tool:
+```
+Workflow({ scriptPath: ".claude/skills/pr-review/review.js",
+           args: { base: "<base, e.g. origin/terraform>", repo: "." } })
+```
+One reviewer per CodeRabbit category, each finding adversarially re-checked (try to *refute* it; drop if already-handled or uncertain), plus a real fmt/validate/lint run. Returns `{ confirmed (by severity), build, droppedFalsePositives }`. **Don't have the LLM re-do what the scanners cover** (formatting, lint, known policy patterns) — it focuses on judgment.
+
+## The rubric — CodeRabbit's six categories (+ tests, docs)
+Each finding gets a **severity** (Critical/Major/Minor/Trivial/Info) and, where useful, an **effort** note (quick win / heavy lift).
+
+1. **Security & Privacy** — insecure defaults, over-broad IAM/RBAC, unencrypted or publicly-exposed resources, secrets in variables/outputs, missing input validation, data exposure. *(Layer-1: checkov/trivy/gitleaks; Layer-2: defaults that are technically allowed but wrong for the module, reasoning about real exposure.)*
+2. **Functional Correctness** — logic errors, wrong `count`/`for_each`/conditions, off-by-one, unhandled edge cases, null handling, **HCL or examples that don't match the stated intent / the variable description / the linked issue**.
+3. **Stability & Reliability** — resource-lifecycle hazards (forced replacement, destroy-before-create, missing `depends_on`/`create_before_destroy`), **provider/version-constraint drift**, missing timeouts/retries, **backward-compat for module consumers**.
+4. **Data Integrity & Integration** — **module input/output contract breaks & backward-compat** (renamed/removed/retyped variables or outputs, changed defaults that silently alter consumer behavior), state-move hazards, cross-module effects the diff can't show. *(Layer-1: none for HCL contracts; Layer-2 owns this.)*
+5. **Performance & Scalability** — unnecessary resource churn, expensive data sources in hot paths, unbounded `for_each`/`count`, patterns that scale poorly across many tenants/clusters.
+6. **Maintainability & Code Quality** — naming, structure/readability, **duplication/DRY across modules**, complexity, **dead code** — and **does a new module/resource follow the same conventions/guards as its siblings in the same family?**
+7. **Tests** — new variables/branches/examples exercised? does each example **fmt-clean and `terraform validate`** (where providers are initialized)? are README/example snippets consistent with the actual variables and outputs?
+8. **Documentation & conventions** — stale variable descriptions/READMEs not updated to match the change; docs that now contradict the HCL; PR title/description quality; **plus every applicable rule from the repo's CLAUDE.md** (catalog conventions, `.checkov.yaml` skips, ref-pinning style). Read CLAUDE.md first.
+
+*(Formatting/style/typos are delegated to Layer-1 linters + LanguageTool-class tools — don't hand-nitpick them.)*
+
+## Procedure
+1. Scope the diff (base branch / merge-base). Note new/changed public surface (module variables, outputs, examples, new modules).
+2. **Layer 1:** run `make scan`; fix every real finding; note any uninstalled tool as a coverage gap.
+3. **Layer 2:** run `review.js` for a non-trivial diff (inline a few lenses for a tiny one). Always keep the adversarial-verify step — it's what beats CodeRabbit's precision.
+4. Triage confirmed findings **Security → Correctness → Performance → Reliability → Best-practice → Style**. Fix blockers + majors; decide minors/nits explicitly.
+5. Re-run the affected scanner/lens after a substantive fix, then open the PR.
+6. In the PR body, note "self-reviewed: scanners + N-lens review" so reviewers know the bar.
+
+## Scale & gaps
+Scale to the diff: a one-variable tweak → `make scan` + a couple of lenses; a new module → the full set. Known CodeRabbit gaps to optionally cover yourself: i18n and license/SCA compliance. This is a **front-runner** for CodeRabbit, not a replacement — CodeRabbit still runs on the PR; see `docs/pr-review-gate.md` for how the two relate and how to enable the advisory pre-push hook (`make hooks`).

--- a/.claude/skills/pr-review/review.js
+++ b/.claude/skills/pr-review/review.js
@@ -10,9 +10,10 @@ export const meta = {
 // args.base = review base (PR base branch / merge-base). args.repo = repo path (default: repo root).
 const base = (args && args.base) || 'origin/terraform'
 const repo = (args && args.repo) || '.'
-// Working tree vs base (committed + staged + unstaged) — the gate runs before commit,
-// so uncommitted changes must be in scope.
-const diffRef = `git -C ${repo} diff ${base}`
+// Working tree vs merge-base (committed + staged + unstaged) — the gate runs before
+// commit, so uncommitted changes must be in scope; the merge-base (matching Layer 1 /
+// scan.sh) excludes upstream-only changes when the branch is behind base.
+const diffRef = `git -C ${repo} diff $(git -C ${repo} merge-base HEAD ${base})`
 
 const SEV = ['critical', 'major', 'minor', 'trivial', 'info']
 const FINDINGS = {

--- a/.claude/skills/pr-review/review.js
+++ b/.claude/skills/pr-review/review.js
@@ -1,0 +1,84 @@
+export const meta = {
+  name: 'pr-review',
+  description: 'LLM half of the pr-review gate: one reviewer per CodeRabbit review category (judgment, not lint), adversarial verification of each finding to drop false positives, a real validate/lint run, then synthesis. Pair with scripts/pr-scan.sh (the deterministic tool layer).',
+  phases: [
+    { title: 'Review', detail: 'one reviewer per category + a validate/lint run' },
+    { title: 'Verify', detail: 'adversarially confirm or refute each candidate finding' },
+  ],
+}
+
+// args.base = review base (PR base branch / merge-base). args.repo = repo path (default: repo root).
+const base = (args && args.base) || 'origin/terraform'
+const repo = (args && args.repo) || '.'
+// Working tree vs base (committed + staged + unstaged) — the gate runs before commit,
+// so uncommitted changes must be in scope.
+const diffRef = `git -C ${repo} diff ${base}`
+
+const SEV = ['critical', 'major', 'minor', 'trivial', 'info']
+const FINDINGS = {
+  type: 'object', additionalProperties: false, required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['file', 'severity', 'category', 'title', 'detail'],
+        properties: {
+          file: { type: 'string' }, line: { type: 'string' },
+          severity: { enum: SEV }, category: { type: 'string' },
+          title: { type: 'string' }, detail: { type: 'string' }, fix: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const SCANNERS_NOTE = 'The deterministic scanner layer (terraform fmt, tflint, checkov, trivy, gitleaks, actionlint, shellcheck, yamllint, semgrep, etc.) already covers formatting, lint rules, IaC security/misconfig policy, secrets, and known-vuln patterns — do NOT re-report those. Focus only on what a linter cannot judge.'
+
+const LENSES = [
+  { key: 'security-privacy', focus: 'Insecure defaults, over-broad IAM/RBAC, exposed or unencrypted resources, secret handling in variables/outputs, public network exposure, missing input validation — the judgment a policy scanner misses (e.g. a default that is technically allowed but wrong for this module).' },
+  { key: 'correctness', focus: 'Logic errors, wrong conditions/count/for_each, off-by-one, unhandled edge cases, null handling, and code (HCL or examples) that does NOT match its stated intent, the variable description, or the linked issue.' },
+  { key: 'reliability', focus: 'Resource lifecycle hazards (forced replacement, destroy-before-create, missing depends_on), provider/version-constraint drift, create_before_destroy gaps, missing timeouts/retries, and backward-compat for module consumers (a renamed/removed variable or output is a breaking change).' },
+  { key: 'data-integrity-contracts', focus: 'Module input/output contract breaks & backward-compat — renamed/removed/retyped variables or outputs, changed defaults that silently alter consumer behavior, state-move hazards, and cross-module effects the diff alone cannot show.' },
+  { key: 'performance', focus: 'Unnecessary resource churn, expensive data sources in hot paths, unbounded for_each/count, and patterns that scale poorly across many tenants/clusters.' },
+  { key: 'maintainability-design', focus: 'Naming, structure/readability, duplication/DRY across modules, complexity, dead code, variable/output design — and especially: does a NEW module or resource follow the SAME conventions/guards as its siblings in the same family?' },
+  { key: 'tests', focus: 'Are new variables/branches/examples exercised? does each example terraform-validate and stay fmt-clean? are README/example snippets consistent with the actual variables and outputs?' },
+  { key: 'docs-conventions', focus: 'Stale comments/variable-descriptions/READMEs not updated to match the change; docs now contradicting the HCL; PLUS every applicable rule from the repo CLAUDE.md and the module-catalog conventions (fmt+validate, the .checkov.yaml skips, ref-pinning style) — read CLAUDE.md in the repo first.' },
+]
+
+phase('Review')
+const reviews = (await parallel(LENSES.map(l => () =>
+  agent(
+    `You are a strict senior Terraform/IaC reviewer (CodeRabbit-grade). Review ONLY the change in \`${diffRef}\` (read surrounding code in ${repo} for context) through ONE category: ${l.key}.\nFocus: ${l.focus}\n${SCANNERS_NOTE}\nReport concrete, line-anchored findings only — no vague advice, no praise. Severity: critical (ship-stopper), major (fix before merge), minor, trivial, info. Return an empty findings array if clean on this category.`,
+    { label: `lens:${l.key}`, phase: 'Review', schema: FINDINGS, agentType: 'Explore', effort: 'high' }
+  )
+))).filter(Boolean)
+
+const BUILD = { type: 'object', additionalProperties: false, required: ['pass', 'detail'], properties: { pass: { type: 'boolean' }, detail: { type: 'string' } } }
+const build = await agent(
+  `In ${repo}, check the Terraform touched by \`${diffRef}\`. Run terraform fmt -check -recursive -diff, and tflint --recursive if available. For any module/example whose providers are already initialized (.terraform present), run terraform validate; otherwise note it needs terraform init and skip it (do not run init — it is environment-specific). Report verbatim pass/fail per module/example.`,
+  { label: 'build-test', phase: 'Review', schema: BUILD, agentType: 'Explore', effort: 'high' }
+)
+
+const candidates = reviews.flatMap(r => (r && r.findings) || [])
+const rank = { critical: 0, major: 1, minor: 2, trivial: 3, info: 4 }
+
+phase('Verify')
+const VERDICT = { type: 'object', additionalProperties: false, required: ['real', 'reason'], properties: { real: { type: 'boolean' }, severity: { enum: SEV }, reason: { type: 'string' } } }
+const verified = (await parallel(candidates.map(f => () =>
+  agent(
+    `Adversarially verify this review finding against the ACTUAL code in ${repo} (diff base ${base}). Try to REFUTE it: is it real, still valid, and NOT already handled elsewhere (a variable default, a validation block, an existing example, intentional design, or a .checkov.yaml skip)? Read the cited file and its neighbours.\nFinding: ${f.severity} | ${f.category} | ${f.file}:${f.line || '?'} — ${f.title}\n${f.detail}\nDefault real=false when uncertain — a confident wrong finding costs more than a missed nit. Return {real, severity (your re-assessed severity), reason}.`,
+    { label: `verify:${f.file}`, phase: 'Verify', schema: VERDICT, agentType: 'Explore', effort: 'high' }
+  ).then(v => (v ? { ...f, verdict: v } : null))
+))).filter(Boolean)
+
+const confirmed = verified
+  .filter(f => f.verdict.real)
+  .map(f => ({ ...f, severity: f.verdict.severity || f.severity }))
+  .sort((a, b) => rank[a.severity] - rank[b.severity])
+
+return {
+  confirmed,
+  build,
+  droppedFalsePositives: verified.filter(f => !f.verdict.real).map(f => ({ title: f.title, file: f.file, why: f.verdict.reason })),
+}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -77,7 +77,10 @@ if command -v gitleaks >/dev/null 2>&1; then
   fi
   # Manual run / empty stdin / no non-delete refs: fall back to merge-base(HEAD)..HEAD.
   [ "$scanned_any" -eq 0 ] && scan_range "$(detect_mb HEAD)..HEAD"
+  # Reached only if scan_range never hit a leak (it exits 1 on a finding).
+  echo "[pre-push] scan complete, no secrets — push proceeding."
+else
+  echo "[pre-push] gitleaks not installed — secret scan SKIPPED (install: brew install gitleaks)"
 fi
 
-echo "[pre-push] scan complete, no secrets — push proceeding."
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# pre-push hook — run the pr-scan scanner gate before pushing.
+# Enable it once with:  make hooks   (sets core.hooksPath to .githooks)
+#
+# Behavior: ADVISORY — prints all scanner findings for triage; HARD-BLOCKS only
+# on secrets (gitleaks), which are clear-cut. Everything else (terraform fmt /
+# tflint / checkov / trivy / lint) is printed but does not block, so a pre-existing
+# IaC finding can't stop a push.
+#
+# Skip once (e.g. you already ran the pr-review skill, or a confirmed false
+# positive):
+#     OCD_SKIP_PRESCAN=1 git push
+#
+# Args: $1=remote name  $2=remote URL.  Stdin: <localref> <localsha> <remoteref> <remotesha>.
+set -u
+
+if [ "${OCD_SKIP_PRESCAN:-0}" = "1" ]; then
+  echo "[pre-push] OCD_SKIP_PRESCAN=1 — pr-scan skipped"
+  exit 0
+fi
+
+REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+SCAN="$REPO/scripts/pr-scan.sh"
+if [ ! -f "$SCAN" ]; then
+  echo "[pre-push] scripts/pr-scan.sh not found — skipping (nothing to gate)"
+  exit 0
+fi
+
+echo "[pre-push] pr-scan scanners — advisory, blocks only on secrets. Skip with: OCD_SKIP_PRESCAN=1 git push"
+bash "$SCAN" 2>&1 || true
+
+# --- hard block: secrets only ---
+# Scan exactly the commits being pushed, read from the pre-push stdin protocol:
+#   <localref> <localsha> <remoteref> <remotesha>  (one line per ref)
+# Deletes (localsha all-zeros) are skipped; a new remote ref (remotesha all-zeros)
+# is scanned from the detected base's merge-base; otherwise we scan remotesha..localsha.
+# If stdin is empty (run manually), fall back to merge-base(HEAD, base)..HEAD.
+ZERO='^0\{7,\}$'   # all-zeros object id (any length)
+
+detect_mb() {  # echo the merge-base of $1 with the first available upstream base
+  _b=""
+  for _r in origin/terraform upstream/terraform origin/main; do
+    git rev-parse --verify --quiet "$_r" >/dev/null 2>&1 && { _b="$_r"; break; }
+  done
+  git merge-base "$1" "${_b:-HEAD~1}" 2>/dev/null || echo HEAD~1
+}
+
+scan_range() {  # $1=range (e.g. A..B); block on leaks, advisory otherwise
+  command -v gitleaks >/dev/null 2>&1 || return 0
+  GL="$(mktemp)"
+  if ! gitleaks git --no-banner --redact --log-opts="$1" >"$GL" 2>&1; then
+    echo
+    echo "[pre-push] BLOCKED — gitleaks flagged potential secret(s) in $1:"
+    tail -15 "$GL"
+    echo "[pre-push] Remove the secret, or if it is a false positive: OCD_SKIP_PRESCAN=1 git push"
+    rm -f "$GL"; exit 1
+  fi
+  rm -f "$GL"
+}
+
+if command -v gitleaks >/dev/null 2>&1; then
+  scanned_any=0
+  # Only consume stdin when it is piped/redirected; a manual run leaves it on the
+  # terminal, where `read` would block — fall through to the HEAD fallback instead.
+  if [ ! -t 0 ]; then
+    while read -r _localref localsha _remoteref remotesha; do
+      [ -n "${localsha:-}" ] || continue
+      # Skip branch/ref deletions — nothing local to scan.
+      expr "$localsha" : "$ZERO" >/dev/null && continue
+      if expr "${remotesha:-}" : "$ZERO" >/dev/null; then
+        scan_range "$(detect_mb "$localsha")..$localsha"   # new ref: vs merge-base
+      else
+        scan_range "$remotesha..$localsha"                 # existing ref: pushed commits
+      fi
+      scanned_any=1
+    done
+  fi
+  # Manual run / empty stdin / no non-delete refs: fall back to merge-base(HEAD)..HEAD.
+  [ "$scanned_any" -eq 0 ] && scan_range "$(detect_mb HEAD)..HEAD"
+fi
+
+echo "[pre-push] scan complete, no secrets — push proceeding."
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ replay_pid*
 *.tfvars
 .env
 
-# Claude Code
-.claude/
-CLAUDE.md
+# Claude Code — shared skills + project context (.claude/skills, CLAUDE.md) are tracked.
+.claude/settings.local.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks configuration for this repository.
+#
+# Extends the bundled default ruleset and allowlists known non-secrets. gitleaks
+# auto-loads this file from the repo root, so the pre-PR scanner gate
+# (scripts/pr-scan.sh, .githooks/pre-push) and any manual `gitleaks` run pick it
+# up automatically.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known non-secrets in this repo."
+# OCD_SKIP_PRESCAN is the pre-PR gate's own escape-hatch env var; it appears in
+# help text, scripts, and docs as `OCD_SKIP_PRESCAN=1 git push`, which the
+# generic-api-key rule otherwise flags as a KEY=value secret (false positive).
+regexes = [
+  '''OCD_SKIP_PRESCAN''',
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ plane), with tenant RKE2 clusters running as VMs inside Harvester. It is a **sou
 catalog, not a deployable environment**: no root module, no backend, no
 `terraform.tfvars`, no live state here.
 
-```
+```text
             open-cloud-datacenter @ terraform   (THIS branch — reusable modules)
             ┌──────────────────────────────────────────────────────────┐
             │  modules/{platform,tenancy,operators,cloud,addons}         │
@@ -62,7 +62,7 @@ SemVer (the `0.x` line means "pre-stable — surface may change"). See `README.m
 Five purpose-driven families — grouped by *when you need a module*, not who built
 it. You can stop at any layer and still have a useful system.
 
-```
+```text
 modules/
 ├── platform/                  Foundation — run once
 │   ├── rancher/               Bootstrap RKE2 + Rancher VM(s) on Harvester via cloud-init; LB + IP pool; storage class/network

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,298 @@
+# CLAUDE.md — Open Cloud Datacenter Terraform Modules
+
+> Documents the **`terraform`** branch of `open-cloud-datacenter`. Derived by
+> reading the module tree (`modules/`), `README.md`, `docs/architecture.md`, the
+> CI workflows, and the pre-PR review gate. Every claim below is traceable to a
+> file in this branch — keep it that way when you edit it.
+
+## THE BIG PICTURE (read this first, every time)
+
+This branch is the **Open Cloud Datacenter (OCDC) Terraform module catalog** —
+reusable, single-concern modules that stand up a self-hosted, cloud-style datacenter
+on **Harvester HCI** (KubeVirt hypervisor) + **Rancher** (Kubernetes management
+plane), with tenant RKE2 clusters running as VMs inside Harvester. It is a **source
+catalog, not a deployable environment**: no root module, no backend, no
+`terraform.tfvars`, no live state here.
+
+```
+            open-cloud-datacenter @ terraform   (THIS branch — reusable modules)
+            ┌──────────────────────────────────────────────────────────┐
+            │  modules/{platform,tenancy,operators,cloud,addons}         │
+            └──────────────────────────────────────────────────────────┘
+                       ▲  source = "…?ref=terraform/vX.Y.Z"  (git + tag pin)
+            ┌──────────┴───────────────────────────────────────────────┐
+            │  a consumer / instance repo (per-environment)             │
+            │  layered TF that pins these modules by tag and owns the    │
+            │  backend, state, secrets, and all env values (hosts/IPs)   │
+            └────────────────────────────────────────────────────────────┘
+```
+
+The **source-vs-consumer split** is the central idea: this repo holds the modules;
+**per-environment Terraform lives in separate consumer repos** that reference them by
+a branch-scoped release tag and supply every environment-specific value. Changing
+module code here changes the public contract every consumer depends on.
+
+**When you go down a rabbit hole**, return to: *does this keep the module reusable
+and its public surface stable?* The deep dive — per-module purpose, provider
+versions, dependency graph, deploy phases — is in
+[`docs/architecture.md`](docs/architecture.md).
+
+---
+
+## Repositories & branches
+
+| Repo / branch | Purpose |
+|---|---|
+| `open-cloud-datacenter` @ **`terraform`** (this branch) | The Terraform module catalog: `platform/`, `tenancy/`, `operators/`, `cloud/`, `addons/`. Tagged `terraform/vX.Y.Z`. |
+| `open-cloud-datacenter` @ **`controlplane`** | The control-plane services — dc-api (Go REST API) + dcctl (CLI) + cloud-ui (React). The `cloud/` modules here deploy those images. |
+| `open-cloud-datacenter` @ **`operators`** | Operator source code (kubebuilder projects). The `operators/` modules here re-express that source's `config/` kustomize output as typed Terraform. |
+| `open-cloud-datacenter` @ **`main`** | Legacy unified module layout, frozen at `?ref=v0.4.5`. New consumers pin `terraform/*` tags instead. |
+| A consumer / instance repo | Per-environment layered Terraform + GitOps overlays that pin these modules by tag and own the state + secrets. |
+
+Each branch is a long-lived development line with its own root tree and **its own
+namespaced tags** (`terraform/v0.1.0`, `operators/v0.1.0`, `controlplane/v0.1.0`).
+The `terraform/` portion is a branch namespace; the `vX.Y.Z` portion is strict
+SemVer (the `0.x` line means "pre-stable — surface may change"). See `README.md`
+§Releases & versioning.
+
+---
+
+## Module catalog (`modules/`)
+
+Five purpose-driven families — grouped by *when you need a module*, not who built
+it. You can stop at any layer and still have a useful system.
+
+```
+modules/
+├── platform/                  Foundation — run once
+│   ├── rancher/               Bootstrap RKE2 + Rancher VM(s) on Harvester via cloud-init; LB + IP pool; storage class/network
+│   ├── harvester-integration/ Register Harvester into Rancher; UI extension; cloud credential; registration manifest
+│   ├── networking/            VLAN-backed harvester_network resources (one per entry in var.vlans)
+│   ├── storage/               Download + register OS images into Harvester (harvester_image)
+│   ├── monitoring/            Calert + Google Chat alert routing + curated dashboards on top of rancher-monitoring
+│   ├── nginx-lb-vm/           Standalone nginx LoadBalancer VM (stable join/VIP address for HA bootstrap)
+│   └── identity/
+│       ├── rancher-oidc/      Point Rancher auth at any generic OIDC provider
+│       └── providers/{asgardeo,azure-ad}/   Per-IdP presets that emit OIDC endpoints for rancher-oidc
+│
+├── tenancy/                   Day-2 tenant operations
+│   ├── tenant-space/          Full onboarding bundle: Rancher project + namespaces + quotas + RBAC + optional VLAN/VyOS; composes the sub-modules below
+│   ├── rbac/                  Bulk-create Rancher projects + namespaces with CPU/memory/storage quotas
+│   ├── cluster-roles/         Custom Rancher role templates (e.g. vm-manager, vm-metrics-observer, cluster-reader)
+│   ├── vm/                    Provision a standalone Harvester VM (multi-disk, cloud-init, custom networks)
+│   ├── k8s-cluster/           Provision a tenant RKE2 cluster via Rancher machine provisioning (multi-pool)
+│   ├── vyos-tenant/           Per-tenant VyOS vif/DHCP/NAT config (sub-module of tenant-space)
+│   ├── tenant-cloud-config/   Node cloud-init template ConfigMap for a tenant common namespace (sub-module)
+│   └── rancher-bot-user/      Per-tenant CI/machine identity + token (sub-module of tenant-space)
+│
+├── operators/                 Managed-service operator deployments (typed TF mirror of each operator's kustomize output)
+│   ├── dc-webhook/            KubeOVN/MAC-pinning mutating admission webhook for KubeVirt VMs
+│   ├── keyvault/              keyvault-operator (OpenBao HA) controller + CRDs
+│   └── database/              dbaas-operator (RDS-style managed PostgreSQL on KubeVirt) controller + CRDs
+│
+├── cloud/                     DC-API self-service layer (optional)
+│   ├── dc-controlplane/       3-node HA RKE2 cluster hosting DC-API (composes tenancy/tenant-space + tenancy/k8s-cluster)
+│   └── dc-services/           DC-API runtime on that cluster: Postgres + dc-api + cloud-ui + ingress + GitHub Actions runner
+│
+└── addons/                    Niche glue that papers over vanilla Rancher+Harvester gaps — may be deprecated as gaps close
+    ├── namespace-credentials/      Long-running reconciler: auto-issue scoped SA + kubeconfig Secret per tenant namespace
+    ├── harvester-cloud-credential/ Materialize a Harvester kubeconfig Secret for use as a Rancher cloud credential
+    └── harvester-vm-access/        Namespace-scoped SA + kubeconfig for delegated tenant access to Harvester VMs
+```
+
+> The `README.md`/`docs/architecture.md` tables describe `operators/keyvault` and
+> `operators/database` as "coming" — that prose lags the tree; both modules exist
+> with real code today (their READMEs pin `?ref=terraform/v0.2.0`). Trust the tree.
+
+The full deploy ordering (Phase 0 bootstrap → 1 Rancher auth → 2 platform →
+3 tenancy → 4 operators → 5 cloud → 6 addons), per-module outputs consumed
+downstream, and the dependency graph live in [`docs/architecture.md`](docs/architecture.md).
+
+---
+
+## Conventions & patterns (confirmed from the code — match them)
+
+**Module file layout.** Each module is a directory with `main.tf` (+ `variables.tf`,
+`outputs.tf`, `versions.tf` where present) and its own `README.md`. Bigger modules
+add `templates/` (cloud-init / config `.tpl`/`.tftpl`), `crds/` (operators), and an
+`examples/basic/` (7 modules ship one — `rancher`, `networking`, `storage`,
+`monitoring`, `harvester-integration`, `rbac`, `k8s-cluster`).
+
+**Providers are declared, not configured, in modules.** Every module pins its
+providers in a `terraform { required_providers { … } }` block (`versions.tf` or top
+of `main.tf`) but **declares no `provider "…" {}` config and no backend** — all
+provider auth and the backend live in the calling consumer layer. Stated explicitly
+at the top of several modules (e.g. `cloud/dc-services/main.tf`,
+`operators/dc-webhook/main.tf`). Provider pins vary by module (e.g.
+`harvester/harvester` ranges `~> 0.6.0` to `~> 1.7`; `rancher/rancher2 ~> 13.1`;
+`hashicorp/kubernetes ~> 2.30`); the source of truth is each module's `versions.tf`,
+summarized in `docs/architecture.md` §Provider version summary.
+
+**Typed `kubernetes_*` resources for native objects.** Namespaces, Secrets,
+Deployments, Services, Ingress, RBAC, StatefulSets are typed throughout (see all of
+`cloud/dc-services/main.tf`) — better diffing, no CRD needed at plan time.
+`kubernetes_manifest` is used for CRDs and custom resources Helm/typed resources
+don't cover — operator CRDs + `MutatingWebhookConfiguration` + ServiceMonitors in
+`operators/*`, PrometheusRules / Grafana-dashboard CRs in `platform/monitoring`, a
+`ScheduledVMBackup` CR in `tenancy/vm`. (`monitoring` also expresses its Calert
+Deployment/Service as `kubernetes_manifest` — a localized exception, not the norm.)
+
+**Helm is invoked via the `helm` CLI, NOT the `helm_release` resource.** There are
+**zero `helm_release` resources** in the catalog. Off-the-shelf charts are installed
+with `null_resource` + `local-exec` running `helm upgrade --install …
+oci://…`. `cloud/dc-services/main.tf` documents *why*: the TF helm provider fails
+posting release Secrets through Rancher's proxy chain ("request body too large"),
+while the helm CLI through the same proxy works. If you add a chart, follow that
+pattern (materialize the kubeconfig with `local_sensitive_file`, trigger on
+`chart_version`/values SHA, and add an idempotent `when = destroy` `helm uninstall`).
+
+**Secrets.**
+- Generated secrets use `random_password` and never leave the module (e.g. the
+  Postgres password and RKE2 join token in `cloud/dc-services` and `platform/rancher`).
+- Charts/Deployments consume secrets by **referencing a pre-created
+  `kubernetes_secret` by name**, not by `--set` literals (e.g. the ARC runner's
+  `githubConfigSecret`, the dc-api env `secret_key_ref`s). Decouples rotation from
+  the release.
+- Secret-bearing **variables are marked `sensitive = true`** (`vm_password`,
+  `rancher_admin_password`, `harvester_kubeconfig`, `db_password`, …). Supply them
+  from the consumer layer (env vars / `*.secret.tfvars` / a secrets manager) —
+  `*.tfvars` is git-ignored here; **never commit a secret value.** (`docs/architecture.md`
+  §Security considerations.)
+
+**Two-phase apply where a name/endpoint is unknown at first plan.** Most modules are
+single-phase. The exception is `tenancy/k8s-cluster`: when a node pool isn't in
+`machine_config_overrides`, `rancher2_machine_config_v2` gets a provider-generated
+random name the cluster can't reference in one plan — so apply in two phases (see the
+comment at `modules/tenancy/k8s-cluster/main.tf`):
+```bash
+terraform apply -target=module.<name>.rancher2_machine_config_v2.pool   # phase 1
+terraform apply -target=module.<name>                                   # phase 2
+```
+`operators/dc-webhook`'s README explicitly notes it is **single-phase** (cluster
+endpoint known before apply). Document the apply order in any module that needs it.
+
+**Module composition is by relative `source = "../…"`, not remote state.** Higher
+modules call lower ones directly: `tenancy/tenant-space` composes `vyos-tenant`,
+`tenant-cloud-config`, and `rancher-bot-user`; `cloud/dc-controlplane` composes
+`tenancy/tenant-space` + `tenancy/k8s-cluster`, passing the Harvester k8s provider
+through with `providers = { kubernetes.harvester = kubernetes.harvester }`.
+`data "terraform_remote_state"` appears only as **consumer-side guidance** in
+`platform/storage`'s README/outputs (how a downstream layer reads `image_ids`) — it
+is for consumer layers composing module outputs across state, not for wiring modules
+to each other inside this repo.
+
+**Operator modules mirror upstream kustomize as typed TF.** `operators/{database,keyvault}`
+re-express the operator's `config/default` kustomize output as typed `kubernetes_*`
+resources (apply needs no kustomize) and vendor the CRD YAML under `crds/`. Their
+headers give a "refresh from upstream" procedure: rebuild `kubectl kustomize …`, diff
+each kind+name against the TF, reconcile, and **bump `crds/*.yaml` alongside the
+operator image tag** (schema travels with the image).
+
+**Input validation lives in the module.** Modules guard inputs with `check {}`
+blocks and `lifecycle { precondition { … } }` (e.g. `platform/rancher`,
+`tenancy/tenant-space`) and use `lifecycle { ignore_changes = [...] }` for fields a
+controller/CI owns (CI-rolled container `image`, Rancher-set `container_resource_limit`,
+auto-managed annotations / cloudinit-disk size). Preserve these — they are what keeps
+re-applies and brownfield imports diff-clean.
+
+**Backward-compat is a contract.** A module's `variables` + `outputs` are the public
+surface every consumer pins against. Renaming/removing/retyping one, or changing a
+default, is a **breaking change**: call it out and drive the SemVer bump (MAJOR for
+breaking, MINOR for additive-with-safe-defaults, PATCH for fixes/docs — `README.md`
+§Releases & versioning). The LLM review's most valuable lens here is exactly this
+contract check.
+
+**Formatting & validation.** `terraform fmt -recursive` must be clean. Run
+`terraform validate` inside a module/example where providers can init. The scan gate
+(below) runs an **init-free** `terraform fmt -check` + tflint + checkov + trivy; it
+deliberately does **not** run `terraform validate` (that needs provider downloads).
+
+**IaC policy / `.checkov.yaml`.** Checkov reads the repo-root `.checkov.yaml`, which
+skips exactly one rule: **`CKV_TF_1`** — because example/doc module sources pin a
+semantic-version tag (`?ref=terraform/vX.Y.Z`) for readability rather than a
+commit-hash (commit-hash pinning is recommended for production consumers but not
+enforced in this catalog's own examples). Honor that file; don't re-skip inline.
+
+**PRs.** Fill in `pull_request_template.md`. File an issue first
+(`issue_template.md`), branch `feature/<id>-<desc>` or `fix/<id>-<desc>` off
+`terraform`, open the PR **against `terraform`**, and link `Closes #ID`. CodeRabbit
+auto-reviews this branch (opted in via `.coderabbit.yaml`, anchored to `^terraform$`
+because the default branch's config does not reach this root tree). Full guidelines:
+[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md).
+
+---
+
+## CI & quality gates
+
+PRs against this branch run two GitHub checks (`.github/workflows/`):
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `terraform-scan.yml` | PR touching `*.tf` / `*.tfvars` / `*.hcl` | Trivy IaC misconfig scan; results posted as a PR comment. |
+| `linter.yml` | PR + on approved review | Super-Linter over Terraform / YAML / Markdown / Shell (diff-scoped). |
+
+---
+
+## Before pushing — run the pre-PR review gate
+
+A local, two-layer self-review that front-runs CodeRabbit, defined in
+[`docs/pr-review-gate.md`](docs/pr-review-gate.md). This is the Terraform module
+catalog, so the gate is Terraform-first.
+
+```bash
+make scan        # Layer 1 — deterministic scanners on your diff (the OSS analyzers
+                 # CodeRabbit runs): terraform fmt-check, tflint, checkov, trivy on
+                 # changed *.tf; plus gitleaks, hadolint, actionlint, shellcheck,
+                 # yamllint, markdownlint, semgrep when matching files change.
+                 # checkov auto-picks up .checkov.yaml (so CKV_TF_1 stays skipped).
+```
+
+- **One-time:** `make scan-tools` installs the analyzers (best-effort Homebrew);
+  `make hooks` wires an advisory pre-push hook (prints findings; **hard-blocks only
+  on a detected secret** — override once with `OCD_SKIP_PRESCAN=1 git push`).
+- **Claude Code users:** for a feature-sized change (a new module, or a changed
+  public variable/output), also invoke the **`pr-review`** skill
+  (`.claude/skills/pr-review/`) — the LLM multi-lens review layered on the scanners.
+  Its key lens for a module catalog is **contract/backward-compat**: only it reasons
+  about a renamed/removed variable or output being a breaking change.
+
+Fix what the gate flags, then open the PR — the same scan files are portable and can
+be copied into the consumer repos where most day-to-day `*.tf` work happens.
+
+---
+
+## Hard rules
+
+- **This repo is the *source*, not an environment.** Don't add a backend, a root
+  module, `terraform.tfvars`, or environment values (hostnames/IPs/credentials) to a
+  module. Those belong in the consumer repo. `*.tfvars` / `*.tfstate*` /
+  `.terraform/` are git-ignored here.
+- **Never commit secrets.** Use `random_password` for generated values; mark
+  secret-bearing variables `sensitive = true`; reference pre-created
+  `kubernetes_secret`s by name. The pre-push hook hard-blocks on a detected secret.
+- **A module's variables/outputs are a public contract.** Treat any rename, removal,
+  retype, or default change as breaking; bump the `terraform/vX.Y.Z` tag accordingly
+  and note it in the PR.
+- **Match the established pattern, don't introduce a competing one.** Typed
+  `kubernetes_*` for native objects; `kubernetes_manifest` only for CRDs/custom
+  resources; Helm via `null_resource`+CLI (not `helm_release`); composition via
+  relative `source`. If you must deviate, say why in a code comment (the existing
+  Helm-CLI and `ignore_changes` comments are the model).
+- **Public repo — keep it generic.** No internal environment/host/org/board names in
+  module code, comments, examples, or docs you add. Run `make scan` (gitleaks)
+  before pushing.
+- **Run `terraform fmt -recursive` and `make scan` after every non-trivial change.**
+
+---
+
+## Reference
+
+| For | See |
+|---|---|
+| Public layout, mental model, deploy phases, SemVer/versioning, contributing | [`README.md`](README.md) |
+| Per-module purpose, provider versions, dependency graph, network/security notes | [`docs/architecture.md`](docs/architecture.md) |
+| The pre-PR review gate (scanners + LLM lenses) and how to widen coverage | [`docs/pr-review-gate.md`](docs/pr-review-gate.md) |
+| Branching, commit/PR conventions, disclosure | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) |
+| The control-plane services these `cloud/` modules deploy | `open-cloud-datacenter` @ `controlplane` |
+| The operator source the `operators/` modules mirror | `open-cloud-datacenter` @ `operators` |
+| A worked, layered consumer of these modules | a consumer / instance repo (separate, per-environment) |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: help scan scan-tools hooks
+
+# Default target — print help
+help:
+	@echo "Usage:"
+	@echo "  make scan        Run the pre-PR scanner gate on your diff (OSS analyzers)"
+	@echo "  make scan-tools  Install the analyzers make scan uses (brew)"
+	@echo "  make hooks       Enable the advisory pre-push scanner hook (one-time)"
+
+# ── Pre-PR review gate ──────────────────────────────────────────────────────
+# Run the deterministic scanner layer (the OSS analyzers CodeRabbit runs) on your
+# diff before opening a PR; `make hooks` wires it as an advisory pre-push hook.
+scan:
+	bash scripts/pr-scan.sh
+
+# Opt-in, best-effort installer for the analyzers `make scan` runs (brew).
+# The scan never auto-installs; run this once to widen coverage.
+scan-tools:
+	bash scripts/install-scan-tools.sh
+
+hooks:
+	git config core.hooksPath .githooks
+	@echo "pre-push gate active — scripts/pr-scan.sh runs on push (skip once: OCD_SKIP_PRESCAN=1 git push)"

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -1,0 +1,146 @@
+# The pre-PR review gate
+
+A local, two-layer self-review you run **before opening a PR**. It front-runs the
+external reviewer (CodeRabbit): it runs the same open-source analyzers CodeRabbit
+runs and adds an LLM judgment pass, so most findings are fixed before the diff is
+ever pushed. It is **not** a replacement for CodeRabbit — CodeRabbit still runs on
+the PR — it just means there's little left for it to flag. This is the Terraform
+module catalog, so the gate is **Terraform-first**.
+
+## Quick start
+
+**Using Claude Code?** Just work as normal. This branch's `CLAUDE.md` tells the agent
+to run this gate against your diff before pushing, and the `pr-review` skill gives
+it the procedure — so it runs `make scan` (and, for a feature-sized change, the LLM
+review) against your changes on its own. One-time: `make scan-tools` installs the
+analyzers; `make hooks` adds a hard pre-push backstop.
+
+**Reviewing by hand (no Claude needed):**
+
+1. **One-time:** `make scan-tools` (install the analyzers via Homebrew) and,
+   recommended, `make hooks` (turn on the automatic pre-push scan).
+2. **Before every PR:** `make scan` — runs the analyzers on your changed files;
+   read what it flags and fix it.
+3. **Push.** With `make hooks` on, the scan runs automatically and **blocks only on
+   a detected secret** (everything else is advisory). Override once with
+   `OCD_SKIP_PRESCAN=1 git push`.
+
+## The two layers
+
+### Layer 1 — deterministic scanners (`make scan`)
+`scripts/pr-scan.sh` figures out what changed (the diff against the merge-base with
+`origin/terraform`, falling back to `upstream/terraform` then `origin/main`), then
+runs the analyzer matching each changed file type. Every tool is optional: if it's
+installed and relevant files changed it runs; otherwise it's skipped and named under
+"gaps" so coverage holes are explicit. A tool that prints findings (or exits
+nonzero) has flagged something to fix.
+
+| Tool | Runs when | Catches |
+|---|---|---|
+| **terraform fmt** + **tflint** + **checkov** + **trivy** | `*.tf` changed | Terraform formatting, lint, and IaC security/misconfiguration (see [Terraform PRs](#terraform-prs)) |
+| **gitleaks** | always | Committed secrets/credentials (this is the only hard block in the hook) |
+| **hadolint** | a `Dockerfile` changed | Dockerfile best-practice and correctness issues |
+| **actionlint** (+ **zizmor**) | `.github/workflows/*` changed | GitHub Actions workflow errors (and Actions security) |
+| **shellcheck** / **yamllint** / **markdownlint** | `*.sh` / `*.yaml` / `*.md` changed | Shell bugs, YAML errors, Markdown lint |
+| **semgrep** | `*.go/ts/tsx/js/py` changed | SAST patterns across languages (for any helper scripts that ship alongside HCL) |
+
+The script is macOS bash-3.2 safe and roots itself at the repo top level, so you can
+run it from any subdirectory.
+
+#### Terraform PRs
+
+Terraform is first-class here because this branch *is* the Terraform module catalog.
+When the diff touches any `*.tf` file, the scan runs four best-effort, init-free
+checks (each only if the tool is installed; otherwise it is named under "gaps"):
+
+| Check | What it does |
+|---|---|
+| `terraform fmt -check -recursive -diff` | Fails on unformatted HCL and prints the diff. No `terraform init` needed. |
+| `tflint --recursive` | Terraform linter — provider-aware best-practice and correctness rules. |
+| `checkov -d . --compact --quiet` | IaC security/compliance policy scan. Picks up the repo's `.checkov.yaml` automatically (so the catalog's documented skips, e.g. `CKV_TF_1` for example ref-tags, are honored). |
+| `trivy config --quiet .` | IaC misconfiguration scan (a second, complementary policy engine). |
+
+It deliberately does **not** run `terraform validate`: that needs `terraform init`
+and provider downloads, which are environment-specific and out of scope for a local
+pre-PR diff check. Install all four with `make scan-tools` (or `brew install
+terraform tflint checkov trivy`).
+
+#### Beyond this branch
+
+This gate lives on the **terraform** branch (the shared Terraform module catalog).
+The same checks are valuable in any other place that holds Terraform — most
+notably the per-environment **consumer repos** that reference these modules, where
+much of the day-to-day `*.tf` work actually happens. The gate is plain files with
+no branch-specific dependencies, so to cover those PRs too, copy these same files
+into the target repo and commit them there:
+
+- `scripts/pr-scan.sh`
+- `scripts/install-scan-tools.sh`
+- `.githooks/pre-push`
+- the `scan`, `scan-tools`, and `hooks` targets from the `Makefile` (plus their
+  `.PHONY` and `help` entries)
+
+Then run `make hooks` once in that checkout. The Terraform checks above will run on
+every `*.tf` diff there exactly as they do here. (If the target repo's integration
+branch isn't named `terraform`, adjust the base-detection list at the top of
+`scripts/pr-scan.sh` and `.githooks/pre-push` to match.)
+
+### Layer 2 — LLM multi-lens review (the `pr-review` skill)
+Scanners can't reason about intent, design, or cross-module contracts. The `pr-review`
+skill (`.claude/skills/pr-review/`) adds that: one reviewer per CodeRabbit review
+category (security, correctness, reliability, data-integrity/contracts, performance,
+maintainability, tests, docs), then an **adversarial verification** pass that tries
+to refute each finding and drops false positives, plus a real fmt/validate/lint run.
+It's told to skip anything the scanners already cover. For a module catalog its most
+valuable lens is **contract/backward-compat**: a renamed or removed variable or
+output is a breaking change for every consumer, and only the LLM lens reasons about
+that.
+
+## How to use it
+
+- **One-time install (recommended first):** run `make scan-tools` to install the
+  analyzers (best-effort via Homebrew; it tolerates already-installed tools and
+  prints an OK/MISSING list at the end). The scan never auto-installs — it only
+  names what is missing — so do this once up front, and again whenever you start
+  touching a new file type.
+- **Every push, automatically (recommended):** run `make hooks` once. This sets
+  `git config core.hooksPath .githooks`, enabling `.githooks/pre-push`. On every
+  `git push` it runs the scanners as **advisory** output (prints findings) and
+  **hard-blocks only on a detected secret**. Skip a single push (e.g. you already
+  reviewed, or a confirmed false positive) with `OCD_SKIP_PRESCAN=1 git push`.
+- **On demand:** `make scan` (or `bash scripts/pr-scan.sh [base-ref]`) anytime.
+- **In Claude Code:** invoke the `pr-review` skill, which runs Layer 1 and then the
+  Layer-2 engine via the Workflow tool:
+  `Workflow({ scriptPath: ".claude/skills/pr-review/review.js", args: { base: "origin/terraform", repo: "." } })`.
+
+Fix what the gate flags, then open the PR — and note in the description that you
+self-reviewed (scanners + N-lens review) so reviewers know the bar.
+
+## How it relates to CodeRabbit
+
+CodeRabbit is itself two layers: ~56 OSS analyzers in a sandbox, plus a
+context-engineered LLM with a separate judge model that filters false positives.
+This gate mirrors that locally — the same analyzers, the same multi-category LLM
+review with adversarial verification — so it acts as a **front-runner**: it catches
+most of what CodeRabbit would post, before the code is pushed. CodeRabbit still runs
+on the PR as the backstop; the goal is simply that it finds little to add.
+
+## Widen coverage
+
+`make scan` names any analyzer it couldn't run because it isn't installed, and points
+you at `make scan-tools`. The simplest path is to run that installer — it covers
+everything below in one shot (best-effort, tolerating already-installed tools):
+
+```bash
+make scan-tools
+```
+
+To install by hand instead (or on a machine without Homebrew), the equivalent set is:
+
+```bash
+brew install terraform tflint checkov trivy gitleaks actionlint yamllint \
+  shellcheck markdownlint-cli semgrep
+```
+
+Known CodeRabbit gaps you may want to cover by hand: i18n and license/SCA
+compliance.

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -77,6 +77,8 @@ into the target repo and commit them there:
 - `scripts/pr-scan.sh`
 - `scripts/install-scan-tools.sh`
 - `.githooks/pre-push`
+- `.gitleaks.toml` (allowlists the `OCD_SKIP_PRESCAN` escape-hatch env var; without
+  it, gitleaks false-flags the `OCD_SKIP_PRESCAN=1 git push` help text as a secret)
 - the `scan`, `scan-tools`, and `hooks` targets from the `Makefile` (plus their
   `.PHONY` and `help` entries)
 

--- a/scripts/install-scan-tools.sh
+++ b/scripts/install-scan-tools.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# install-scan-tools — opt-in, best-effort installer for the analyzers that
+# scripts/pr-scan.sh runs on this Terraform module catalog. The scan itself NEVER
+# auto-installs anything; you run this once (or whenever you start touching a new
+# file type) to widen coverage.
+#
+# Usage:  scripts/install-scan-tools.sh   (or: make scan-tools)
+#
+# It installs via Homebrew (if present), tolerating tools that are already
+# installed and continuing past any single failure. At the end it prints a
+# one-line OK/MISSING availability check for every tool so you can see what is
+# ready. Portable to macOS bash 3.2 (no associative arrays, no mapfile).
+set -u
+
+# Brew formulae the scanners use. terraform/tflint/checkov/trivy are the core of
+# the Terraform gate; the rest cover the workflows, shell, yaml, and docs that
+# ship alongside the modules.
+BREW_TOOLS="terraform tflint checkov trivy gitleaks actionlint yamllint shellcheck markdownlint-cli semgrep"
+
+# Every command we ultimately want on PATH (for the final availability check).
+CHECK_CMDS="terraform tflint checkov trivy gitleaks actionlint yamllint shellcheck markdownlint semgrep"
+
+echo "== install-scan-tools =="
+
+# ---- Homebrew formulae ----
+if command -v brew >/dev/null 2>&1; then
+  echo
+  echo "-- brew install (tolerating already-installed) --"
+  for t in $BREW_TOOLS; do
+    echo ">> brew install $t"
+    brew install "$t" || echo "   (skipped: brew install $t failed — continuing)"
+  done
+else
+  echo
+  echo "Homebrew (brew) not found — skipping the brew tools. Install them manually with"
+  echo "your package manager. The full list is:"
+  echo "  $BREW_TOOLS"
+fi
+
+# ---- availability check ----
+echo
+echo "-- availability (what pr-scan can use now) --"
+missing=0
+for c in $CHECK_CMDS; do
+  if command -v "$c" >/dev/null 2>&1; then
+    echo "  OK       $c"
+  else
+    echo "  MISSING  $c"
+    missing=$((missing + 1))
+  fi
+done
+
+echo
+if [ "$missing" -eq 0 ]; then
+  echo "All scan tools are available."
+else
+  echo "$missing tool(s) still MISSING above — re-run after installing them, or install by hand."
+fi
+exit 0

--- a/scripts/pr-scan.sh
+++ b/scripts/pr-scan.sh
@@ -76,7 +76,7 @@ fi
 # ---- GitHub Actions ----
 if match '\.github/workflows/.*\.ya?ml$'; then
   if have actionlint; then sec "actionlint"; actionlint 2>&1 | head -40; else gap "actionlint" "brew install actionlint"; fi
-  have zizmor && { sec "zizmor (Actions security)"; zizmor .github/workflows 2>&1 | tail -30; }
+  if have zizmor; then sec "zizmor (Actions security)"; zizmor .github/workflows 2>&1 | tail -30; else gap "zizmor" "brew install zizmor"; fi
 fi
 
 # ---- shell / yaml / markdown ----

--- a/scripts/pr-scan.sh
+++ b/scripts/pr-scan.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# pr-scan — the deterministic scanner layer of the pre-PR review gate. Runs the
+# same open-source analyzers CodeRabbit runs in its sandbox, locally, scoped to
+# your diff, BEFORE you push — so its tool-based comments are pre-empted.
+#
+# This is the Terraform module catalog (the `terraform` branch), so the Terraform
+# block is the primary one; the other language blocks simply skip when no
+# matching files changed.
+#
+# Every tool is optional: installed + relevant files changed -> run; otherwise it
+# is skipped and named under "gaps" so coverage holes are explicit. A tool
+# printing findings (or exiting nonzero) means it FLAGGED something — read that
+# section and fix it before opening the PR.
+#
+# Usage:  scripts/pr-scan.sh [base-ref]
+#   base-ref  defaults to the first available of origin/terraform,
+#             upstream/terraform, origin/main, else HEAD~1. The changed-file set
+#             is the WORKING TREE (committed + staged + unstaged) diffed against the
+#             merge-base of HEAD with that ref — so it reflects what you're about to
+#             push/commit, not just committed history.
+#
+# Run it from anywhere in the repo — it roots itself at the repo top level.
+# Portable to macOS bash 3.2 (no mapfile / no associative arrays).
+set -u
+
+# Root at the repo top level regardless of where we were invoked from.
+REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "pr-scan: not inside a git repo"; exit 2; }
+cd "$REPO" || { echo "pr-scan: cannot cd to $REPO"; exit 2; }
+
+BASE="${1:-}"
+if [ -z "$BASE" ]; then
+  for b in origin/terraform upstream/terraform origin/main; do
+    git rev-parse --verify --quiet "$b" >/dev/null 2>&1 && { BASE="$b"; break; }
+  done
+  [ -z "$BASE" ] && BASE="HEAD~1"
+fi
+MB="$(git merge-base HEAD "$BASE" 2>/dev/null || echo "$BASE")"
+
+FL="$(mktemp)"; trap 'rm -f "$FL"' EXIT
+# Scan the WORKING TREE vs the merge-base (committed + staged + unstaged), since the
+# gate is meant to run before commit. Base versions are read with `git show $MB:...`.
+git diff --name-only "$MB" > "$FL" 2>/dev/null
+N=$(grep -c . "$FL" 2>/dev/null || echo 0)
+echo "== pr-scan scanners ==  base=$BASE  merge-base=${MB:0:12}  changed-files=$N"
+[ "$N" -eq 0 ] && { echo "nothing changed vs base — nothing to scan"; exit 0; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+match(){ grep -qiE "$1" "$FL"; }
+sec(){ echo; echo "### $1"; }
+GAPS=""
+gap(){ GAPS="$GAPS
+  - $1  ($2)"; }
+
+# ---- Terraform (first-class: this catalog is all Terraform) ----
+# All best-effort and init-free; we deliberately do NOT run `terraform validate`
+# (it needs `terraform init`/providers, which is environment-specific). Checkov
+# picks up the repo's .checkov.yaml automatically from the working dir.
+if match '\.tf$'; then
+  if have terraform; then sec "terraform fmt -check"; terraform fmt -check -recursive -diff 2>&1 | head -60
+  else gap "terraform fmt" "brew install terraform"; fi
+  if have tflint; then sec "tflint"; tflint --recursive 2>&1 | head -40; else gap "tflint" "brew install tflint"; fi
+  if have checkov; then sec "checkov (IaC security)"; checkov -d . --compact --quiet 2>&1 | tail -40; else gap "checkov" "brew install checkov"; fi
+  if have trivy; then sec "trivy config (IaC misconfig)"; trivy config --quiet . 2>&1 | tail -40; else gap "trivy" "brew install trivy"; fi
+fi
+
+# ---- secrets (always; scoped to the new commits) ----
+if have gitleaks; then sec "gitleaks (secrets)"; gitleaks git --no-banner --redact --log-opts="$MB..HEAD" 2>&1 | tail -30
+else gap "gitleaks" "brew install gitleaks"; fi
+
+# ---- Dockerfiles ----
+if match '(^|/)Dockerfile'; then
+  if have hadolint; then sec "hadolint"; grep -iE '(^|/)Dockerfile' "$FL" | while IFS= read -r f; do [ -f "$f" ] && { echo "-- $f"; hadolint "$f"; }; done 2>&1 | head -40
+  else gap "hadolint" "brew install hadolint"; fi
+fi
+
+# ---- GitHub Actions ----
+if match '\.github/workflows/.*\.ya?ml$'; then
+  if have actionlint; then sec "actionlint"; actionlint 2>&1 | head -40; else gap "actionlint" "brew install actionlint"; fi
+  have zizmor && { sec "zizmor (Actions security)"; zizmor .github/workflows 2>&1 | tail -30; }
+fi
+
+# ---- shell / yaml / markdown ----
+if match '\.sh$'; then
+  if have shellcheck; then sec "shellcheck"; grep -iE '\.sh$' "$FL" | while IFS= read -r f; do [ -f "$f" ] && shellcheck "$f"; done 2>&1 | head -60
+  else gap "shellcheck" "brew install shellcheck"; fi
+fi
+if match '\.ya?ml$'; then
+  if have yamllint; then sec "yamllint"; grep -iE '\.ya?ml$' "$FL" | while IFS= read -r f; do [ -f "$f" ] && yamllint -f parsable "$f"; done 2>&1 | head -60
+  else gap "yamllint" "brew install yamllint"; fi
+fi
+if match '\.md$'; then
+  if have markdownlint; then sec "markdownlint"; grep -iE '\.md$' "$FL" | while IFS= read -r f; do [ -f "$f" ] && markdownlint "$f"; done 2>&1 | head -40
+  else gap "markdownlint" "npm i -g markdownlint-cli"; fi
+fi
+
+# ---- SAST (multi-language; covers any helper scripts that ship alongside HCL) ----
+if match '\.(go|ts|tsx|js|py)$'; then
+  if have semgrep; then sec "semgrep (SAST)"; semgrep --config auto --error -q 2>&1 | tail -60
+  else gap "semgrep" "brew install semgrep"; fi
+fi
+
+echo
+echo "== summary =="
+echo "Read each section above. Findings (or a nonzero tool exit) = something to address."
+if [ -n "$GAPS" ]; then
+  echo "not installed for files in this diff (install to widen coverage):$GAPS"
+  echo
+  echo "Install them all at once:  make scan-tools  (best-effort brew installer)"
+else
+  echo "all applicable scanners were available."
+fi


### PR DESCRIPTION
## What this adds

Brings the pre-PR review gate to the `terraform` branch — where most of our PRs land — and gives the branch a real project-context `CLAUDE.md` (it had none). Same gate as `controlplane` (#204), Terraform-first.

## Contents

- **`make scan`** (`scripts/pr-scan.sh`): on any `.tf` change, runs `terraform fmt -check`, **tflint**, **checkov** (uses the repo's `.checkov.yaml`), and **trivy config**, scoped to your diff. Advisory; names any tool it couldn't run.
- **`make scan-tools`** (`scripts/install-scan-tools.sh`): one-time installer for the Terraform analyzers.
- **`make hooks`** (`.githooks/pre-push`): optional advisory pre-push hook — blocks only on a detected secret; override with `OCD_SKIP_PRESCAN=1 git push`.
- **`.claude/skills/pr-review/`**: the LLM review skill for Claude Code users (Terraform-framed).
- **`CLAUDE.md`**: code-derived project context — the module-catalog map (platform / tenancy / operators / cloud / addons), conventions (fmt + validate, the `.checkov.yaml` skips, ref-pinning), and the source-vs-consumer model. `.claude/` + `CLAUDE.md` were gitignored on this branch; un-ignored so the shared skill + context are tracked (matching `controlplane`).
- **`.gitleaks.toml`**: allowlists the gate's own `OCD_SKIP_PRESCAN` env var (otherwise flagged as a `KEY=value` secret).
- **`docs/pr-review-gate.md`**: usage, and how to copy the gate to consumer repos holding Terraform.

## Notes

The gate is diff-scoped and best-effort — each tool runs only if installed and relevant files changed, so this adds no hard dependency. CodeRabbit still runs on the PR; this just front-runs it. The gate's own review findings (working-tree diff scope, per-ref pre-push scanning, the gitleaks allowlist) were applied before this PR, so it should land clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local pre-push and pre-PR review gate to catch formatting, lint, security, and contract issues before changes are shared.
  * Introduced one-command setup for scan tools and repository hooks.

* **Documentation**
  * Added guidance for running scans, enabling hooks, and using the review workflow.
  * Expanded contributor documentation for repository conventions and quality checks.

* **Bug Fixes**
  * Improved secret detection during push by blocking likely leaks while allowing a documented bypass for emergencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->