### PR TITLE
[Fix] Enforce project quota shrink against real usage

### DIFF
--- a/.github/workflows/authz.yaml
+++ b/.github/workflows/authz.yaml
@@ -10,8 +10,9 @@ name: authz-tests
 # real Harvester / KubeOVN cluster.
 #
 # Scope: the role × verb matrix, membership, service-account, tenant,
-# option-D, and phase-6a suites. Resource tests (vnet/subnet/vm/cluster/...)
-# genuinely provision on the cluster and are deliberately NOT in scope here.
+# phase-6a slug-recycle, and project-capacity suites. Resource tests
+# (vnet/subnet/vm/cluster/...) genuinely provision on the cluster and are
+# deliberately NOT in scope here.
 
 on:
   pull_request:
@@ -47,5 +48,5 @@ jobs:
         # single shared Postgres container + the ~35 status-code assertions.
         run: |
           go test -tags integration -timeout 12m -v \
-            -run 'TestRBAC_|TestMembers_|TestServiceAccountAPI_|TestTenants_|TestOptionD_|TestPhase6a' \
+            -run 'TestRBAC_|TestMembers_|TestServiceAccountAPI_|TestTenants_|TestPhase6a|TestProjectCap_' \
             ./test/integration/...

--- a/dc-api/internal/db/projects.go
+++ b/dc-api/internal/db/projects.go
@@ -223,8 +223,8 @@ func (r *Repository) UpdateProjectQuota(ctx context.Context, projectUUID uuid.UU
 	}
 	if newQuota.CPUCores < inUse.CPUCores || newQuota.MemoryGB < inUse.MemoryGB || newQuota.StorageGB < inUse.StorageGB {
 		usage := &models.TenantCapUsage{
-			Cap:       newQuota,    // requested
-			Allocated: inUse,       // actually in use
+			Cap:       newQuota,           // requested
+			Allocated: inUse,              // actually in use
 			Available: models.TenantCap{}, // not meaningful for this error
 		}
 		return nil, usage, ErrProjectQuotaBelowUsage
@@ -281,9 +281,28 @@ func (r *Repository) UpdateProjectQuota(ctx context.Context, projectUUID uuid.UU
 // and sums spec usage for rows in PENDING or ACTIVE state. DELETING is
 // excluded (in-flight teardown); FAILED is excluded (never consumed).
 //
-// Current scope: VMs (cpu+memory from spec_json), clusters (cpu+memory ×
-// machine_pool_size), bastions (fixed small footprint). Storage is summed
-// from any volumes table once that lands; for now it's 0.
+// Usage is derived from what is actually persisted: the size label on each
+// row, resolved through the in-memory models.Sizes catalog (passed into the
+// query as parallel arrays and unnested into a size_specs CTE).
+//   - VM: resources.size → catalog cpu/memory.
+//   - Cluster: sum over its cluster_node_pools rows (np.size × np.count),
+//     across ALL pool roles (system + worker). Pool rows aren't filtered by
+//     their own status — the parent resource's status governs.
+//   - Bastion: fixed allocation (2 CPU, 4 GB) — small, but counted.
+//
+// LEFT JOIN semantics: a row with an unknown/NULL size label contributes 0
+// rather than dropping the whole sum. Storage is summed from any volumes
+// table once that lands; for now it's 0.
+//
+// Known scope gaps (each only ever under-counts or over-counts toward
+// safety — the guard never permits an over-allocation because of them):
+//   - Databases (databases table) and key vaults (key_vaults table) are not
+//     yet counted; their instance classes have no cpu/memory catalog to
+//     resolve against. TODO: add a class → cpu/memory catalog and fold them
+//     into this sum.
+//   - A pool row whose own status is failed still counts (over-count, so a
+//     shrink may be rejected conservatively); pool rows can't distinguish
+//     "never provisioned" from "running but a later update failed".
 //
 // TODO(M2.5 polish): wire actual storage sum once the volumes table exists.
 // TODO(observability): cache result with short TTL to avoid 4 SUMs per
@@ -291,34 +310,54 @@ func (r *Repository) UpdateProjectQuota(ctx context.Context, projectUUID uuid.UU
 func sumProjectResourceUsageTx(ctx context.Context, tx pgx.Tx, projectUUID uuid.UUID) (models.TenantCap, error) {
 	var u models.TenantCap
 
-	// Resources table holds VMs, clusters, bastions. Spec is JSONB.
-	// VM: spec_json->>'cpu'  (int), 'memory_gb' (int).
-	// Cluster: spec_json->>'cpu_per_node' × spec_json->>'node_count'.
-	// Bastion: fixed allocation (2 CPU, 4 GB) — small, but counted.
-	const q = `
-		SELECT
-			COALESCE(SUM(
-				CASE type
-					WHEN 'VIRTUAL_MACHINE' THEN COALESCE((metadata->>'cpu')::INTEGER, 0)
-					WHEN 'CLUSTER'         THEN COALESCE((metadata->>'cpu_per_node')::INTEGER, 0) * COALESCE(machine_pool_size, 0)
-					WHEN 'BASTION'         THEN 2
-					ELSE 0
-				END
-			), 0)::INTEGER AS cpu_used,
-			COALESCE(SUM(
-				CASE type
-					WHEN 'VIRTUAL_MACHINE' THEN COALESCE((metadata->>'memory_gb')::INTEGER, 0)
-					WHEN 'CLUSTER'         THEN COALESCE((metadata->>'memory_per_node_gb')::INTEGER, 0) * COALESCE(machine_pool_size, 0)
-					WHEN 'BASTION'         THEN 4
-					ELSE 0
-				END
-			), 0)::INTEGER AS mem_used,
-			0::INTEGER AS storage_used   -- TODO: sum from volumes when that table exists
-		FROM   resources
-		WHERE  project_uuid = $1
-		  AND  status IN ('PENDING', 'ACTIVE')`
+	// Flatten the size catalog into parallel arrays for unnest. Map iteration
+	// order doesn't matter — the CTE is joined by label, never by position.
+	sizeNames := make([]string, 0, len(models.Sizes))
+	sizeCPUs := make([]int32, 0, len(models.Sizes))
+	sizeMems := make([]int32, 0, len(models.Sizes))
+	for name, spec := range models.Sizes {
+		sizeNames = append(sizeNames, name)
+		sizeCPUs = append(sizeCPUs, int32(spec.CPU))
+		sizeMems = append(sizeMems, int32(spec.MemoryGB))
+	}
 
-	if err := tx.QueryRow(ctx, q, projectUUID).Scan(&u.CPUCores, &u.MemoryGB, &u.StorageGB); err != nil {
+	const q = `
+		WITH size_specs AS (
+			SELECT * FROM unnest($2::text[], $3::int[], $4::int[]) AS s(size, cpu, memory_gb)
+		),
+		vm AS (
+			SELECT COALESCE(SUM(s.cpu), 0)       AS cpu,
+			       COALESCE(SUM(s.memory_gb), 0) AS mem
+			FROM   resources r
+			LEFT JOIN size_specs s ON s.size = r.size
+			WHERE  r.project_uuid = $1
+			  AND  r.status IN ('PENDING', 'ACTIVE')
+			  AND  r.type = 'VIRTUAL_MACHINE'
+		),
+		clus AS (
+			SELECT COALESCE(SUM(s.cpu * np.count), 0)       AS cpu,
+			       COALESCE(SUM(s.memory_gb * np.count), 0) AS mem
+			FROM   resources r
+			JOIN   cluster_node_pools np ON np.cluster_id = r.id
+			LEFT JOIN size_specs s ON s.size = np.size
+			WHERE  r.project_uuid = $1
+			  AND  r.status IN ('PENDING', 'ACTIVE')
+			  AND  r.type = 'CLUSTER'
+		),
+		bast AS (
+			SELECT COUNT(*) * 2 AS cpu,
+			       COUNT(*) * 4 AS mem
+			FROM   resources r
+			WHERE  r.project_uuid = $1
+			  AND  r.status IN ('PENDING', 'ACTIVE')
+			  AND  r.type = 'BASTION'
+		)
+		SELECT (vm.cpu + clus.cpu + bast.cpu)::INTEGER AS cpu_used,
+		       (vm.mem + clus.mem + bast.mem)::INTEGER AS mem_used,
+		       0::INTEGER AS storage_used   -- TODO: sum from volumes when that table exists
+		FROM   vm, clus, bast`
+
+	if err := tx.QueryRow(ctx, q, projectUUID, sizeNames, sizeCPUs, sizeMems).Scan(&u.CPUCores, &u.MemoryGB, &u.StorageGB); err != nil {
 		return u, fmt.Errorf("db sum project resource usage: %w", err)
 	}
 	return u, nil

--- a/dc-api/test/integration/nop_env_test.go
+++ b/dc-api/test/integration/nop_env_test.go
@@ -5,7 +5,7 @@ package integration
 // nop_env_test.go — cluster-free ("nop") mode for the integration suite.
 //
 // The pure-authz tests (RBAC role matrix, members, service accounts, tenants,
-// option-D, phase-6a) assert only on HTTP status codes — the authorization
+// phase-6a slug recycle) assert only on HTTP status codes — the authorization
 // decision happens in the handler before any provider call — so they don't need
 // a real Harvester/KubeOVN cluster at all. Opt in with DCAPI_TEST_NOP=1 and the
 // shared env + sub-envs are built with all-nop backends and no kubeconfig, so

--- a/dc-api/test/integration/projects_cap_test.go
+++ b/dc-api/test/integration/projects_cap_test.go
@@ -159,8 +159,10 @@ func TestProjectCap_PatchBelowInUseRejected(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	// Tenant cap: 80 cpu. p1 at 40 cpu. Insert a fake ACTIVE VM consuming 20
-	// cpu. Patch p1 to cpu_cores=10 → below in-use (10 < 20) → 400
+	// Tenant cap: 80 cpu. p1 at 40 cpu. Insert a fake ACTIVE xlarge VM
+	// (16 cpu / 32 GB per models.Sizes) and a fake ACTIVE cluster with two
+	// node pools (system small×1 = 2 cpu, worker medium×2 = 8 cpu) → 26 cpu
+	// in use. Patch p1 to cpu_cores=10 → below in-use (10 < 26) → 400
 	// quota_below_usage.
 	tenantID, client := capTestTenant(t, randomName("inuse"), 80, 256, 2000)
 
@@ -179,41 +181,65 @@ func TestProjectCap_PatchBelowInUseRejected(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, uuid.Nil, projectUUID)
 
-	// Insert a fake VIRTUAL_MACHINE row with cpu=20 and memory_gb=32.
-	// sumProjectResourceUsageTx reads metadata->>'cpu' and metadata->>'memory_gb'.
-	vmID := uuid.New()
-	metadata := []byte(`{"cpu": 20, "memory_gb": 32}`)
-	_, err = env.DB.Pool().Exec(ctx,
-		`INSERT INTO resources
-			(id, tenant_id, tenant_uuid, project_id, project_uuid, owner_id, name, type, status, provider_type, metadata)
-		 VALUES ($1, $2, $3, 'p1', $4, 'test', 'fake-vm-cap', 'VIRTUAL_MACHINE', 'ACTIVE', 'harvester', $5)`,
-		vmID, tenantID, tenantUUID, projectUUID, metadata,
-	)
-	require.NoError(t, err, "insert fake VM resource for in-use check")
+	// Create a fake ACTIVE xlarge VM (16 cpu / 32 GB per models.Sizes) through
+	// the production repository path. Repository.Create is what persists
+	// resources.size — which the usage sum resolves through models.Sizes — so
+	// going through it (instead of a raw INSERT) makes this test fail if the
+	// create path ever stops writing the column the guard depends on.
+	vm, err := env.DB.Create(ctx, &models.Resource{
+		TenantID: tenantID, TenantUUID: tenantUUID,
+		ProjectID: "p1", ProjectUUID: projectUUID,
+		OwnerID: "test", Name: "fake-vm-cap",
+		Type: models.ResourceTypeVM, Size: "xlarge",
+		Status: models.StatusActive, ProviderType: "harvester",
+	})
+	require.NoError(t, err, "create fake VM resource for in-use check")
 
-	// PATCH p1 to cpu_cores=10 → below the 20 cpu in use → quota_below_usage.
+	// Create a fake CLUSTER the same way; its usage is derived from
+	// cluster_node_pools (size × count, all roles), not from the resource row.
+	cluster, err := env.DB.Create(ctx, &models.Resource{
+		TenantID: tenantID, TenantUUID: tenantUUID,
+		ProjectID: "p1", ProjectUUID: projectUUID,
+		OwnerID: "test", Name: "fake-cluster-cap",
+		Type:   models.ResourceTypeCluster,
+		Status: models.StatusActive, ProviderType: "rancher",
+	})
+	require.NoError(t, err, "create fake cluster resource for in-use check")
+	require.NoError(t, env.DB.CreateNodePool(ctx, &models.NodePool{
+		ClusterID: cluster.ID, Name: "system", Role: models.NodePoolRoleSystem,
+		Size: "small", Count: 1, Status: models.NodePoolStatusReady,
+	}), "insert fake system pool")
+	require.NoError(t, env.DB.CreateNodePool(ctx, &models.NodePool{
+		ClusterID: cluster.ID, Name: "workers", Role: models.NodePoolRoleWorker,
+		Size: "medium", Count: 2, Status: models.NodePoolStatusReady,
+	}), "insert fake worker pool")
+
+	// PATCH p1 to cpu_cores=10 → below the 26 cpu in use → quota_below_usage.
 	newCPU := 10
 	_, body, patchStatus, err := client.PatchProject(ctx, "p1", PatchProjectRequest{
 		CPUCores: &newCPU,
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, patchStatus,
-		"PATCH to 10 cpu must fail with 400 (20 cpu in use): %s", body)
+		"PATCH to 10 cpu must fail with 400 (26 cpu in use): %s", body)
 
 	// Parse the error body to check the error code and in_use field.
 	var errBody struct {
-		Error  string          `json:"error"`
-		InUse  models.TenantCap `json:"in_use"`
+		Error string           `json:"error"`
+		InUse models.TenantCap `json:"in_use"`
 	}
 	require.NoError(t, json.Unmarshal(body, &errBody), "parse error body: %s", body)
 	require.Equal(t, "quota_below_usage", errBody.Error,
 		"error body must say quota_below_usage: %s", body)
-	require.Equal(t, 20, errBody.InUse.CPUCores,
-		"in_use.cpu_cores must be 20 (the fake VM's allocation): %s", body)
+	require.Equal(t, 26, errBody.InUse.CPUCores,
+		"in_use.cpu_cores must be 26 (xlarge VM 16 + small×1 pool 2 + medium×2 pool 8): %s", body)
+	require.Equal(t, 52, errBody.InUse.MemoryGB,
+		"in_use.memory_gb must be 52 (xlarge VM 32 + small×1 pool 4 + medium×2 pool 16): %s", body)
 
 	t.Cleanup(func() {
 		ctx := context.Background()
-		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM resources WHERE id = $1`, vmID)
+		// Node pools cascade with the cluster row (ON DELETE CASCADE).
+		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM resources WHERE id IN ($1, $2)`, vm.ID, cluster.ID)
 		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM projects WHERE tenant_id = $1`, tenantID)
 		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM role_assignments WHERE scope_id = $1 AND scope_type = 'tenant'`, tenantID)
 		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM tenants WHERE id = $1`, tenantID)
@@ -308,4 +334,3 @@ func TestProjectCap_GetTenantCapUsage(t *testing.T) {
 		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM tenants WHERE id = $1`, tenantID)
 	})
 }
-


### PR DESCRIPTION
## What this fixes

The project-quota shrink guard computed a project's in-use CPU/memory by reading `resources.metadata` and `resources.machine_pool_size` — columns that nothing on the create path ever writes. Every VM and cluster therefore summed to zero usage, and a project owner could shrink a project's quota below what its running resources actually consume without the guard firing. Quota enforcement is a stated core principle of the API, so this was a real correctness bug rather than a cosmetic one.

## The fix

`sumProjectResourceUsageTx` now derives usage from data the create path really persists: each VM's `size` label and each cluster's node-pool rows (size × count, all roles), resolved through the `models.Sizes` catalog, which is passed into the query as `unnest` arrays. Bastions keep their fixed 2 CPU / 4 GB footprint, and storage stays 0 until a volumes table exists (pre-existing TODO).

## Why it's safe

It is a single query rewrite inside the existing `UpdateProjectQuota` transaction — no schema change, no API change, no handler change. Because size labels and node-pool rows have always been persisted, the fix is retroactively correct for every existing row; no backfill is needed. A row with an unknown size label contributes 0, same as before.

## Tests

The covering test previously **masked** the bug: it seeded `metadata` with a raw SQL INSERT, so it passed while the production path wrote nothing. It now creates the VM and cluster through `Repository.Create` (the production insert) plus real `cluster_node_pools` rows, so it fails if the create path ever stops writing the column the guard reads. The `TestProjectCap_` suite (5 tests) now also runs in the cluster-free authz CI job on every PR. A `-run` pattern in that job that matches no existing test was dropped, along with its comment references.

## Verified

`go build ./...`, `go vet ./...`, the full unit suite, and the nop-mode integration run (real Postgres via testcontainers) are green: 5/5 `TestProjectCap_` PASS including the de-masked shrink-below-usage rejection (asserts both `in_use.cpu_cores = 26` and `in_use.memory_gb = 52` from an xlarge VM + small×1 and medium×2 pools). Self-reviewed: diff-scoped scanners (golangci-lint, govulncheck, gitleaks, actionlint) + multi-lens adversarial review; the adversarial pass found no defects in the query (multi-tenancy isolation, NULL/empty-project handling, and the CI filter's full match set were each verified by execution).

## Not included

Storage usage still sums to 0 (needs the volumes table, pre-existing TODO). Databases and key vaults are not yet counted — their instance classes have no cpu/memory catalog to resolve against; that follow-up is now documented in the function comment. A node-pool row whose own status is failed still counts toward usage (conservative over-count; pool rows can't distinguish "never provisioned" from "running but a later update failed"). The unused `resources.metadata`/`machine_pool_size` columns are left in place — the migrator is additive-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project quota usage calculations so project limits now reflect both virtual machine and cluster node-pool consumption more accurately.
  * Requests that reduce a project’s quota below current usage now return the correct error with updated in-use totals.

* **Tests**
  * Updated authorization and project-capacity integration coverage to match the current test scope and the revised usage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->