### PR TITLE
[Feature] Route image create and resolve through the agent

### DIFF
--- a/dc-api/internal/providers/clusteraccess/capabilities.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities.go
@@ -75,8 +75,10 @@ var vmCapability = AgentCapability{
 
 // The network families (NAD, Vpc, Subnet) are onboarded for the kubeovn CRD
 // CRUD slice (RouteVerbs/AgentVerbs filled below). vmImageCapability is onboarded
-// for the read/list path (ListImages routed via the agent — RouteVerbs={Get,List},
-// AgentVerbs={get,list}). vmiCapability remains a GVK-only pre-seeded entry:
+// for the read/list path AND image create (ListImages/resolveImage/CreateImage
+// routed via the agent — RouteVerbs={Get,List,Create}, AgentVerbs={get,list,
+// create,patch}; create+patch because SSA is the agent's create mechanism).
+// vmiCapability remains a GVK-only pre-seeded entry:
 // DefaultGVKMapper still resolves its GVR (the table stays a superset the drivers
 // rely on) but RouteVerbs=nil means it contributes nothing to the routing
 // allow-set and AgentVerbs=nil means it emits no RBAC rule. Onboarding it is a
@@ -93,14 +95,17 @@ var (
 		APIVersion: "harvesterhci.io/v1beta1",
 		Kind:       "VirtualMachineImage",
 		Namespaced: true,
-		// Onboarded for the read path only: ListImages routes the cross-namespace
-		// image catalog read through the agent (VerbList), and VerbGet rounds out
-		// the read family. No write verbs — image create/import stays local-only.
-		RouteVerbs: []Verb{VerbGet, VerbList},
-		// SA grant: get/list on virtualmachineimages so the agent can serve the
-		// image catalog list (and a future per-image get). No watch — there is no
-		// routed watch path, so granting it would be unused RBAC (least-privilege).
-		AgentVerbs: []Verb{VerbGet, VerbList},
+		// Onboarded for the read/list path AND image create: ListImages routes the
+		// cross-namespace catalog read (VerbList) and resolveImage the create-time
+		// storageClass lookup, VerbGet rounds out the read family, and CreateImage
+		// routes the image import (VerbCreate). No delete — image deletion stays
+		// local-only for now.
+		RouteVerbs: []Verb{VerbGet, VerbList, VerbCreate},
+		// SA grant: get/list to serve the catalog read + resolveImage lookup, plus
+		// create+patch because the AgentBacked create is a server-side apply
+		// (VerbApply→patch). Mirrors vmCapability/nadCapability's write grant. No
+		// watch — there is no routed watch path, so granting it would be unused RBAC.
+		AgentVerbs: []Verb{VerbGet, VerbList, VerbCreate, VerbApply},
 	}
 	// nadCapability onboards the NetworkAttachmentDefinition CRUD that
 	// CreateSubnet/DeleteSubnet route through the kubeovn seam.
@@ -142,7 +147,7 @@ var (
 //
 // Onboarded (RouteVerbs + AgentVerbs set): vmCapability, the three network
 // families nadCapability/vpcCapability/subnetCapability (the kubeovn CRD CRUD
-// slice), and vmImageCapability (read/list path). vmiCapability stays a GVK-only
+// slice), and vmImageCapability (read/list path + image create). vmiCapability stays a GVK-only
 // pre-seeded entry that keeps the wire mapper a superset without granting any
 // routing or RBAC. New families are added here (one struct each) in later
 // phases — never by editing the mapper, the allow-set switch, or the RBAC YAML
@@ -190,7 +195,9 @@ func buildDerived() {
 // set of seam Verbs that MAY route to the agent for ANY family. With the VM,
 // network, and image families onboarded this equals
 // {VerbGet, VerbList, VerbCreate, VerbDelete} (List added when ListVMs/Images/
-// Networks were routed through the agent). agentDecision consults this for
+// Networks were routed through the agent; the image family also routes VerbCreate
+// for CreateImage, but VM/NAD already contribute it so the union is unchanged).
+// agentDecision consults this for
 // membership, then gates reads vs writes by the per-family env toggles
 // (VerbList falls on the read side — see IsReadVerb).
 //

--- a/dc-api/internal/providers/clusteraccess/capabilities_test.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities_test.go
@@ -75,8 +75,7 @@ func TestRoutableVerbs_UnknownGVRNotRoutable(t *testing.T) {
 
 // TestRoutableVerbs_ListRoutedForListFamilies asserts VerbList is routable for
 // exactly the families whose harvester list ops now route through the agent: the
-// VM, NAD, and image families. The image family routes List (and Get) but NOT
-// any write verb.
+// VM, NAD, and image families.
 func TestRoutableVerbs_ListRoutedForListFamilies(t *testing.T) {
 	listFamilies := []schema.GroupVersionResource{
 		{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"},
@@ -93,17 +92,31 @@ func TestRoutableVerbs_ListRoutedForListFamilies(t *testing.T) {
 			t.Errorf("%s must route VerbList", gvr.Resource)
 		}
 	}
+}
 
-	// The image family is read/list only — it must NOT route any write verb.
+// TestRoutableVerbs_ImageRoutesGetListCreate pins the image family's routable set
+// to exactly {Get, List, Create}: the read/list path (resolveImage/ListImages)
+// plus CreateImage's create (the image slice). Delete/Apply/Update must NOT be
+// routable — image deletion and generic apply stay local-only.
+func TestRoutableVerbs_ImageRoutesGetListCreate(t *testing.T) {
 	imgGVR := schema.GroupVersionResource{Group: "harvesterhci.io", Version: "v1beta1", Resource: "virtualmachineimages"}
-	imgVerbs, _ := RoutableVerbs(imgGVR)
-	for _, w := range []Verb{VerbCreate, VerbApply, VerbUpdate, VerbDelete} {
-		if imgVerbs[w] {
-			t.Errorf("virtualmachineimages must NOT route write verb %v", w)
+	imgVerbs, ok := RoutableVerbs(imgGVR)
+	if !ok {
+		t.Fatal("virtualmachineimages must be an onboarded routable family")
+	}
+	for _, want := range []Verb{VerbGet, VerbList, VerbCreate} {
+		if !imgVerbs[want] {
+			t.Errorf("virtualmachineimages must route %v, got %v", want, imgVerbs)
 		}
 	}
-	if !imgVerbs[VerbGet] || !imgVerbs[VerbList] {
-		t.Errorf("virtualmachineimages must route Get+List, got %v", imgVerbs)
+	// CreateImage routes VerbCreate but NOT the other write verbs.
+	for _, w := range []Verb{VerbApply, VerbUpdate, VerbDelete} {
+		if imgVerbs[w] {
+			t.Errorf("virtualmachineimages must NOT route %v", w)
+		}
+	}
+	if len(imgVerbs) != 3 {
+		t.Errorf("virtualmachineimages routable set = %v, want exactly {Get, List, Create}", imgVerbs)
 	}
 }
 

--- a/dc-api/internal/providers/harvester/client.go
+++ b/dc-api/internal/providers/harvester/client.go
@@ -26,8 +26,10 @@ package harvester
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -97,40 +99,43 @@ type Client struct {
 	// clusteraccess.Direct wrapping `dynamic` (today's behaviour, byte-identical)
 	// unless WithRoutedAccessor injects a routed accessor. The VM-object ops route
 	// through it: GetVM's primary VirtualMachine read (read slice), CreateVM's
-	// create + DeleteVM's delete (write slice 1), and the collection reads
-	// ListVMs/ListImages/ListNetworks (list slice — M-D). Image RESOLUTION (the
-	// create-time storageClass lookup), the cloud-provider SA bootstrap, and the
-	// VMI read inside GetVM still call c.dynamic directly. The seam never leaks an
-	// agent concept past the ComputeProvider interface.
+	// create + DeleteVM's delete (write slice 1), the collection reads
+	// ListVMs/ListImages/ListNetworks (list slice — M-D), and the image slice —
+	// CreateImage's create and resolveImage's create-time storageClass lookup. The
+	// cloud-provider SA bootstrap and the VMI read inside GetVM still call
+	// c.dynamic directly. The seam never leaks an agent concept past the
+	// ComputeProvider interface.
 	access clusteraccess.Accessor
 
 	// remoteRegion/remoteZone are non-empty ONLY for a credential-free REMOTE
 	// client built by NewRemoteClient (multi-zone routing). For such a client
-	// c.dynamic is nil: the seam ops (CreateVM/GetVM/DeleteVM via c.access, and
-	// the list reads via c.access.List) route to that zone's agent. The two
+	// c.dynamic is nil: the seam ops (CreateVM/GetVM/DeleteVM via c.access, the
+	// list reads via c.access.List, and the image slice — CreateImage's create and
+	// resolveImage's lookup — via c.access) route to that zone's agent. The two
 	// remaining direct paths behave differently on a remote client:
 	//   - GetVM's VMI IP enrichment read DEGRADES GRACEFULLY: it is SKIPPED (the
 	//     `c.dynamic == nil` guard returns the agent-supplied VM status WITHOUT IP
 	//     enrichment — no error), so a remote VM's status is still reported.
-	//   - the genuinely local-only ops — image RESOLUTION/import, the cloud-provider
-	//     SA bootstrap, and VM create's local storageClass resolution — have no
-	//     direct path and return a clear local-only error (localOnlyErr) naming the
-	//     zone instead of panicking on a nil dynamic client.
+	//   - the genuinely local-only ops — the cloud-provider SA bootstrap and VM
+	//     create's local storageClass resolution — have no direct path and return a
+	//     clear local-only error (localOnlyErr) naming the zone instead of panicking
+	//     on a nil dynamic client.
 	// Empty for the LOCAL client → today's behaviour.
 	remoteRegion, remoteZone string
 }
 
-// localOnlyErr is returned by a REMOTE client's direct-only methods (image
-// resolution/import, the cloud-provider SA bootstrap, VM create which needs the
-// image storageClass resolved locally). These touch c.dynamic, which a remote
-// client does not have. Failing here — BEFORE a PENDING row or a provisioner
-// call — is the documented local-only constraint for the remote-zone build:
-// routing the VM-object CRUD lifecycle and the collection reads is in scope;
-// routing image resolution/import and the SA bootstrap is future work behind this
-// explicit error.
+// localOnlyErr is returned by a REMOTE client's direct-only methods: VM create
+// (which resolves the image storageClass — see CreateVM's note) and the
+// cloud-provider SA bootstrap. These touch c.dynamic, which a remote client does
+// not have. Failing here — BEFORE a PENDING row or a provisioner call — is the
+// documented local-only constraint for the remote-zone build. NOTE: image
+// resolution/import (resolveImage, CreateImage) and the collection reads are NO
+// LONGER local-only — they route through the cluster-access seam (c.access), so a
+// remote client serves them via the agent; only VM create's storageClass lookup
+// and the SA bootstrap remain behind this explicit error.
 func (c *Client) localOnlyErr(op string) error {
 	return fmt.Errorf(
-		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct Harvester credentials there (image resolution/import and the cloud-provider SA bootstrap are local-only for now)",
+		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct Harvester credentials there (VM create's storageClass resolution and the cloud-provider SA bootstrap are local-only for now)",
 		op, c.remoteRegion, c.remoteZone)
 }
 
@@ -225,10 +230,11 @@ func (c *Client) Name() string { return "harvester" }
 // is a handler-layer bug, not a recoverable provider condition.
 func (c *Client) CreateVM(ctx context.Context, tenantID, projectID string, spec models.VMSpec) (*models.Resource, error) {
 	if c.dynamic == nil {
-		// REMOTE client: VM create needs the image template resolved against the
-		// zone's local VirtualMachineImage catalog (resolveImage → c.dynamic),
-		// which we don't have for a remote zone. Fail clearly BEFORE building the
-		// manifest so the handler surfaces a useful error rather than misrouting.
+		// REMOTE client: routing the full VM create lifecycle to a remote zone is a
+		// later slice (resolveImage now routes through c.access, but wiring the whole
+		// create — manifest build, MAC pinning, DNS injection — for a remote zone is
+		// out of scope here). Fail clearly BEFORE building the manifest so the handler
+		// surfaces a useful error rather than misrouting.
 		return nil, c.localOnlyErr("VM create")
 	}
 	ns := common.NamespaceForProject(tenantID, projectID)
@@ -753,20 +759,38 @@ func (c *Client) ListNetworks(ctx context.Context) ([]*models.Network, error) {
 // CreateImage creates a VirtualMachineImage CRD in Harvester, which triggers
 // Harvester to download the image from the given URL into Longhorn storage.
 // The image is available for VM creation once its status transitions to "active".
+//
+// The object is created through the cluster-access seam (c.access.Create): the
+// Direct path (toggle OFF) is a plain dynamic POST — byte-identical to the
+// pre-seam behaviour except that the name is now client-assigned; the agent path
+// (toggle ON + live agent) is a server-side apply, the agent's only create
+// mechanism. SSA REQUIRES a name (generateName cannot SSA), so we assign a fixed
+// "image-<rand>" name here rather than relying on the apiserver's generateName.
+// A POST accepts the explicit name fine, so both seams agree. A REMOTE client
+// (c.dynamic nil) now serves this through the agent — it no longer returns
+// localOnlyErr.
 func (c *Client) CreateImage(ctx context.Context, displayName, downloadURL string) (*models.Image, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("CreateImage")
-	}
 	// Images are created in the "default" namespace in Harvester.
 	const imageNamespace = "default"
+
+	// Client-assigned name: SSA (the agent create path) has no generateName
+	// equivalent, so we must supply metadata.name. The short crypto-random suffix
+	// mirrors what the apiserver's generateName would have produced ("image-XXXXX")
+	// and keeps names collision-resistant. resolveImage matches by full ID, name,
+	// OR displayName, so a client-assigned name is transparent to VM create.
+	suffix, err := randHexSuffix()
+	if err != nil {
+		return nil, fmt.Errorf("harvester create image %q: generate name suffix: %w", displayName, err)
+	}
+	name := "image-" + suffix
 
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "harvesterhci.io/v1beta1",
 			"kind":       "VirtualMachineImage",
 			"metadata": map[string]interface{}{
-				"generateName": "image-",
-				"namespace":    imageNamespace,
+				"name":      name,
+				"namespace": imageNamespace,
 				"labels": map[string]interface{}{
 					"dc-api/managed": "true",
 				},
@@ -779,7 +803,7 @@ func (c *Client) CreateImage(ctx context.Context, displayName, downloadURL strin
 		},
 	}
 
-	created, err := c.dynamic.Resource(vmImageGVR).Namespace(imageNamespace).Create(ctx, obj, metav1.CreateOptions{})
+	created, err := c.access.Create(ctx, vmImageGVR, imageNamespace, obj, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("harvester create image %q: %w", displayName, err)
 	}
@@ -789,6 +813,18 @@ func (c *Client) CreateImage(ctx context.Context, displayName, downloadURL strin
 		DisplayName: displayName,
 		Namespace:   imageNamespace,
 	}, nil
+}
+
+// randHexSuffix returns 8 hex characters (4 crypto-random bytes) for a
+// client-assigned image name. It mirrors the "image-XXXXX" shape the apiserver's
+// generateName produced, but is chosen here because the agent create path is a
+// server-side apply, which requires a name up front.
+func randHexSuffix() (string, error) {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // resolveImage resolves a user-supplied image string to a "namespace/resource-name" ID
@@ -802,7 +838,12 @@ func (c *Client) CreateImage(ctx context.Context, displayName, downloadURL strin
 //   - A full ID:      "default/image-abc123"  (looked up by namespace+name)
 //   - A display name: "ubuntu-22.04"          (looked up by spec.displayName)
 func (c *Client) resolveImage(ctx context.Context, nameOrID string) (imageID, storageClass string, err error) {
-	list, err := c.dynamic.Resource(vmImageGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	// Routed through the cluster-access seam (c.access): Direct (byte-identical
+	// cross-namespace dynamic List) when the toggle is OFF, Session.List when ON
+	// and an agent serves the zone. This is why a REMOTE client (c.dynamic nil)
+	// can now resolve an image — the lookup no longer touches c.dynamic. Field
+	// extraction (displayName, status.storageClassName) below is seam-agnostic.
+	list, err := c.access.List(ctx, vmImageGVR, "", metav1.ListOptions{})
 	if err != nil {
 		return "", "", fmt.Errorf("list images for lookup: %w", err)
 	}

--- a/dc-api/internal/providers/harvester/client.go
+++ b/dc-api/internal/providers/harvester/client.go
@@ -116,8 +116,8 @@ type Client struct {
 	//   - GetVM's VMI IP enrichment read DEGRADES GRACEFULLY: it is SKIPPED (the
 	//     `c.dynamic == nil` guard returns the agent-supplied VM status WITHOUT IP
 	//     enrichment — no error), so a remote VM's status is still reported.
-	//   - the genuinely local-only ops — the cloud-provider SA bootstrap and VM
-	//     create's local storageClass resolution — have no direct path and return a
+	//   - the genuinely local-only ops — the cloud-provider SA bootstrap and the
+	//     full VM create orchestration — have no direct path and return a
 	//     clear local-only error (localOnlyErr) naming the zone instead of panicking
 	//     on a nil dynamic client.
 	// Empty for the LOCAL client → today's behaviour.
@@ -125,17 +125,18 @@ type Client struct {
 }
 
 // localOnlyErr is returned by a REMOTE client's direct-only methods: VM create
-// (which resolves the image storageClass — see CreateVM's note) and the
+// (the full create orchestration is not yet routed — see CreateVM's note) and the
 // cloud-provider SA bootstrap. These touch c.dynamic, which a remote client does
 // not have. Failing here — BEFORE a PENDING row or a provisioner call — is the
 // documented local-only constraint for the remote-zone build. NOTE: image
 // resolution/import (resolveImage, CreateImage) and the collection reads are NO
 // LONGER local-only — they route through the cluster-access seam (c.access), so a
-// remote client serves them via the agent; only VM create's storageClass lookup
-// and the SA bootstrap remain behind this explicit error.
+// remote client serves them via the agent. resolveImage's storageClass lookup
+// routes too; only the full VM create orchestration and the SA bootstrap remain
+// behind this explicit error.
 func (c *Client) localOnlyErr(op string) error {
 	return fmt.Errorf(
-		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct Harvester credentials there (VM create's storageClass resolution and the cloud-provider SA bootstrap are local-only for now)",
+		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct Harvester credentials there (the full VM create orchestration and the cloud-provider SA bootstrap are local-only for now)",
 		op, c.remoteRegion, c.remoteZone)
 }
 

--- a/dc-api/internal/providers/harvester/createimage_seam_test.go
+++ b/dc-api/internal/providers/harvester/createimage_seam_test.go
@@ -1,0 +1,284 @@
+package harvester
+
+// createimage_seam_test.go proves the image slice of the credential-locality
+// work: CreateImage and resolveImage route through the cluster-access seam
+// (c.access) so they work for a REMOTE (agent-only) zone, while the local Direct
+// path is unchanged.
+//
+//   - CreateImage via Direct (toggle OFF / local client) → a plain create on the
+//     dynamic client, with a client-assigned "image-<hex>" name (generateName is
+//     gone: SSA on the agent path cannot use it, and a POST accepts an explicit
+//     name fine).
+//   - CreateImage routed (REMOTE client, no dynamic) → c.access.Create is invoked
+//     with a NAMED object (metadata.name set, no metadata.generateName), the shape
+//     the agent's server-side apply requires.
+//   - resolveImage routes through c.access.List (not c.dynamic), so a remote client
+//     can resolve an image's storageClass — it previously required c.dynamic.
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+// recordingImageAccessor is a synthetic Accessor that records the object passed
+// to Create and serves a seeded list from List. It is deliberately independent of
+// the vmwrite_seam_test.go countingAccessor (which does not capture the object or
+// serve seeded List items). Only the two methods the image slice exercises are
+// meaningful; the rest satisfy the interface inertly.
+type recordingImageAccessor struct {
+	createCalls int
+	lastCreated *unstructured.Unstructured
+	lastCreNS   string
+	lastCreGVR  schema.GroupVersionResource
+
+	listCalls  int
+	lastListNS string
+	listItems  []unstructured.Unstructured
+}
+
+var _ clusteraccess.Accessor = (*recordingImageAccessor)(nil)
+
+func (a *recordingImageAccessor) Get(context.Context, schema.GroupVersionResource, string, string, metav1.GetOptions) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+
+func (a *recordingImageAccessor) List(_ context.Context, _ schema.GroupVersionResource, ns string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	a.listCalls++
+	a.lastListNS = ns
+	return &unstructured.UnstructuredList{Items: a.listItems}, nil
+}
+
+func (a *recordingImageAccessor) Create(_ context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	a.createCalls++
+	a.lastCreated = obj
+	a.lastCreNS = ns
+	a.lastCreGVR = gvr
+	// Echo the object back the way a POST would (the created object carries the
+	// name the caller assigned).
+	return obj, nil
+}
+
+func (a *recordingImageAccessor) Apply(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ string, _ bool) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *recordingImageAccessor) Update(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *recordingImageAccessor) Delete(context.Context, schema.GroupVersionResource, string, string, metav1.DeleteOptions) error {
+	return nil
+}
+
+// ── CreateImage: remote path routes via c.access.Create with a NAMED object ──
+
+func TestCreateImage_Remote_RoutesViaAccessorWithName(t *testing.T) {
+	rec := &recordingImageAccessor{}
+	// A REMOTE client has no dynamic; every op must go through the accessor.
+	c := NewRemoteClient(rec, "lk", "zone-1")
+
+	img, err := c.CreateImage(context.Background(), "ubuntu-22.04", "https://example.com/img.qcow2")
+	if err != nil {
+		t.Fatalf("CreateImage (remote): %v", err)
+	}
+
+	// The create routed through the seam exactly once, on the image GVR, in the
+	// default namespace.
+	if rec.createCalls != 1 {
+		t.Fatalf("accessor Create called %d times, want 1", rec.createCalls)
+	}
+	if rec.lastCreGVR != vmImageGVR {
+		t.Errorf("accessor Create GVR = %v, want %v", rec.lastCreGVR, vmImageGVR)
+	}
+	if rec.lastCreNS != "default" {
+		t.Errorf("accessor Create namespace = %q, want %q", rec.lastCreNS, "default")
+	}
+
+	// The object MUST carry metadata.name (SSA needs it) and MUST NOT carry
+	// metadata.generateName (SSA cannot use it).
+	name, hasName, _ := unstructured.NestedString(rec.lastCreated.Object, "metadata", "name")
+	if !hasName || name == "" {
+		t.Fatalf("created object has no metadata.name; got metadata=%v", rec.lastCreated.Object["metadata"])
+	}
+	if len(name) <= len("image-") || name[:len("image-")] != "image-" {
+		t.Errorf("metadata.name = %q, want an \"image-<hex>\" name", name)
+	}
+	if _, hasGen, _ := unstructured.NestedString(rec.lastCreated.Object, "metadata", "generateName"); hasGen {
+		t.Errorf("created object still sets metadata.generateName; SSA cannot use it")
+	}
+
+	// The returned Image ID uses the client-assigned name.
+	if img.ID != "default/"+name {
+		t.Errorf("image ID = %q, want %q", img.ID, "default/"+name)
+	}
+	if img.DisplayName != "ubuntu-22.04" {
+		t.Errorf("image DisplayName = %q, want ubuntu-22.04", img.DisplayName)
+	}
+
+	// spec is preserved.
+	dn, _, _ := unstructured.NestedString(rec.lastCreated.Object, "spec", "displayName")
+	url, _, _ := unstructured.NestedString(rec.lastCreated.Object, "spec", "url")
+	st, _, _ := unstructured.NestedString(rec.lastCreated.Object, "spec", "sourceType")
+	if dn != "ubuntu-22.04" || url != "https://example.com/img.qcow2" || st != "download" {
+		t.Errorf("spec = {displayName:%q url:%q sourceType:%q}, want ubuntu-22.04 / the URL / download", dn, url, st)
+	}
+}
+
+// TestCreateImage_TwoCallsGetDistinctNames proves the client-assigned suffix is
+// random per call (no collision on repeated imports of the same display name).
+func TestCreateImage_TwoCallsGetDistinctNames(t *testing.T) {
+	rec := &recordingImageAccessor{}
+	c := NewRemoteClient(rec, "lk", "zone-1")
+
+	a, err := c.CreateImage(context.Background(), "ubuntu", "https://example.com/a")
+	if err != nil {
+		t.Fatalf("CreateImage #1: %v", err)
+	}
+	b, err := c.CreateImage(context.Background(), "ubuntu", "https://example.com/b")
+	if err != nil {
+		t.Fatalf("CreateImage #2: %v", err)
+	}
+	if a.ID == b.ID {
+		t.Errorf("two CreateImage calls produced the same ID %q — names must be unique", a.ID)
+	}
+}
+
+// TestCreateImage_Routed_TogglesBetweenAgentAndDirect proves the Routed decision
+// gates CreateImage per-verb/per-family: with VerbCreate activated for the image
+// GVR the create routes to the agent accessor; with it de-activated it falls to
+// Direct. This is the same routing contract the registry enforces via the
+// per-family RouteVerbs allow-set (image now includes VerbCreate).
+func TestCreateImage_Routed_TogglesBetweenAgentAndDirect(t *testing.T) {
+	newRouted := func(agent, direct clusteraccess.Accessor, allow bool) *clusteraccess.Routed {
+		return clusteraccess.NewRouted(direct, func(v clusteraccess.Verb, gvr schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
+			if allow && v == clusteraccess.VerbCreate && gvr == vmImageGVR {
+				return agent, true
+			}
+			return nil, false
+		})
+	}
+
+	// Toggle ON → the agent accessor gets the create; Direct is untouched.
+	t.Run("on routes to agent", func(t *testing.T) {
+		agent := &recordingImageAccessor{}
+		direct := &recordingImageAccessor{}
+		c := &Client{access: newRouted(agent, direct, true)}
+		if _, err := c.CreateImage(context.Background(), "ubuntu", "https://example.com/a"); err != nil {
+			t.Fatalf("CreateImage: %v", err)
+		}
+		if agent.createCalls != 1 {
+			t.Errorf("agent Create called %d times, want 1", agent.createCalls)
+		}
+		if direct.createCalls != 0 {
+			t.Errorf("direct Create called %d times with toggle ON, want 0", direct.createCalls)
+		}
+	})
+
+	// Toggle OFF → Direct gets the create; the agent is untouched.
+	t.Run("off uses direct", func(t *testing.T) {
+		agent := &recordingImageAccessor{}
+		direct := &recordingImageAccessor{}
+		c := &Client{access: newRouted(agent, direct, false)}
+		if _, err := c.CreateImage(context.Background(), "ubuntu", "https://example.com/a"); err != nil {
+			t.Fatalf("CreateImage: %v", err)
+		}
+		if direct.createCalls != 1 {
+			t.Errorf("direct Create called %d times, want 1", direct.createCalls)
+		}
+		if agent.createCalls != 0 {
+			t.Errorf("agent Create called %d times with toggle OFF, want 0", agent.createCalls)
+		}
+	})
+}
+
+// ── CreateImage: local Direct path still works (byte-identical apart from name) ─
+
+func TestCreateImage_Local_UsesDirect(t *testing.T) {
+	dyn := newEmptyFakeDynamic()
+	c := &Client{dynamic: dyn, access: clusteraccess.NewDirect(dyn)}
+
+	img, err := c.CreateImage(context.Background(), "ubuntu-22.04", "https://example.com/img.qcow2")
+	if err != nil {
+		t.Fatalf("CreateImage (local): %v", err)
+	}
+	if img.Namespace != "default" || img.DisplayName != "ubuntu-22.04" {
+		t.Errorf("image = %+v, want namespace=default displayName=ubuntu-22.04", img)
+	}
+
+	// The object really landed in the local fake store under the returned name.
+	// img.ID is "default/<name>", so strip the "default/" prefix.
+	name := img.ID[len("default/"):]
+	got, err := dyn.Resource(vmImageGVR).Namespace("default").Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("image not found in direct store under %q: %v", name, err)
+	}
+	// The stored object carries a real name, not generateName.
+	if got.GetName() != name {
+		t.Errorf("stored object name = %q, want %q", got.GetName(), name)
+	}
+	if _, hasGen, _ := unstructured.NestedString(got.Object, "metadata", "generateName"); hasGen {
+		t.Errorf("stored object unexpectedly carries metadata.generateName")
+	}
+}
+
+// ── resolveImage routes through c.access.List (not c.dynamic) ────────────────
+
+func TestResolveImage_RoutesViaAccessorList(t *testing.T) {
+	// Seed the accessor's List with one ready image (status.storageClassName set).
+	item := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "harvesterhci.io/v1beta1",
+		"kind":       "VirtualMachineImage",
+		"metadata": map[string]interface{}{
+			"name":      "image-abc123",
+			"namespace": "default",
+		},
+		"spec":   map[string]interface{}{"displayName": "ubuntu-22.04"},
+		"status": map[string]interface{}{"storageClassName": "longhorn-image-abc123"},
+	}}
+	rec := &recordingImageAccessor{listItems: []unstructured.Unstructured{item}}
+	// REMOTE client: resolveImage must NOT touch c.dynamic (it is nil) — proving
+	// the lookup routes through the seam.
+	c := NewRemoteClient(rec, "lk", "zone-1")
+
+	// By display name.
+	id, sc, err := c.resolveImage(context.Background(), "ubuntu-22.04")
+	if err != nil {
+		t.Fatalf("resolveImage by displayName: %v", err)
+	}
+	if id != "default/image-abc123" || sc != "longhorn-image-abc123" {
+		t.Errorf("resolveImage = (%q, %q), want (default/image-abc123, longhorn-image-abc123)", id, sc)
+	}
+	if rec.listCalls != 1 {
+		t.Errorf("accessor List called %d times, want 1", rec.listCalls)
+	}
+	// Cross-namespace lookup: namespace must be empty (all namespaces).
+	if rec.lastListNS != "" {
+		t.Errorf("resolveImage List namespace = %q, want empty (all namespaces)", rec.lastListNS)
+	}
+
+	// By full ID also resolves.
+	id2, _, err := c.resolveImage(context.Background(), "default/image-abc123")
+	if err != nil {
+		t.Fatalf("resolveImage by ID: %v", err)
+	}
+	if id2 != "default/image-abc123" {
+		t.Errorf("resolveImage by ID = %q, want default/image-abc123", id2)
+	}
+}
+
+// TestResolveImage_NotFound proves the seam-routed lookup still surfaces the
+// not-found error when no image matches.
+func TestResolveImage_NotFound(t *testing.T) {
+	rec := &recordingImageAccessor{listItems: nil}
+	c := NewRemoteClient(rec, "lk", "zone-1")
+
+	if _, _, err := c.resolveImage(context.Background(), "missing"); err == nil {
+		t.Fatal("resolveImage returned nil error for a missing image; want not-found")
+	}
+}

--- a/dc-api/internal/providers/harvester/vmwrite_seam_test.go
+++ b/dc-api/internal/providers/harvester/vmwrite_seam_test.go
@@ -128,6 +128,13 @@ type countingAccessor struct {
 	createCalls int
 	applyCalls  int
 	deleteCalls int
+
+	// listDelegate, when non-nil, serves List. CreateVM now resolves the image via
+	// c.access.List (the image slice routed resolveImage through the seam), so the
+	// Direct fallback in a CreateVM routing test must reach the seeded image store.
+	// Tests that don't exercise CreateVM leave it nil (List returns empty). It never
+	// affects create/delete counting.
+	listDelegate clusteraccess.Accessor
 }
 
 var _ clusteraccess.Accessor = (*countingAccessor)(nil)
@@ -139,7 +146,10 @@ func (c *countingAccessor) Get(_ context.Context, _ schema.GroupVersionResource,
 	}}, nil
 }
 
-func (c *countingAccessor) List(_ context.Context, _ schema.GroupVersionResource, _ string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (c *countingAccessor) List(ctx context.Context, gvr schema.GroupVersionResource, ns string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if c.listDelegate != nil {
+		return c.listDelegate.List(ctx, gvr, ns, opts)
+	}
 	return &unstructured.UnstructuredList{}, nil
 }
 
@@ -200,8 +210,9 @@ func (c *countingAccessor) deleteCount() int {
 
 // newEmptyFakeDynamic returns a fake dynamic client with NO objects, so a DeleteVM
 // sees no object (and CreateVM, when it reaches a real store, would be a fresh
-// create). resolveImage does NOT go through the seam, so CreateVM tests pre-seed
-// an image object via newFakeDynamicWithImage instead.
+// create). resolveImage now lists via the seam (c.access.List), so CreateVM tests
+// seed the image via newFakeDynamicWithImage and delegate the Direct fallback's
+// List to it (countingAccessor.listDelegate).
 func newEmptyFakeDynamic() *dynamicfake.FakeDynamicClient {
 	gvrToListKind := map[schema.GroupVersionResource]string{
 		harvesterVMResource:  "VirtualMachineList",
@@ -212,7 +223,9 @@ func newEmptyFakeDynamic() *dynamicfake.FakeDynamicClient {
 }
 
 // newFakeDynamicWithImage seeds a ready VirtualMachineImage (status.storageClassName
-// populated) so resolveImage — which always runs on c.dynamic — succeeds. The VM
+// populated) so resolveImage succeeds. resolveImage lists via c.access.List, so a
+// CreateVM test wires this store into the accessor (either as the client's own
+// Direct, or via countingAccessor.listDelegate on the Direct fallback). The VM
 // store itself stays empty.
 func newFakeDynamicWithImage(imageName, storageClass string) *dynamicfake.FakeDynamicClient {
 	img := &unstructured.Unstructured{Object: map[string]interface{}{
@@ -274,7 +287,9 @@ func writeRouted(direct clusteraccess.Accessor, agent clusteraccess.Accessor, al
 
 func TestCreateVM_ToggleOff_UsesDirect_AgentUntouched(t *testing.T) {
 	dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
-	direct := &countingAccessor{}
+	// resolveImage now lists images via c.access.List; the Direct fallback must
+	// reach the seeded image store, so delegate List to a real Direct over `dyn`.
+	direct := &countingAccessor{listDelegate: clusteraccess.NewDirect(dyn)}
 	sess := &writeStubSession{}
 	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
 
@@ -332,7 +347,9 @@ func TestDeleteVM_ToggleOff_UsesDirect_AgentUntouched(t *testing.T) {
 
 func TestCreateVM_ToggleOn_RoutesToAgentApply(t *testing.T) {
 	dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
-	direct := &countingAccessor{}
+	// VerbList is NOT in this test's agent allow-set, so resolveImage's List falls
+	// to Direct — delegate it to the seeded image store.
+	direct := &countingAccessor{listDelegate: clusteraccess.NewDirect(dyn)}
 	sess := &writeStubSession{
 		applyResult: agentgw.ApplyResult{
 			APIVersion:      "kubevirt.io/v1",
@@ -438,7 +455,9 @@ func TestCreateVM_ToggleOn_AgentError_SurfacesNoDirectFallback(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
-			direct := &countingAccessor{}
+			// resolveImage runs before the routed create; its List falls to Direct
+			// here (VerbList not activated), so delegate it to the seeded store.
+			direct := &countingAccessor{listDelegate: clusteraccess.NewDirect(dyn)}
 			sess := &writeStubSession{applyErr: tc.applyErr}
 			agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
 
@@ -511,7 +530,9 @@ func TestDeleteVM_ToggleOn_AgentError_SurfacesNoDirectFallback(t *testing.T) {
 // flipping the env var can never strand the zone when the agent is down.
 func TestCreateVM_NoConnectedAgent_UsesDirect(t *testing.T) {
 	dyn := newFakeDynamicWithImage("ubuntu-22.04", "harvester-longhorn-default-image-abc123")
-	direct := &countingAccessor{}
+	// No agent → everything (incl. resolveImage's List) is Direct; delegate List
+	// to the seeded image store.
+	direct := &countingAccessor{listDelegate: clusteraccess.NewDirect(dyn)}
 	sess := &writeStubSession{}
 	agent := clusteraccess.NewAgentBacked(sess, "lk", "zone-1", "dc-api", clusteraccess.DefaultGVKMapper(), zerolog.Nop())
 

--- a/flux/platform/dc-agent/base/rbac.yaml
+++ b/flux/platform/dc-agent/base/rbac.yaml
@@ -28,7 +28,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["harvesterhci.io"]
     resources: ["virtualmachineimages"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "create", "patch"]
   - apiGroups: ["k8s.cni.cncf.io"]
     resources: ["network-attachment-definitions"]
     verbs: ["get", "list", "watch", "create", "patch", "delete"]


### PR DESCRIPTION
## What this changes

The **image slice** of the credential-locality work (#7): `CreateImage` and `resolveImage` now route through the cluster-access seam, so image **creation** and **lookup** work in a remote, agent-only zone (previously both were direct `c.dynamic` calls that returned a local-only error there). Stacks on `controlplane` — it needs the already-merged `List` op + image capability, not the full-object `Get` (#201).

## Changes

- **Capability / RBAC**: `vmImageCapability` gains `VerbCreate` (routed) and `Create`/`Apply` (agent verbs); regenerated RBAC grants `create,patch` on `virtualmachineimages` (`patch` because the agent's create is server-side apply).
- **`resolveImage`**: lists via `c.access.List` instead of a direct `c.dynamic` list → routes to the zone's agent.
- **`CreateImage`**: routes via `c.access.Create`. Since SSA (the agent create path) requires a name, the image now gets a **client-assigned `image-<random>` name** (crypto-random) instead of the apiserver's `generateName`. The local path still POSTs it; Harvester imports it identically. `resolveImage` matches by display name / ID, so the assigned name isn't user-visible.

## Verification

Both modules build + vet; unit tests pass, including new create/resolve seam tests (remote-routes-via-accessor + local-Direct) and the RBAC drift check. Fixed a test regression this surfaced: routing `resolveImage` broke the `CreateVM` seam tests (their fake accessor returned no images), fixed by delegating that fake's `List` to a real Direct over the seeded image store.

## Remaining pre-merge check

`CreateImage` builds a `VirtualMachineImage` CR and this swaps `generateName` for an explicit `name`. Unit tests prove the routing + object shape, but a **live structural diff of the generated image against a real Harvester `VirtualMachineImage`** (that both the POST and the agent's SSA path accept the explicit name and Harvester still imports it) is the remaining check — needs cluster access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image creation can now be routed through the agent when needed, enabling broader remote usage.
  * Image lookup now works through the same routed path, improving support for remote environments.

* **Bug Fixes**
  * Fixed image creation and resolution for setups without direct local access.
  * Improved handling so repeated image creations use unique names and avoid collisions.

* **Tests**
  * Expanded routing tests to verify image operations follow the expected path and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->