### PR TITLE
[Feature] Route the cloud-provider SA bootstrap through the agent

### DIFF
--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -117,13 +117,14 @@ func (a *AgentBacked) ref(gvr schema.GroupVersionResource, ns, name string) (age
 // what the read-modify-patch write ops (NAT/DNS/cloud-provider SA) need: they
 // read .spec/.data to modify it.
 //
-// COMPAT: an OLDER agent that predates get_object replies OP_UNSUPPORTED; this
-// FALLS BACK to Session.GetStatus and synthesizes the prior status-only partial
-// object (apiVersion, kind, metadata.name/namespace, resourceVersion,
-// generation, status). The behavior degrades to the prior status-only read
-// rather than erroring, keeping the change non-breaking during a rolling deploy.
-// Callers that only read status (e.g. the VM read slice's
-// status.printableStatus) are unaffected by which path served them.
+// COMPAT: an OLDER agent that predates get_object replies OP_UNSUPPORTED. For a
+// family whose Get consumers read status alone (StatusFallbackOK — the VM read
+// slice), this FALLS BACK to Session.GetStatus and synthesizes the prior
+// status-only partial object, keeping that read non-breaking during a rolling
+// deploy. For a FULL-object family (a Secret's .data, the KubeOVN .spec/.labels
+// read-modify-patch ops) the status-only partial would drop the fields the caller
+// needs, so a CLEAR error is returned instead of a silent partial — the zone's
+// agent must be upgraded. See AgentCapability.StatusFallbackOK.
 //
 // Found==false (on either path) is translated to a k8serrors.NewNotFound-shaped
 // error so callers' existing IsNotFound / "not found" checks fire unchanged on
@@ -152,13 +153,26 @@ func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, 
 		// (agent unavailable, RBAC, timeout) propagates.
 		terr := a.translateErr(err)
 		if errors.Is(terr, agentgw.ErrOpNotRoutable) {
-			a.log.Info().
-				Str("seam", "agent").
-				Str("region", a.region).Str("zone", a.zone).
-				Str("api_version", ref.APIVersion).Str("kind", ref.Kind).
-				Str("namespace", ref.Namespace).Str("name", ref.Name).
-				Msg("agent does not support get_object; falling back to status-only get_status")
-			return a.getStatusFallback(ctx, gvr, ref, ns, name)
+			// OP_UNSUPPORTED: the agent predates get_object. Degrading to the
+			// status-only get_status is valid ONLY for families whose Get consumers
+			// read status alone (VMs). For a full-object consumer (a Secret's
+			// .data.token, the KubeOVN read-modify-patch ops' .spec/.metadata.labels)
+			// the synthesized partial would silently drop the very fields the caller
+			// needs — e.g. the cloud-provider SA bootstrap would poll a token-less
+			// Secret until it times out. So gate the fallback on the family's
+			// StatusFallbackOK; otherwise surface a clear, immediate error (Routed.Get
+			// is terminal on agent activation, so this propagates rather than silently
+			// degrading). ErrOpNotRoutable stays wrapped for callers' errors.Is checks.
+			if StatusFallbackOK(gvr) {
+				a.log.Info().
+					Str("seam", "agent").
+					Str("region", a.region).Str("zone", a.zone).
+					Str("api_version", ref.APIVersion).Str("kind", ref.Kind).
+					Str("namespace", ref.Namespace).Str("name", ref.Name).
+					Msg("agent does not support get_object; falling back to status-only get_status")
+				return a.getStatusFallback(ctx, gvr, ref, ns, name)
+			}
+			return nil, fmt.Errorf("clusteraccess: full-object read of %s in zone %s/%s requires an agent that supports get_object, but the zone's agent predates it (upgrade the agent): %w", gvr.String(), a.region, a.zone, terr)
 		}
 		return nil, terr
 	}

--- a/dc-api/internal/providers/clusteraccess/capabilities.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities.go
@@ -48,6 +48,18 @@ type AgentCapability struct {
 	// get_status/watch_status read+watch, and SSA-create needs create+patch. A
 	// capability that grants no RBAC (pre-seeded GVK-only) leaves this nil.
 	AgentVerbs []Verb
+	// StatusFallbackOK allows AgentBacked.Get to degrade to a status-only read
+	// (Session.GetStatus) when an OLDER agent predates full-object get_object and
+	// replies OP_UNSUPPORTED. Set it ONLY for families whose Get consumers read
+	// status alone (the VM read slice's status.printableStatus). Families whose Get
+	// consumers need the full object — Secrets (.data.token) and the KubeOVN
+	// read-modify-patch ops that read .spec / .metadata.labels — MUST leave this
+	// false: the status-only partial the fallback synthesizes drops .spec/.data/
+	// .labels, so degrading to it would silently return a useless object (the
+	// cloud-provider SA bootstrap would poll a token-less Secret until timeout).
+	// With the flag false, an old agent yields a clear error instead — see
+	// AgentBacked.Get.
+	StatusFallbackOK bool
 }
 
 // vmCapability is the one truly onboarded capability in phase 1.
@@ -71,6 +83,11 @@ var vmCapability = AgentCapability{
 	// needs create+patch. Reproduces the old rule verbatim:
 	// get,list,watch,create,patch,delete.
 	AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
+	// GetVM reads only status.printableStatus, so the status-only fallback is a
+	// valid degrade for an older agent without get_object (preserves the
+	// rolling-deploy compat added with the full-object Get). Every other
+	// routable-Get family reads the full object and leaves this false.
+	StatusFallbackOK: true,
 }
 
 // The network families (NAD, Vpc, Subnet) are onboarded for the kubeovn CRD
@@ -223,6 +240,8 @@ var (
 	derivedGVKTable   map[schema.GroupVersionResource]gvk
 	derivedRouteSet   map[schema.GroupVersionResource]map[Verb]bool
 	derivedUnionRoute map[Verb]bool
+
+	derivedStatusFallback map[schema.GroupVersionResource]bool
 )
 
 func buildDerived() {
@@ -230,8 +249,12 @@ func buildDerived() {
 		derivedGVKTable = make(map[schema.GroupVersionResource]gvk, len(AgentCapabilities))
 		derivedRouteSet = make(map[schema.GroupVersionResource]map[Verb]bool, len(AgentCapabilities))
 		derivedUnionRoute = make(map[Verb]bool)
+		derivedStatusFallback = make(map[schema.GroupVersionResource]bool, len(AgentCapabilities))
 		for _, c := range AgentCapabilities {
 			derivedGVKTable[c.GVR] = gvk{APIVersion: c.APIVersion, Kind: c.Kind}
+			if c.StatusFallbackOK {
+				derivedStatusFallback[c.GVR] = true
+			}
 			if len(c.RouteVerbs) > 0 {
 				set := make(map[Verb]bool, len(c.RouteVerbs))
 				for _, v := range c.RouteVerbs {
@@ -284,6 +307,16 @@ func RoutableVerbs(gvr schema.GroupVersionResource) (map[Verb]bool, bool) {
 		out[v] = true
 	}
 	return out, true
+}
+
+// StatusFallbackOK reports whether AgentBacked.Get may degrade a routed read of
+// this GVR to a status-only get_status when an older agent lacks get_object. True
+// only for families whose Get consumers read status alone (VMs); false (the
+// default) for full-object consumers, which then get a clear error on an old
+// agent instead of a silently-partial object. See AgentCapability.StatusFallbackOK.
+func StatusFallbackOK(gvr schema.GroupVersionResource) bool {
+	buildDerived()
+	return derivedStatusFallback[gvr]
 }
 
 // IsReadVerb classifies a seam Verb as a read for the reads/writes toggle split.

--- a/dc-api/internal/providers/clusteraccess/capabilities.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities.go
@@ -141,17 +141,67 @@ var (
 		RouteVerbs: []Verb{VerbGet, VerbCreate, VerbDelete},
 		AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
 	}
+	// serviceAccountCapability onboards the ServiceAccount create that
+	// EnsureCloudProviderSA routes through the harvester seam (the cloud-provider
+	// SA bootstrap slice, F32). The GVR matches harvester.serviceAccountsGVR
+	// exactly (core group, v1, serviceaccounts).
+	serviceAccountCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"},
+		APIVersion: "v1",
+		Kind:       "ServiceAccount",
+		Namespaced: true,
+		// dc-api routes only the create — the SA bootstrap creates the SA idempotently
+		// and never reads/lists/deletes it through the seam.
+		RouteVerbs: []Verb{VerbCreate},
+		// SA grant: create + patch, because the AgentBacked create is a server-side
+		// apply (VerbApply→patch). Mirrors the write grant on the other families
+		// (create for the direct-POST semantics, patch for the agent's SSA create).
+		AgentVerbs: []Verb{VerbCreate, VerbApply},
+	}
+	// roleBindingCapability onboards the RoleBinding create that
+	// EnsureCloudProviderSA routes through the harvester seam. The RoleBinding binds
+	// the SA to the harvesterhci.io:cloudprovider ClusterRole. The GVR matches
+	// harvester.roleBindingsGVR exactly (rbac.authorization.k8s.io, v1, rolebindings).
+	roleBindingCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "RoleBinding",
+		Namespaced: true,
+		// dc-api routes only the create — the bootstrap creates the RoleBinding
+		// idempotently and never reads/lists/deletes it through the seam.
+		RouteVerbs: []Verb{VerbCreate},
+		// SA grant: create + patch (SSA is the agent's create mechanism).
+		AgentVerbs: []Verb{VerbCreate, VerbApply},
+	}
+	// secretCapability onboards the token Secret ops that EnsureCloudProviderSA
+	// routes through the harvester seam: Create (the kubernetes.io/service-account-
+	// token Secret) and Get (the token-population poll reads .data.token off the
+	// Secret). The GVR matches harvester.secretsGVR exactly (core group, v1, secrets).
+	secretCapability = AgentCapability{
+		GVR:        schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+		APIVersion: "v1",
+		Kind:       "Secret",
+		Namespaced: true,
+		// dc-api routes Get (read the populated SA token) and Create (the token
+		// Secret). No list/delete through the seam.
+		RouteVerbs: []Verb{VerbGet, VerbCreate},
+		// SA grant: get to read the populated token, create + patch for the token
+		// Secret (create for the direct POST, patch because the agent create is SSA).
+		AgentVerbs: []Verb{VerbGet, VerbCreate, VerbApply},
+	}
 )
 
 // AgentCapabilities is THE registry: one declaration per resource family.
 //
 // Onboarded (RouteVerbs + AgentVerbs set): vmCapability, the three network
 // families nadCapability/vpcCapability/subnetCapability (the kubeovn CRD CRUD
-// slice), and vmImageCapability (read/list path + image create). vmiCapability stays a GVK-only
-// pre-seeded entry that keeps the wire mapper a superset without granting any
-// routing or RBAC. New families are added here (one struct each) in later
-// phases — never by editing the mapper, the allow-set switch, or the RBAC YAML
-// by hand.
+// slice), vmImageCapability (read/list path + image create), and the three
+// cloud-provider SA bootstrap families serviceAccountCapability/
+// roleBindingCapability/secretCapability (F32 — EnsureCloudProviderSA routed
+// through the harvester seam). vmiCapability stays a GVK-only pre-seeded entry
+// that keeps the wire mapper a superset without granting any routing or RBAC.
+// New families are added here (one struct each) in later phases — never by
+// editing the mapper, the allow-set switch, or the RBAC YAML by hand.
 var AgentCapabilities = []AgentCapability{
 	vmCapability,
 	vmiCapability,
@@ -159,6 +209,9 @@ var AgentCapabilities = []AgentCapability{
 	nadCapability,
 	vpcCapability,
 	subnetCapability,
+	serviceAccountCapability,
+	roleBindingCapability,
+	secretCapability,
 }
 
 // Registry returns the declared capabilities.
@@ -193,10 +246,12 @@ func buildDerived() {
 
 // UnionRouteVerbs returns the union of RouteVerbs across all capabilities — the
 // set of seam Verbs that MAY route to the agent for ANY family. With the VM,
-// network, and image families onboarded this equals
+// network, image, and cloud-provider-SA families onboarded this equals
 // {VerbGet, VerbList, VerbCreate, VerbDelete} (List added when ListVMs/Images/
 // Networks were routed through the agent; the image family also routes VerbCreate
 // for CreateImage, but VM/NAD already contribute it so the union is unchanged).
+// The SA/RoleBinding/Secret families (F32) route only Get/Create, both already
+// in the union, so the union is unchanged by them too.
 // agentDecision consults this for
 // membership, then gates reads vs writes by the per-family env toggles
 // (VerbList falls on the read side — see IsReadVerb).

--- a/dc-api/internal/providers/clusteraccess/capabilities_test.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities_test.go
@@ -120,8 +120,55 @@ func TestRoutableVerbs_ImageRoutesGetListCreate(t *testing.T) {
 	}
 }
 
-// TestDefaultGVKMapperResolvesKnownGVRs pins the derived GVK table to the same
-// six entries (and same APIVersion/Kind) the pre-refactor literal had.
+// TestRoutableVerbs_CloudProviderSAFamilies pins the routable sets for the three
+// cloud-provider-SA bootstrap families (F32): ServiceAccount and RoleBinding
+// route exactly {Create}; Secret routes exactly {Get, Create} (Get to read the
+// populated token, Create for the token Secret). No other verb is routable for
+// these families — in particular Delete/Apply/Update/List/Watch must NOT be.
+func TestRoutableVerbs_CloudProviderSAFamilies(t *testing.T) {
+	saGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
+	rbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+	secGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+
+	// SA and RoleBinding: exactly {Create}.
+	for _, gvr := range []schema.GroupVersionResource{saGVR, rbGVR} {
+		verbs, ok := RoutableVerbs(gvr)
+		if !ok {
+			t.Errorf("%s must be an onboarded routable family", gvr.Resource)
+			continue
+		}
+		if !verbs[VerbCreate] {
+			t.Errorf("%s must route VerbCreate, got %v", gvr.Resource, verbs)
+		}
+		if len(verbs) != 1 {
+			t.Errorf("%s routable set = %v, want exactly {Create}", gvr.Resource, verbs)
+		}
+	}
+
+	// Secret: exactly {Get, Create}.
+	secVerbs, ok := RoutableVerbs(secGVR)
+	if !ok {
+		t.Fatal("secrets must be an onboarded routable family")
+	}
+	for _, want := range []Verb{VerbGet, VerbCreate} {
+		if !secVerbs[want] {
+			t.Errorf("secrets must route %v, got %v", want, secVerbs)
+		}
+	}
+	for _, w := range []Verb{VerbList, VerbApply, VerbUpdate, VerbDelete, VerbWatch} {
+		if secVerbs[w] {
+			t.Errorf("secrets must NOT route %v", w)
+		}
+	}
+	if len(secVerbs) != 2 {
+		t.Errorf("secrets routable set = %v, want exactly {Get, Create}", secVerbs)
+	}
+}
+
+// TestDefaultGVKMapperResolvesKnownGVRs pins the derived GVK table to the
+// onboarded entries (and same APIVersion/Kind). The six original entries plus the
+// three cloud-provider-SA bootstrap families (serviceaccounts, rolebindings,
+// secrets — F32).
 func TestDefaultGVKMapperResolvesKnownGVRs(t *testing.T) {
 	m := DefaultGVKMapper()
 	cases := []struct {
@@ -135,6 +182,9 @@ func TestDefaultGVKMapperResolvesKnownGVRs(t *testing.T) {
 		{schema.GroupVersionResource{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}, "k8s.cni.cncf.io/v1", "NetworkAttachmentDefinition"},
 		{schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}, "kubeovn.io/v1", "Vpc"},
 		{schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "subnets"}, "kubeovn.io/v1", "Subnet"},
+		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, "v1", "ServiceAccount"},
+		{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}, "rbac.authorization.k8s.io/v1", "RoleBinding"},
+		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, "v1", "Secret"},
 	}
 	for _, c := range cases {
 		av, k, ok := m.GVK(c.gvr)

--- a/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -323,6 +324,46 @@ func TestAgentBackedGet_FallsBackToStatusOnUnsupported(t *testing.T) {
 	// the degraded path.
 	if _, found, _ := unstructured.NestedMap(obj.Object, "spec"); found {
 		t.Error("status-only fallback object unexpectedly carries .spec")
+	}
+}
+
+// TestAgentBackedGet_FullObjectFamilyErrorsOnUnsupported proves the other half of
+// the compat gate: a FULL-object family (Secrets — StatusFallbackOK=false) whose
+// caller needs .data must NOT degrade to the status-only partial on an older
+// agent. Get returns a clear error (still wrapping ErrOpNotRoutable) and never
+// calls GetStatus — so the cloud-provider SA bootstrap fails fast instead of
+// polling a token-less Secret until timeout.
+func TestAgentBackedGet_FullObjectFamilyErrorsOnUnsupported(t *testing.T) {
+	secretsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	if verbs, ok := RoutableVerbs(secretsGVR); !ok || !verbs[VerbGet] {
+		t.Fatal("precondition: secrets Get must be a routable family")
+	}
+	if StatusFallbackOK(secretsGVR) {
+		t.Fatal("precondition: secrets must NOT permit the status-only fallback")
+	}
+	sess := &fakeSession{
+		getObject: func(ref agentgw.ResourceRef) (agentgw.GetObjectResult, error) {
+			return agentgw.GetObjectResult{}, &agentgw.AgentError{Code: agentgw.CodeOpUnsupported, Message: "unknown op"}
+		},
+		getStatus: func(ref agentgw.ResourceRef) (agentgw.StatusSnapshot, error) {
+			t.Error("full-object family must NOT fall back to GetStatus")
+			return agentgw.StatusSnapshot{}, nil
+		},
+	}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	_, err := a.Get(context.Background(), secretsGVR, "dc-t-p", "sa-token", metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("Get must return an error for a full-object family on OP_UNSUPPORTED, got nil")
+	}
+	if !errors.Is(err, agentgw.ErrOpNotRoutable) {
+		t.Errorf("error must wrap ErrOpNotRoutable for callers' errors.Is checks, got %v", err)
+	}
+	if sess.getStatusCalled {
+		t.Error("Get fell back to GetStatus for a full-object family; it must error instead")
+	}
+	if !strings.Contains(err.Error(), "get_object") {
+		t.Errorf("error should mention get_object upgrade guidance, got %q", err.Error())
 	}
 }
 

--- a/dc-api/internal/providers/harvester/client.go
+++ b/dc-api/internal/providers/harvester/client.go
@@ -100,43 +100,45 @@ type Client struct {
 	// unless WithRoutedAccessor injects a routed accessor. The VM-object ops route
 	// through it: GetVM's primary VirtualMachine read (read slice), CreateVM's
 	// create + DeleteVM's delete (write slice 1), the collection reads
-	// ListVMs/ListImages/ListNetworks (list slice — M-D), and the image slice —
-	// CreateImage's create and resolveImage's create-time storageClass lookup. The
-	// cloud-provider SA bootstrap and the VMI read inside GetVM still call
-	// c.dynamic directly. The seam never leaks an agent concept past the
-	// ComputeProvider interface.
+	// ListVMs/ListImages/ListNetworks (list slice — M-D), the image slice —
+	// CreateImage's create and resolveImage's create-time storageClass lookup — and
+	// the cloud-provider SA bootstrap (EnsureCloudProviderSA — the SA/RoleBinding/
+	// Secret creates + the token-population Secret Get, F32). Only the VMI read
+	// inside GetVM still calls c.dynamic directly. The seam never leaks an agent
+	// concept past the ComputeProvider interface.
 	access clusteraccess.Accessor
 
 	// remoteRegion/remoteZone are non-empty ONLY for a credential-free REMOTE
 	// client built by NewRemoteClient (multi-zone routing). For such a client
 	// c.dynamic is nil: the seam ops (CreateVM/GetVM/DeleteVM via c.access, the
-	// list reads via c.access.List, and the image slice — CreateImage's create and
-	// resolveImage's lookup — via c.access) route to that zone's agent. The two
-	// remaining direct paths behave differently on a remote client:
+	// list reads via c.access.List, the image slice — CreateImage's create and
+	// resolveImage's lookup — via c.access, and the cloud-provider SA bootstrap
+	// EnsureCloudProviderSA — the three creates + the token-population Get via
+	// c.access) route to that zone's agent. The two remaining direct paths behave
+	// differently on a remote client:
 	//   - GetVM's VMI IP enrichment read DEGRADES GRACEFULLY: it is SKIPPED (the
 	//     `c.dynamic == nil` guard returns the agent-supplied VM status WITHOUT IP
 	//     enrichment — no error), so a remote VM's status is still reported.
-	//   - the genuinely local-only ops — the cloud-provider SA bootstrap and the
-	//     full VM create orchestration — have no direct path and return a
-	//     clear local-only error (localOnlyErr) naming the zone instead of panicking
-	//     on a nil dynamic client.
+	//   - the one genuinely local-only op — the full VM create orchestration — has
+	//     no direct path and returns a clear local-only error (localOnlyErr) naming
+	//     the zone instead of panicking on a nil dynamic client.
 	// Empty for the LOCAL client → today's behaviour.
 	remoteRegion, remoteZone string
 }
 
-// localOnlyErr is returned by a REMOTE client's direct-only methods: VM create
-// (the full create orchestration is not yet routed — see CreateVM's note) and the
-// cloud-provider SA bootstrap. These touch c.dynamic, which a remote client does
-// not have. Failing here — BEFORE a PENDING row or a provisioner call — is the
-// documented local-only constraint for the remote-zone build. NOTE: image
-// resolution/import (resolveImage, CreateImage) and the collection reads are NO
-// LONGER local-only — they route through the cluster-access seam (c.access), so a
-// remote client serves them via the agent. resolveImage's storageClass lookup
-// routes too; only the full VM create orchestration and the SA bootstrap remain
-// behind this explicit error.
+// localOnlyErr is returned by a REMOTE client's one remaining direct-only method:
+// the full VM create orchestration (CreateVM — manifest build, MAC pinning, DNS
+// injection — is not yet routed for a remote zone; see CreateVM's note). It
+// touches c.dynamic, which a remote client does not have. Failing here — BEFORE a
+// PENDING row or a provisioner call — is the documented local-only constraint for
+// the remote-zone build. NOTE: image resolution/import (resolveImage,
+// CreateImage), the collection reads, AND the cloud-provider SA bootstrap
+// (EnsureCloudProviderSA) are NO LONGER local-only — they route through the
+// cluster-access seam (c.access), so a remote client serves them via the agent.
+// Only the full VM create orchestration remains behind this explicit error.
 func (c *Client) localOnlyErr(op string) error {
 	return fmt.Errorf(
-		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct Harvester credentials there (the full VM create orchestration and the cloud-provider SA bootstrap are local-only for now)",
+		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct Harvester credentials there (the full VM create orchestration is local-only for now)",
 		op, c.remoteRegion, c.remoteZone)
 }
 
@@ -494,14 +496,22 @@ func (c *Client) HarvesterCACert() []byte { return c.restConfig.CAData }
 // the Secret's .data.token field). Polls up to 30 s for the token controller
 // to populate the Secret after creation.
 func (c *Client) EnsureCloudProviderSA(ctx context.Context, tenantNamespace string) ([]byte, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("cloud-provider ServiceAccount bootstrap")
-	}
 	saName := "harvester-cloud-provider-" + tenantNamespace
 
 	commonLabels := map[string]interface{}{
 		"dc-api/managed": "true",
 	}
+
+	// The three creates and the token-population Get all go through the
+	// cluster-access seam (c.access), so a REMOTE (agent-only) client serves them
+	// via the agent. With the toggle OFF (default / local client) each is the exact
+	// dynamic-client call this method ran before — byte-identical POST/GET. With the
+	// toggle ON and a live agent for the zone, the creates route to the agent's
+	// server-side apply and the Get to the agent's full-object read. SSA is
+	// idempotent (apply-on-existing is a no-op update, not an already-exists error),
+	// so the routed create won't hit IsAlreadyExists; the guard is kept for the
+	// local POST path, where re-running the bootstrap must treat an existing object
+	// as success.
 
 	// ── Step 1: ServiceAccount ────────────────────────────────────────────────
 	saObj := &unstructured.Unstructured{
@@ -515,7 +525,7 @@ func (c *Client) EnsureCloudProviderSA(ctx context.Context, tenantNamespace stri
 			},
 		},
 	}
-	_, err := c.dynamic.Resource(serviceAccountsGVR).Namespace(tenantNamespace).Create(ctx, saObj, metav1.CreateOptions{})
+	_, err := c.access.Create(ctx, serviceAccountsGVR, tenantNamespace, saObj, metav1.CreateOptions{})
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("create cloud-provider ServiceAccount in %s: %w", tenantNamespace, err)
 	}
@@ -544,7 +554,7 @@ func (c *Client) EnsureCloudProviderSA(ctx context.Context, tenantNamespace stri
 			},
 		},
 	}
-	_, err = c.dynamic.Resource(roleBindingsGVR).Namespace(tenantNamespace).Create(ctx, rbObj, metav1.CreateOptions{})
+	_, err = c.access.Create(ctx, roleBindingsGVR, tenantNamespace, rbObj, metav1.CreateOptions{})
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("create cloud-provider RoleBinding in %s: %w", tenantNamespace, err)
 	}
@@ -566,7 +576,7 @@ func (c *Client) EnsureCloudProviderSA(ctx context.Context, tenantNamespace stri
 			"type": "kubernetes.io/service-account-token",
 		},
 	}
-	_, err = c.dynamic.Resource(secretsGVR).Namespace(tenantNamespace).Create(ctx, secretObj, metav1.CreateOptions{})
+	_, err = c.access.Create(ctx, secretsGVR, tenantNamespace, secretObj, metav1.CreateOptions{})
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("create cloud-provider token Secret in %s: %w", tenantNamespace, err)
 	}
@@ -574,10 +584,12 @@ func (c *Client) EnsureCloudProviderSA(ctx context.Context, tenantNamespace stri
 	// ── Step 4: poll for token population ────────────────────────────────────
 	// The Kubernetes token controller populates .data.token asynchronously
 	// after seeing the kubernetes.io/service-account-token Secret.
-	// Poll up to 30 s in 2 s intervals.
+	// Poll up to 30 s in 2 s intervals. The read routes through the seam
+	// (c.access.Get) — the agent's full-object Get returns the Secret with its
+	// populated .data.token.
 	deadline := time.Now().Add(30 * time.Second)
 	for {
-		secret, err := c.dynamic.Resource(secretsGVR).Namespace(tenantNamespace).Get(ctx, secretName, metav1.GetOptions{})
+		secret, err := c.access.Get(ctx, secretsGVR, tenantNamespace, secretName, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("get cloud-provider token Secret %s: %w", secretName, err)
 		}

--- a/dc-api/internal/providers/harvester/cloudprovidersa_seam_test.go
+++ b/dc-api/internal/providers/harvester/cloudprovidersa_seam_test.go
@@ -1,0 +1,359 @@
+package harvester
+
+// cloudprovidersa_seam_test.go proves the cloud-provider ServiceAccount slice
+// (F32) of the credential-locality work: EnsureCloudProviderSA routes its three
+// creates (ServiceAccount, RoleBinding, token Secret) AND the token-population
+// poll's read through the cluster-access seam (c.access), so it works for a
+// REMOTE (agent-only) zone, while the local Direct path is unchanged.
+//
+//   - Remote (no dynamic) → the three creates route through c.access.Create with
+//     the correct GVRs/namespace/names/shapes, and the token is read from the
+//     Secret's .data.token via c.access.Get (NOT c.dynamic). Fixed names, no
+//     generateName.
+//   - Local (Direct over a fake dynamic) → the three creates land in the fake
+//     store and the token is read back from the seeded Secret.
+//   - The three GVRs are the ones the harvester client already declares, so the
+//     seam addresses the same resources the direct path did.
+
+import (
+	"context"
+	"encoding/base64"
+	"sync"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+const (
+	testSANamespace = "dc-teamalpha-web"
+	// The SA/RoleBinding name and token-Secret name the bootstrap derives.
+	wantSAName     = "harvester-cloud-provider-" + testSANamespace
+	wantSecretName = wantSAName + "-token"
+	// A real SA token would be a JWT; any non-empty bytes prove the decode+return
+	// path. base64 of "sa-token-bytes".
+	fakeTokenPlain = "sa-token-bytes"
+)
+
+// saRecordingAccessor records every Create (GVR, namespace, object) and serves a
+// programmable Secret from Get so the token-population poll returns on the first
+// iteration. It is deliberately independent of the other seam tests' accessors:
+// only Create and Get are meaningful here; the rest satisfy the interface inertly.
+type saRecordingAccessor struct {
+	mu sync.Mutex
+
+	creates []recordedCreate
+
+	getCalls    int
+	lastGetGVR  schema.GroupVersionResource
+	lastGetNS   string
+	lastGetName string
+	// tokenB64 is what Get returns in the Secret's .data.token. Empty → the poll
+	// sees an unpopulated Secret (used to prove the poll actually reads .data).
+	tokenB64 string
+}
+
+type recordedCreate struct {
+	gvr schema.GroupVersionResource
+	ns  string
+	obj *unstructured.Unstructured
+}
+
+var _ clusteraccess.Accessor = (*saRecordingAccessor)(nil)
+
+func (a *saRecordingAccessor) Get(_ context.Context, gvr schema.GroupVersionResource, ns, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.getCalls++
+	a.lastGetGVR = gvr
+	a.lastGetNS = ns
+	a.lastGetName = name
+	// Return a Secret shell with .data.token populated (agent full-object Get shape).
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": ns,
+		},
+		"data": map[string]interface{}{
+			"token": a.tokenB64,
+		},
+	}}, nil
+}
+
+func (a *saRecordingAccessor) List(context.Context, schema.GroupVersionResource, string, metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+
+func (a *saRecordingAccessor) Create(_ context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.creates = append(a.creates, recordedCreate{gvr: gvr, ns: ns, obj: obj})
+	return obj, nil
+}
+
+func (a *saRecordingAccessor) Apply(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ string, _ bool) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *saRecordingAccessor) Update(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *saRecordingAccessor) Delete(context.Context, schema.GroupVersionResource, string, string, metav1.DeleteOptions) error {
+	return nil
+}
+
+// createFor returns the recorded create for the given GVR, or fails the test.
+func (a *saRecordingAccessor) createFor(t *testing.T, gvr schema.GroupVersionResource) recordedCreate {
+	t.Helper()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, c := range a.creates {
+		if c.gvr == gvr {
+			return c
+		}
+	}
+	t.Fatalf("no create recorded for GVR %v (recorded: %d creates)", gvr, len(a.creates))
+	return recordedCreate{}
+}
+
+// ── Remote path: the 3 creates + the token Get route through the seam ────────
+
+func TestEnsureCloudProviderSA_Remote_RoutesCreatesAndTokenGet(t *testing.T) {
+	rec := &saRecordingAccessor{tokenB64: base64.StdEncoding.EncodeToString([]byte(fakeTokenPlain))}
+	// A REMOTE client has no dynamic; every op MUST go through the accessor. If the
+	// SA bootstrap still touched c.dynamic this would panic on a nil client.
+	c := NewRemoteClient(rec, "lk", "zone-1")
+
+	token, err := c.EnsureCloudProviderSA(context.Background(), testSANamespace)
+	if err != nil {
+		t.Fatalf("EnsureCloudProviderSA (remote): %v", err)
+	}
+
+	// The returned token is the DECODED .data.token (raw bytes, not base64).
+	if string(token) != fakeTokenPlain {
+		t.Errorf("returned token = %q, want %q (decoded from .data.token)", string(token), fakeTokenPlain)
+	}
+
+	// Exactly three creates routed through the seam.
+	if len(rec.creates) != 3 {
+		t.Fatalf("accessor Create called %d times, want 3 (SA, RoleBinding, Secret)", len(rec.creates))
+	}
+
+	// ── ServiceAccount create ────────────────────────────────────────────────
+	sa := rec.createFor(t, serviceAccountsGVR)
+	if sa.ns != testSANamespace {
+		t.Errorf("SA create namespace = %q, want %q", sa.ns, testSANamespace)
+	}
+	assertNameNoGenerateName(t, sa.obj, wantSAName, "ServiceAccount")
+	if kind, _, _ := unstructured.NestedString(sa.obj.Object, "kind"); kind != "ServiceAccount" {
+		t.Errorf("SA create kind = %q, want ServiceAccount", kind)
+	}
+
+	// ── RoleBinding create ───────────────────────────────────────────────────
+	rb := rec.createFor(t, roleBindingsGVR)
+	if rb.ns != testSANamespace {
+		t.Errorf("RoleBinding create namespace = %q, want %q", rb.ns, testSANamespace)
+	}
+	assertNameNoGenerateName(t, rb.obj, wantSAName, "RoleBinding")
+	// The RoleBinding must bind the harvesterhci.io:cloudprovider ClusterRole to the SA.
+	roleRefKind, _, _ := unstructured.NestedString(rb.obj.Object, "roleRef", "kind")
+	roleRefName, _, _ := unstructured.NestedString(rb.obj.Object, "roleRef", "name")
+	if roleRefKind != "ClusterRole" || roleRefName != "harvesterhci.io:cloudprovider" {
+		t.Errorf("RoleBinding roleRef = {kind:%q name:%q}, want {ClusterRole harvesterhci.io:cloudprovider}", roleRefKind, roleRefName)
+	}
+	subjects, _, _ := unstructured.NestedSlice(rb.obj.Object, "subjects")
+	if len(subjects) != 1 {
+		t.Fatalf("RoleBinding subjects = %d, want 1", len(subjects))
+	}
+	subj, _ := subjects[0].(map[string]interface{})
+	if subj["kind"] != "ServiceAccount" || subj["name"] != wantSAName || subj["namespace"] != testSANamespace {
+		t.Errorf("RoleBinding subject = %v, want SA %q in %q", subj, wantSAName, testSANamespace)
+	}
+
+	// ── token Secret create ──────────────────────────────────────────────────
+	sec := rec.createFor(t, secretsGVR)
+	if sec.ns != testSANamespace {
+		t.Errorf("Secret create namespace = %q, want %q", sec.ns, testSANamespace)
+	}
+	assertNameNoGenerateName(t, sec.obj, wantSecretName, "Secret")
+	if typ, _, _ := unstructured.NestedString(sec.obj.Object, "type"); typ != "kubernetes.io/service-account-token" {
+		t.Errorf("Secret type = %q, want kubernetes.io/service-account-token", typ)
+	}
+	annot, _, _ := unstructured.NestedString(sec.obj.Object, "metadata", "annotations", "kubernetes.io/service-account.name")
+	if annot != wantSAName {
+		t.Errorf("Secret service-account.name annotation = %q, want %q", annot, wantSAName)
+	}
+
+	// ── token-population Get routed through the seam ─────────────────────────
+	if rec.getCalls != 1 {
+		t.Errorf("accessor Get called %d times, want 1 (single poll iteration)", rec.getCalls)
+	}
+	if rec.lastGetGVR != secretsGVR {
+		t.Errorf("token Get GVR = %v, want %v", rec.lastGetGVR, secretsGVR)
+	}
+	if rec.lastGetNS != testSANamespace || rec.lastGetName != wantSecretName {
+		t.Errorf("token Get = %s/%s, want %s/%s", rec.lastGetNS, rec.lastGetName, testSANamespace, wantSecretName)
+	}
+}
+
+// assertNameNoGenerateName asserts an object carries a fixed metadata.name (SSA
+// needs it) and NO metadata.generateName (SSA cannot use it — same contract the
+// image slice enforces).
+func assertNameNoGenerateName(t *testing.T, obj *unstructured.Unstructured, wantName, what string) {
+	t.Helper()
+	name, hasName, _ := unstructured.NestedString(obj.Object, "metadata", "name")
+	if !hasName || name != wantName {
+		t.Errorf("%s metadata.name = %q, want %q", what, name, wantName)
+	}
+	if _, hasGen, _ := unstructured.NestedString(obj.Object, "metadata", "generateName"); hasGen {
+		t.Errorf("%s sets metadata.generateName; SSA (the agent create path) cannot use it", what)
+	}
+}
+
+// TestEnsureCloudProviderSA_Remote_TokenReadFromData proves the returned token is
+// what the SEAM's Get supplies in .data.token — swap the seeded token and the
+// return value follows, i.e. the read is genuinely routed (not a constant).
+func TestEnsureCloudProviderSA_Remote_TokenReadFromData(t *testing.T) {
+	const other = "a-different-token"
+	rec := &saRecordingAccessor{tokenB64: base64.StdEncoding.EncodeToString([]byte(other))}
+	c := NewRemoteClient(rec, "lk", "zone-1")
+
+	token, err := c.EnsureCloudProviderSA(context.Background(), testSANamespace)
+	if err != nil {
+		t.Fatalf("EnsureCloudProviderSA: %v", err)
+	}
+	if string(token) != other {
+		t.Errorf("returned token = %q, want %q — the token must come from the seam Get's .data.token", string(token), other)
+	}
+}
+
+// ── Routing: the SA-bootstrap verbs toggle between agent and Direct ──────────
+
+// TestEnsureCloudProviderSA_Routed_TogglesBetweenAgentAndDirect proves the Routed
+// decision gates the bootstrap per-verb/per-family: with the SA/RoleBinding/Secret
+// creates (VerbCreate) and the Secret read (VerbGet) activated for their GVRs, the
+// ops route to the agent accessor; with the decision de-activated they fall to
+// Direct. This mirrors the per-family RouteVerbs allow-set the registry enforces
+// (SA/RoleBinding route VerbCreate; Secret routes VerbGet+VerbCreate).
+func TestEnsureCloudProviderSA_Routed_TogglesBetweenAgentAndDirect(t *testing.T) {
+	// Toggle ON → the agent accessor gets the creates + the token Get; Direct is
+	// untouched.
+	t.Run("on routes to agent", func(t *testing.T) {
+		agent := &saRecordingAccessor{tokenB64: base64.StdEncoding.EncodeToString([]byte(fakeTokenPlain))}
+		direct := &saRecordingAccessor{tokenB64: base64.StdEncoding.EncodeToString([]byte(fakeTokenPlain))}
+		routed := clusteraccess.NewRouted(direct, func(v clusteraccess.Verb, gvr schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
+			switch gvr {
+			case serviceAccountsGVR, roleBindingsGVR:
+				if v == clusteraccess.VerbCreate {
+					return agent, true
+				}
+			case secretsGVR:
+				if v == clusteraccess.VerbCreate || v == clusteraccess.VerbGet {
+					return agent, true
+				}
+			}
+			return nil, false
+		})
+		c := &Client{access: routed}
+		if _, err := c.EnsureCloudProviderSA(context.Background(), testSANamespace); err != nil {
+			t.Fatalf("EnsureCloudProviderSA: %v", err)
+		}
+		if len(agent.creates) != 3 {
+			t.Errorf("agent Create called %d times, want 3", len(agent.creates))
+		}
+		if len(direct.creates) != 0 {
+			t.Errorf("direct Create called %d times with toggle ON, want 0", len(direct.creates))
+		}
+		if agent.getCalls != 1 {
+			t.Errorf("agent Get called %d times, want 1", agent.getCalls)
+		}
+		if direct.getCalls != 0 {
+			t.Errorf("direct Get called %d times with toggle ON, want 0", direct.getCalls)
+		}
+	})
+
+	// Toggle OFF → Direct gets the creates + the token Get; the agent is untouched.
+	t.Run("off uses direct", func(t *testing.T) {
+		agent := &saRecordingAccessor{tokenB64: base64.StdEncoding.EncodeToString([]byte(fakeTokenPlain))}
+		direct := &saRecordingAccessor{tokenB64: base64.StdEncoding.EncodeToString([]byte(fakeTokenPlain))}
+		routed := clusteraccess.NewRouted(direct, func(clusteraccess.Verb, schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
+			return nil, false
+		})
+		c := &Client{access: routed}
+		if _, err := c.EnsureCloudProviderSA(context.Background(), testSANamespace); err != nil {
+			t.Fatalf("EnsureCloudProviderSA: %v", err)
+		}
+		if len(direct.creates) != 3 {
+			t.Errorf("direct Create called %d times, want 3", len(direct.creates))
+		}
+		if len(agent.creates) != 0 {
+			t.Errorf("agent Create called %d times with toggle OFF, want 0", len(agent.creates))
+		}
+		if direct.getCalls != 1 {
+			t.Errorf("direct Get called %d times, want 1", direct.getCalls)
+		}
+		if agent.getCalls != 0 {
+			t.Errorf("agent Get called %d times with toggle OFF, want 0", agent.getCalls)
+		}
+	})
+}
+
+// ── Local Direct path: the bootstrap still works against a fake dynamic ──────
+
+// newFakeDynamicForSA returns a fake dynamic client that already holds a token
+// Secret with .data.token populated, so the local Direct EnsureCloudProviderSA
+// finds the token on the first poll (the fake has no token controller). The SA
+// and RoleBinding creates land freshly.
+func newFakeDynamicForSA(t *testing.T) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	seededSecret := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      wantSecretName,
+			"namespace": testSANamespace,
+		},
+		"type": "kubernetes.io/service-account-token",
+		"data": map[string]interface{}{
+			"token": base64.StdEncoding.EncodeToString([]byte(fakeTokenPlain)),
+		},
+	}}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		serviceAccountsGVR: "ServiceAccountList",
+		roleBindingsGVR:    "RoleBindingList",
+		secretsGVR:         "SecretList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, seededSecret)
+}
+
+func TestEnsureCloudProviderSA_Local_UsesDirect(t *testing.T) {
+	dyn := newFakeDynamicForSA(t)
+	// The Secret create in the bootstrap will hit an already-existing seeded Secret;
+	// IsAlreadyExists is treated as success (idempotent), exactly the local POST
+	// contract the code keeps.
+	c := &Client{dynamic: dyn, access: clusteraccess.NewDirect(dyn)}
+
+	token, err := c.EnsureCloudProviderSA(context.Background(), testSANamespace)
+	if err != nil {
+		t.Fatalf("EnsureCloudProviderSA (local): %v", err)
+	}
+	if string(token) != fakeTokenPlain {
+		t.Errorf("returned token = %q, want %q", string(token), fakeTokenPlain)
+	}
+
+	// The SA and RoleBinding really landed in the fake store under the fixed names.
+	if _, err := dyn.Resource(serviceAccountsGVR).Namespace(testSANamespace).Get(context.Background(), wantSAName, metav1.GetOptions{}); err != nil {
+		t.Errorf("ServiceAccount not found in direct store: %v", err)
+	}
+	if _, err := dyn.Resource(roleBindingsGVR).Namespace(testSANamespace).Get(context.Background(), wantSAName, metav1.GetOptions{}); err != nil {
+		t.Errorf("RoleBinding not found in direct store: %v", err)
+	}
+}

--- a/flux/platform/dc-agent/base/rbac.yaml
+++ b/flux/platform/dc-agent/base/rbac.yaml
@@ -26,6 +26,12 @@ rules:
   - apiGroups: [""]
     resources: ["nodes", "pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "patch"]
   - apiGroups: ["harvesterhci.io"]
     resources: ["virtualmachineimages"]
     verbs: ["get", "list", "create", "patch"]
@@ -41,6 +47,9 @@ rules:
   - apiGroups: ["kubevirt.io"]
     resources: ["virtualmachines"]
     verbs: ["get", "list", "watch", "create", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What this changes

The cloud-provider ServiceAccount slice of the credential-locality work (#7): `EnsureCloudProviderSA` now runs through the cluster-access seam, so the SA bootstrap works in a remote, agent-only zone. Previously it was a direct call that returned a local-only error there.

## Why this is needed

When dc-api creates an RKE2 cluster on Harvester, it mints a per-tenant ServiceAccount + RoleBinding (to `harvesterhci.io:cloudprovider`) + token Secret in the tenant's namespace, then builds a kubeconfig from that token and hands it to the guest cluster so its Harvester CCM/CSI can authenticate back for storage and load balancers. That SA must exist before the guest cluster boots. In a remote zone dc-api holds no Harvester credentials, so the agent has to perform the bootstrap — which is what this slice enables.

## Changes

- **clusteraccess**: onboard three new agent capabilities — `serviceaccounts`, `rolebindings`, and `secrets` (Create routed; Get on secrets so the asynchronously-populated token can be read).
- **harvester**: route the three creates and the token-population Get through the seam; drop the `c.dynamic == nil` local-only guard. VM create is now the only remaining local-only harvester op.
- **RBAC**: regenerated the agent ClusterRole.

## Security note (please review the posture)

The agent's RBAC is generated as a single cluster-wide `ClusterRole` (tenant namespaces aren't known at deploy time — the same model every existing capability already uses). So this slice grants the agent `create`/`patch` on serviceaccounts + rolebindings and `get`/`create`/`patch` on secrets, cluster-wide. `get secrets` cluster-wide is the sensitive one. It is not broader than the agent's existing cluster-wide `create virtualmachines` grant — a VM can mount any namespace's secrets, so the agent already has transitive secret access — and it stays dark until a remote zone actually drives cluster creation. A holistic least-privilege pass over the whole agent RBAC (namespaced Roles) is tracked as a follow-up rather than bolted onto this slice.

## Verification

Both modules build + vet; unit tests pass (routed creates + token Get, the routing toggle, and the local Direct path), and the RBAC drift check is byte-stable. The routing is behind the existing write toggle and defaults off, so with routing off the behaviour is byte-identical to today.

## Not included

No live run — a truly credential-less second zone isn't stood up yet. The remaining local-only harvester op (the full VM-create orchestration) and the other network-plumbing slices (NAT, DNS, NSG, route tables) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cloud-provider ServiceAccount bootstrap during cluster access, including creation of the ServiceAccount, RoleBinding, and token Secret through the agent path.
  * Expanded agent permissions to handle the needed bootstrap resources and token retrieval.

* **Bug Fixes**
  * Improved routing so bootstrap operations work correctly in remote/cluster-access mode.
  * Fixed token reading to wait for and use the Secret’s populated token data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->