### PR TITLE
[Fix] Bound backend calls and recover crash-stranded rows

### DIFF
--- a/.github/workflows/authz.yaml
+++ b/.github/workflows/authz.yaml
@@ -10,9 +10,9 @@ name: authz-tests
 # real Harvester / KubeOVN cluster.
 #
 # Scope: the role × verb matrix, membership, service-account, tenant,
-# phase-6a slug-recycle, and project-capacity suites. Resource tests
-# (vnet/subnet/vm/cluster/...) genuinely provision on the cluster and are
-# deliberately NOT in scope here.
+# phase-6a slug-recycle, project-capacity, and orphan-reaper (pure-DB crash
+# recovery) suites. Resource tests (vnet/subnet/vm/cluster/...) genuinely
+# provision on the cluster and are deliberately NOT in scope here.
 
 on:
   pull_request:
@@ -48,5 +48,5 @@ jobs:
         # single shared Postgres container + the ~35 status-code assertions.
         run: |
           go test -tags integration -timeout 12m -v \
-            -run 'TestRBAC_|TestMembers_|TestServiceAccountAPI_|TestTenants_|TestPhase6a|TestProjectCap_' \
+            -run 'TestRBAC_|TestMembers_|TestServiceAccountAPI_|TestTenants_|TestPhase6a|TestProjectCap_|TestReaper_' \
             ./test/integration/...

--- a/dc-api/cmd/dc-api/main.go
+++ b/dc-api/cmd/dc-api/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/auth"
 	"github.com/wso2/dc-api/internal/api/handlers"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/config"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/directory"
@@ -39,6 +40,14 @@ import (
 	"github.com/wso2/dc-api/internal/providers/rancher"
 	"github.com/wso2/dc-api/internal/reconciler"
 )
+
+// provisionDrainTimeout bounds the post-Shutdown wait for the handlers'
+// fire-and-forget provisioning goroutines (async.Group). Long enough for the
+// typical backend submit to finish; deliberately shorter than a Kubernetes
+// terminationGracePeriod escalation would tolerate. Tasks still running when
+// it expires are abandoned and later reaped as FAILED by the reconciler's
+// orphan sweep.
+const provisionDrainTimeout = 60 * time.Second
 
 func main() {
 	// ── Configuration ─────────────────────────────────────────────────────────
@@ -451,6 +460,12 @@ func main() {
 		log.Info().Msg("IdP directory disabled (DCAPI_IDP_* unset) — invite by user_sub only")
 	}
 
+	// ── Async provisioning task group ────────────────────────────────────────
+	// Tracks the fire-and-forget provisioning goroutines the handlers launch
+	// (VM/cluster/network creates + deletes) so shutdown can drain them below
+	// instead of killing a provision mid-flight on a rolling deploy.
+	tasks := &async.Group{}
+
 	// ── Router ────────────────────────────────────────────────────────────────
 	// All wiring happens in NewRouter. main.go does not know about individual routes.
 	router := api.NewRouter(api.RouterDeps{
@@ -492,6 +507,7 @@ func main() {
 		LocalZone:        cfg.LocalZone,
 		AgentRouteReads:  cfg.AgentRouteReads,
 		AgentRouteWrites: cfg.AgentRouteWrites,
+		Tasks:            tasks,
 		Log:              log.Logger,
 	})
 
@@ -524,6 +540,18 @@ func main() {
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Error().Err(err).Msg("graceful shutdown timed out")
+	}
+
+	// Drain the detached provisioning goroutines (bounded). Without this, a
+	// rolling deploy kills provisions mid-flight, stranding PENDING rows with
+	// no backend_uid — the exact orphans the reconciler sweep exists to reap.
+	log.Info().Dur("timeout", provisionDrainTimeout).Msg("waiting for in-flight provisioning tasks to finish")
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), provisionDrainTimeout)
+	defer drainCancel()
+	if tasks.Wait(drainCtx) {
+		log.Info().Msg("in-flight provisioning tasks drained")
+	} else {
+		log.Warn().Msg("drain timed out — abandoning in-flight provisioning tasks; interrupted creates will be reaped as FAILED by the reconciler's orphan sweep")
 	}
 	log.Info().Msg("DC-API stopped cleanly")
 }

--- a/dc-api/cmd/webhook/main.go
+++ b/dc-api/cmd/webhook/main.go
@@ -65,6 +65,12 @@ type config struct {
 	LogLevel   string `envconfig:"LOG_LEVEL"   default:"info"`
 }
 
+// k8sRequestTimeout bounds every request made through the webhook's
+// rest.Config (both the in-cluster and kubeconfig paths) so a hung API server
+// can't block the NAD-lookup goroutines forever. Mirrors dc-api's provider
+// clients (30s, same as the Rancher http.Client timeout).
+const k8sRequestTimeout = 30 * time.Second
+
 func main() {
 	// ── Config ────────────────────────────────────────────────────────────────
 	var cfg config
@@ -103,6 +109,9 @@ func main() {
 			log.Fatal().Err(err).Msg("webhook: parse kubeconfig failed")
 		}
 	}
+	// Applies to BOTH paths (in-cluster and kubeconfig) — set before the
+	// dynamic client is built from this config.
+	restCfg.Timeout = k8sRequestTimeout
 
 	dynClient, err := dynamic.NewForConfig(restCfg)
 	if err != nil {

--- a/dc-api/internal/api/handlers/bastion.go
+++ b/dc-api/internal/api/handlers/bastion.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/placement"
@@ -43,7 +44,10 @@ type BastionHandler struct {
 	bastionImage    string // DCAPI_BASTION_IMAGE
 	bastionMgmtNAD  string // DCAPI_BASTION_MGMT_NAD
 	dnsSearchDomain string // DCAPI_VPC_DNS_SEARCH_DOMAIN — same as VMHandler
-	log             zerolog.Logger
+	// tasks tracks the async provisioning goroutines so shutdown can drain
+	// them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
+	log   zerolog.Logger
 }
 
 // NewBastionHandler creates a BastionHandler with injected dependencies.
@@ -52,6 +56,7 @@ func NewBastionHandler(
 	resolve providers.Resolver,
 	defaultRegion, defaultZone string,
 	bastionImage, bastionMgmtNAD, dnsSearchDomain string,
+	tasks *async.Group,
 	log zerolog.Logger,
 ) *BastionHandler {
 	return &BastionHandler{
@@ -62,6 +67,7 @@ func NewBastionHandler(
 		bastionImage:    bastionImage,
 		bastionMgmtNAD:  bastionMgmtNAD,
 		dnsSearchDomain: dnsSearchDomain,
+		tasks:           tasks,
 		log:             log,
 	}
 }
@@ -318,7 +324,7 @@ func (h *BastionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		DNSSearchDomain:  h.dnsSearchDomain,
 		MgmtNAD:          h.bastionMgmtNAD,
 	}
-	go h.asyncProvision(compute, resource.ID, tenantID, projectID, userID, spec, req.Description)
+	h.tasks.Go(func() { h.asyncProvision(compute, resource.ID, tenantID, projectID, userID, spec, req.Description) })
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
@@ -423,7 +429,7 @@ func (h *BastionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go func() {
+	h.tasks.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 		if resource.BackendUID == "" {
@@ -434,7 +440,7 @@ func (h *BastionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			h.log.Error().Err(err).Str("backend_uid", resource.BackendUID).Msg("harvester delete bastion VM failed")
 			_ = h.repo.UpdateStatus(ctx, id, models.StatusFailed, "deletion failed: "+err.Error(), "")
 		}
-	}()
+	})
 
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/dc-api/internal/api/handlers/cluster.go
+++ b/dc-api/internal/api/handlers/cluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/placement"
@@ -49,12 +50,15 @@ type ClusterHandler struct {
 	resolve       providers.Resolver
 	defaultRegion string
 	defaultZone   string
-	log           zerolog.Logger
+	// tasks tracks the async provisioning goroutines so shutdown can drain
+	// them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
+	log   zerolog.Logger
 }
 
 // NewClusterHandler creates a ClusterHandler with injected dependencies.
-func NewClusterHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *ClusterHandler {
-	return &ClusterHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+func NewClusterHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, tasks *async.Group, log zerolog.Logger) *ClusterHandler {
+	return &ClusterHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, tasks: tasks, log: log}
 }
 
 // cluster resolves the ClusterProvider for a cluster's (region, zone). Empty
@@ -546,7 +550,7 @@ func (h *ClusterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		WorkerPools: workerPools,
 	}
-	go h.asyncProvision(cluster, resource.ID, tenantID, projectID, userID, spec)
+	h.tasks.Go(func() { h.asyncProvision(cluster, resource.ID, tenantID, projectID, userID, spec) })
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
@@ -708,14 +712,14 @@ func (h *ClusterHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	_ = h.repo.UpdateStatus(r.Context(), id, models.StatusDeleting, "deletion requested", "")
 
-	go func() {
+	h.tasks.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 		if err := cluster.DeleteCluster(ctx, resource.BackendUID); err != nil {
 			h.log.Error().Err(err).Str("cluster", resource.Name).Msg("delete cluster failed")
 			_ = h.repo.UpdateStatus(ctx, id, models.StatusFailed, "deletion failed: "+err.Error(), "")
 		}
-	}()
+	})
 
 	w.WriteHeader(http.StatusAccepted)
 }
@@ -852,7 +856,9 @@ func (h *ClusterHandler) AddNodePool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go h.asyncAddPool(cluster, clusterID, clusterName, pool, mgmtNAD, tenantSubnetNAD, vmNamespace, req.ImageName)
+	h.tasks.Go(func() {
+		h.asyncAddPool(cluster, clusterID, clusterName, pool, mgmtNAD, tenantSubnetNAD, vmNamespace, req.ImageName)
+	})
 
 	writeJSON(w, http.StatusAccepted, poolToResponse(pool))
 }
@@ -1006,7 +1012,9 @@ func (h *ClusterHandler) ScaleOrUpdateNodePool(w http.ResponseWriter, r *http.Re
 		writeError(w, http.StatusBadGateway, "cannot reach the cluster's zone: "+err.Error())
 		return
 	}
-	go h.asyncPatchPool(cluster, clusterName, pool, req.Count > 0, newCount, req.Taints != nil || req.Labels != nil, newTaints, newLabels)
+	h.tasks.Go(func() {
+		h.asyncPatchPool(cluster, clusterName, pool, req.Count > 0, newCount, req.Taints != nil || req.Labels != nil, newTaints, newLabels)
+	})
 
 	writeJSON(w, http.StatusAccepted, poolToResponse(pool))
 }
@@ -1071,7 +1079,7 @@ func (h *ClusterHandler) RemoveNodePool(w http.ResponseWriter, r *http.Request) 
 		h.log.Error().Err(err).Str("pool", poolName).Msg("mark pool deleting")
 	}
 
-	go h.asyncRemovePool(cluster, clusterID, clusterName, pool)
+	h.tasks.Go(func() { h.asyncRemovePool(cluster, clusterID, clusterName, pool) })
 
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/dc-api/internal/api/handlers/dns_zone.go
+++ b/dc-api/internal/api/handlers/dns_zone.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers"
@@ -37,12 +38,15 @@ type PrivateDnsZoneHandler struct {
 	resolve       providers.Resolver
 	defaultRegion string
 	defaultZone   string
-	log           zerolog.Logger
+	// tasks tracks the async provisioning goroutines so shutdown can drain
+	// them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
+	log   zerolog.Logger
 }
 
 // NewPrivateDnsZoneHandler creates a PrivateDnsZoneHandler with injected dependencies.
-func NewPrivateDnsZoneHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *PrivateDnsZoneHandler {
-	return &PrivateDnsZoneHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+func NewPrivateDnsZoneHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, tasks *async.Group, log zerolog.Logger) *PrivateDnsZoneHandler {
+	return &PrivateDnsZoneHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, tasks: tasks, log: log}
 }
 
 // network resolves the NetworkProvider for the parent VNet's (region, zone).
@@ -253,9 +257,11 @@ func (h *PrivateDnsZoneHandler) CreateZone(w http.ResponseWriter, r *http.Reques
 	}
 
 
-	go h.asyncProvisionZone(network, zone.ID, tenantID, userID, vnet.BackendUID, models.DnsZoneSpec{
-		ZoneName:    req.Name,
-		Description: req.Description,
+	h.tasks.Go(func() {
+		h.asyncProvisionZone(network, zone.ID, tenantID, userID, vnet.BackendUID, models.DnsZoneSpec{
+			ZoneName:    req.Name,
+			Description: req.Description,
+		})
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -373,7 +379,7 @@ func (h *PrivateDnsZoneHandler) DeleteZone(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	go func() {
+	h.tasks.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 		if zone.BackendUID == "" {
@@ -386,7 +392,7 @@ func (h *PrivateDnsZoneHandler) DeleteZone(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		_ = h.repo.DeleteDNSZone(ctx, zoneID)
-	}()
+	})
 
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/dc-api/internal/api/handlers/peering.go
+++ b/dc-api/internal/api/handlers/peering.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/placement"
@@ -44,12 +45,15 @@ type PeeringHandler struct {
 	resolve       providers.Resolver
 	defaultRegion string
 	defaultZone   string
-	log           zerolog.Logger
+	// tasks tracks the async provisioning goroutines so shutdown can drain
+	// them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
+	log   zerolog.Logger
 }
 
 // NewPeeringHandler creates a PeeringHandler with injected dependencies.
-func NewPeeringHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, log zerolog.Logger) *PeeringHandler {
-	return &PeeringHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, log: log}
+func NewPeeringHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, tasks *async.Group, log zerolog.Logger) *PeeringHandler {
+	return &PeeringHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, tasks: tasks, log: log}
 }
 
 // network resolves the NetworkProvider for (region, zone). Empty values resolve
@@ -274,7 +278,9 @@ func (h *PeeringHandler) Create(w http.ResponseWriter, r *http.Request) {
 		PeerAddressSpace:      peerVNet.AddressSpace,
 		TransitCIDR:           transitCIDR,
 	}
-	go h.asyncProvisionPeering(network, peering.ID, tenantID, userID, vnet.BackendUID, peerVNet.BackendUID, spec)
+	h.tasks.Go(func() {
+		h.asyncProvisionPeering(network, peering.ID, tenantID, userID, vnet.BackendUID, peerVNet.BackendUID, spec)
+	})
 
 	resp := peeringToResponse(peering)
 	w.Header().Set("Content-Type", "application/json")
@@ -436,7 +442,7 @@ func (h *PeeringHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go func() {
+	h.tasks.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 		if peering.BackendUID == "" {
@@ -459,7 +465,7 @@ func (h *PeeringHandler) Delete(w http.ResponseWriter, r *http.Request) {
 				Msg("release transit CIDR (non-fatal — CASCADE will clean up)")
 		}
 		_ = h.repo.DeletePeering(ctx, peeringID)
-	}()
+	})
 
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/dc-api/internal/api/handlers/projects.go
+++ b/dc-api/internal/api/handlers/projects.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers"
@@ -41,14 +42,17 @@ import (
 type ProjectHandler struct {
 	repo      *db.Repository
 	nsProvisioner providers.ProjectNamespaceProvisioner // may be nil in tests
+	// tasks tracks the async namespace-provisioning goroutines so shutdown can
+	// drain them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
 	log       zerolog.Logger
 }
 
 // NewProjectHandler creates a ProjectHandler with injected dependencies.
 // nsProvisioner may be nil — when nil, K8s namespace creation is skipped
 // (acceptable in tests or when running without a Kubernetes backend).
-func NewProjectHandler(repo *db.Repository, nsProvisioner providers.ProjectNamespaceProvisioner, log zerolog.Logger) *ProjectHandler {
-	return &ProjectHandler{repo: repo, nsProvisioner: nsProvisioner, log: log}
+func NewProjectHandler(repo *db.Repository, nsProvisioner providers.ProjectNamespaceProvisioner, tasks *async.Group, log zerolog.Logger) *ProjectHandler {
+	return &ProjectHandler{repo: repo, nsProvisioner: nsProvisioner, tasks: tasks, log: log}
 }
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
@@ -226,7 +230,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// The project is committed regardless — the namespace can be re-created
 	// on first VNet/VM create via the provider's ensureNamespace call.
 	if h.nsProvisioner != nil {
-		go func() {
+		h.tasks.Go(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 			if nsErr := h.nsProvisioner.EnsureProjectNamespace(ctx, tenantID, req.ID, p.ProjectUUID, p.CPUCores, p.MemoryGB, p.StorageGB, q.MaxVolumes); nsErr != nil {
@@ -234,7 +238,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 					Str("tenant", tenantID).Str("project", req.ID).
 					Msg("project namespace provisioning failed (best-effort; will retry on first resource create)")
 			}
-		}()
+		})
 	}
 
 	writeJSON(w, http.StatusCreated, projectToResponse(p, q))
@@ -489,7 +493,7 @@ func (h *ProjectHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	// Best-effort: log on failure but commit the DB change. Operators can
 	// re-run via PATCH or kubectl directly. (TODO: surface a follow-up.)
 	if h.nsProvisioner != nil {
-		go func() {
+		h.tasks.Go(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
 			currentQuota, _ := h.repo.GetProjectQuota(ctx, p.ProjectUUID)
@@ -501,7 +505,7 @@ func (h *ProjectHandler) Patch(w http.ResponseWriter, r *http.Request) {
 				h.log.Warn().Err(rqErr).Str("project", projectID).
 					Msg("ResourceQuota update after PATCH failed; DB row updated but namespace quota lags")
 			}
-		}()
+		})
 	}
 
 	q, _ := h.repo.GetProjectQuota(r.Context(), p.ProjectUUID)

--- a/dc-api/internal/api/handlers/subnet.go
+++ b/dc-api/internal/api/handlers/subnet.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers"
@@ -38,13 +39,16 @@ type SubnetHandler struct {
 	// is in the local zone. nil = disabled (tests).
 	nat providers.VPCNATProvisioner // nil = F15 disabled (no SNAT provisioning)
 	dns providers.VPCDNSProvisioner // nil = F20 disabled (no per-VPC DNS)
-	log zerolog.Logger
+	// tasks tracks the async provisioning goroutines so shutdown can drain
+	// them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
+	log   zerolog.Logger
 }
 
 // NewSubnetHandler creates a SubnetHandler with injected dependencies.
 // nat and dns may be nil — when nil, the respective provisioning steps are skipped.
-func NewSubnetHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, log zerolog.Logger) *SubnetHandler {
-	return &SubnetHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, nat: nat, dns: dns, log: log}
+func NewSubnetHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, tasks *async.Group, log zerolog.Logger) *SubnetHandler {
+	return &SubnetHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, nat: nat, dns: dns, tasks: tasks, log: log}
 }
 
 // network resolves the NetworkProvider for a subnet's parent VNet (region, zone).
@@ -274,11 +278,13 @@ func (h *SubnetHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// Async: call KubeOVN CreateSubnet. The NAT/DNS provisioning inside the
 	// goroutine is local-only; tell it whether the parent VNet is in the local
 	// zone so a remote-zone subnet skips the local NAT/DNS plumbing.
-	go h.asyncProvisionSubnet(network, h.isLocalZone(vnet.Region, vnet.Zone), subnet.ID, vnet.ID, tenantID, projectID, userID, vnet.BackendUID, models.SubnetSpec{
-		Name:        req.Name,
-		CIDR:        req.CIDR,
-		Gateway:     gw,
-		Description: req.Description,
+	h.tasks.Go(func() {
+		h.asyncProvisionSubnet(network, h.isLocalZone(vnet.Region, vnet.Zone), subnet.ID, vnet.ID, tenantID, projectID, userID, vnet.BackendUID, models.SubnetSpec{
+			Name:        req.Name,
+			CIDR:        req.CIDR,
+			Gateway:     gw,
+			Description: req.Description,
+		})
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -441,7 +447,7 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go func() {
+	h.tasks.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 		if subnet.BackendUID == "" {
@@ -510,7 +516,7 @@ func (h *SubnetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		_ = h.repo.DeleteSubnet(ctx, subnetID)
-	}()
+	})
 
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/dc-api/internal/api/handlers/vm.go
+++ b/dc-api/internal/api/handlers/vm.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/placement"
@@ -67,7 +68,10 @@ type VMHandler struct {
 	// are bridges claimed by KubeOVN's ProviderNetwork or otherwise reserved
 	// for cluster infrastructure. Built from DCAPI_INFRA_RESERVED_NADS.
 	reservedNADs map[string]bool
-	log          zerolog.Logger
+	// tasks tracks the async provisioning goroutines so shutdown can drain
+	// them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
+	log   zerolog.Logger
 }
 
 // NewVMHandler creates a VMHandler with injected dependencies.
@@ -79,6 +83,7 @@ func NewVMHandler(
 	defaultRegion, defaultZone string,
 	dnsSearchDomain string,
 	reservedNADs map[string]bool,
+	tasks *async.Group,
 	log zerolog.Logger,
 ) *VMHandler {
 	return &VMHandler{
@@ -88,6 +93,7 @@ func NewVMHandler(
 		defaultZone:     defaultZone,
 		dnsSearchDomain: dnsSearchDomain,
 		reservedNADs:    reservedNADs,
+		tasks:           tasks,
 		log:             log,
 	}
 }
@@ -436,7 +442,7 @@ func (h *VMHandler) Create(w http.ResponseWriter, r *http.Request) {
 		DNSServerIP:      dnsSrvIP,
 		DNSSearchDomain:  h.dnsSearchDomain,
 	}
-	go h.asyncProvision(compute, resource.ID, tenantID, projectID, userID, spec)
+	h.tasks.Go(func() { h.asyncProvision(compute, resource.ID, tenantID, projectID, userID, spec) })
 
 	// ── Step 6: return 202 Accepted ───────────────────────────────────────────
 	// Credentials are returned ONCE here — never stored server-side.
@@ -558,7 +564,7 @@ func (h *VMHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	// Async: call Harvester delete. The reconciler detects the 404 from Harvester
 	// and removes the DB row — consistent with how cluster deletion works.
-	go func() {
+	h.tasks.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
@@ -575,7 +581,7 @@ func (h *VMHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		}
 		// Leave the row as DELETING. The reconciler polls it every 60s and removes
 		// the row once Harvester returns 404 (VM fully gone).
-	}()
+	})
 
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/dc-api/internal/api/handlers/vnet.go
+++ b/dc-api/internal/api/handlers/vnet.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers"
@@ -47,13 +48,16 @@ type VNetHandler struct {
 	// in the local zone (see isLocalZone). nil = disabled (tests).
 	nat providers.VPCNATProvisioner // nil = SNAT disabled (e.g. in tests)
 	dns providers.VPCDNSProvisioner // nil = F20 DNS disabled (e.g. in tests)
-	log zerolog.Logger
+	// tasks tracks the async provisioning goroutines so shutdown can drain
+	// them (bounded). May be nil (tests) — async.Group is nil-receiver-safe.
+	tasks *async.Group
+	log   zerolog.Logger
 }
 
 // NewVNetHandler creates a VNetHandler with injected dependencies.
 // nat and dns may be nil — when nil, the respective provisioning is skipped.
-func NewVNetHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, log zerolog.Logger) *VNetHandler {
-	return &VNetHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, nat: nat, dns: dns, log: log}
+func NewVNetHandler(repo *db.Repository, resolve providers.Resolver, defaultRegion, defaultZone string, nat providers.VPCNATProvisioner, dns providers.VPCDNSProvisioner, tasks *async.Group, log zerolog.Logger) *VNetHandler {
+	return &VNetHandler{repo: repo, resolve: resolve, defaultRegion: defaultRegion, defaultZone: defaultZone, nat: nat, dns: dns, tasks: tasks, log: log}
 }
 
 // network resolves the NetworkProvider for a VNet's (region, zone). Empty
@@ -277,11 +281,13 @@ func (h *VNetHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 
-	go h.asyncProvisionVNet(network, vnet.ID, tenantID, projectID, userID, models.VNetSpec{
-		Name:         req.Name,
-		AddressSpace: req.AddressSpace,
-		Region:       req.Region,
-		Description:  req.Description,
+	h.tasks.Go(func() {
+		h.asyncProvisionVNet(network, vnet.ID, tenantID, projectID, userID, models.VNetSpec{
+			Name:         req.Name,
+			AddressSpace: req.AddressSpace,
+			Region:       req.Region,
+			Description:  req.Description,
+		})
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -439,7 +445,7 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go func() {
+	h.tasks.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
@@ -474,7 +480,7 @@ func (h *VNetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		_ = h.repo.DeleteVNet(ctx, id)
-	}()
+	})
 
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/dc-api/internal/api/router.go
+++ b/dc-api/internal/api/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/wso2/dc-api/internal/api/auth"
 	"github.com/wso2/dc-api/internal/api/handlers"
 	"github.com/wso2/dc-api/internal/api/middleware"
+	"github.com/wso2/dc-api/internal/async"
 	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/directory"
 	"github.com/wso2/dc-api/internal/models"
@@ -128,7 +129,13 @@ type RouterDeps struct {
 	LocalZone        string
 	AgentRouteReads  bool
 	AgentRouteWrites bool
-	Log              zerolog.Logger
+	// Tasks tracks the fire-and-forget provisioning goroutines the handlers
+	// launch (async VM/cluster/network provisioning + deletes) so main.go can
+	// drain them, bounded, on shutdown instead of killing provisions
+	// mid-flight. Optional: nil (tests, contract harness) falls back to plain
+	// detached goroutines inside async.Group's nil-receiver path.
+	Tasks *async.Group
+	Log   zerolog.Logger
 }
 
 // NewRouter creates and returns the fully configured Chi router.
@@ -248,9 +255,9 @@ func NewRouter(deps RouterDeps) http.Handler {
 		// Instantiate handlers with their dependencies.
 		// Dependency Injection: we pass repo and provider INTO the handler.
 		// The handler does not create these — it receives them.
-		vmHandler := handlers.NewVMHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.DNSSearchDomain, deps.InfraReservedNADs, deps.Log)
-		bastionHandler := handlers.NewBastionHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.BastionImage, deps.BastionMgmtNAD, deps.DNSSearchDomain, deps.Log)
-		clusterHandler := handlers.NewClusterHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
+		vmHandler := handlers.NewVMHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.DNSSearchDomain, deps.InfraReservedNADs, deps.Tasks, deps.Log)
+		bastionHandler := handlers.NewBastionHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.BastionImage, deps.BastionMgmtNAD, deps.DNSSearchDomain, deps.Tasks, deps.Log)
+		clusterHandler := handlers.NewClusterHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Tasks, deps.Log)
 
 		// M1.5 member management handler. The directory provider (possibly nil)
 		// powers invite-by-email resolution.
@@ -272,12 +279,12 @@ func NewRouter(deps RouterDeps) http.Handler {
 		serviceAccountHandler := handlers.NewServiceAccountHandler(deps.Repo, deps.Log)
 
 		// M2 network handlers — all share the same NetworkProvider.
-		vnetHandler := handlers.NewVNetHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.NATProvisioner, deps.DNSProvisioner, deps.Log)
-		subnetHandler := handlers.NewSubnetHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.NATProvisioner, deps.DNSProvisioner, deps.Log)
+		vnetHandler := handlers.NewVNetHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.NATProvisioner, deps.DNSProvisioner, deps.Tasks, deps.Log)
+		subnetHandler := handlers.NewSubnetHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.NATProvisioner, deps.DNSProvisioner, deps.Tasks, deps.Log)
 		rtHandler := handlers.NewRouteTableHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
 		nsgHandler := handlers.NewNSGHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
-		peeringHandler := handlers.NewPeeringHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
-		dnsHandler := handlers.NewPrivateDnsZoneHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Log)
+		peeringHandler := handlers.NewPeeringHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Tasks, deps.Log)
+		dnsHandler := handlers.NewPrivateDnsZoneHandler(deps.Repo, resolve, deps.LocalRegion, deps.LocalZone, deps.Tasks, deps.Log)
 
 		// Tenant list — used by cloud-ui's tenant switcher. Lives at the
 		// /v1/ level (not under /v1/tenants/{tenant_id}) because it's how
@@ -352,7 +359,7 @@ func NewRouter(deps RouterDeps) http.Handler {
 		// tenant_uuid and enforces that the caller has at least Viewer access.
 		tenantCtx := middleware.NewTenantContext(deps.Repo)
 		projectCtx := middleware.NewProjectContext(deps.Repo)
-		projectHandler := handlers.NewProjectHandler(deps.Repo, deps.NSProvisioner, deps.Log)
+		projectHandler := handlers.NewProjectHandler(deps.Repo, deps.NSProvisioner, deps.Tasks, deps.Log)
 
 		r.Route("/tenants/{tenant_id}", func(r chi.Router) {
 			r.Use(tenantCtx.Validate)

--- a/dc-api/internal/async/group.go
+++ b/dc-api/internal/async/group.go
@@ -1,0 +1,86 @@
+// Package async provides Group, a tiny goroutine tracker for the
+// fire-and-forget provisioning goroutines the HTTP handlers launch.
+//
+// Why it exists: handlers return 202 and provision in a detached goroutine
+// (deliberately on context.Background() so an HTTP disconnect doesn't cancel
+// provisioning). Without tracking, main.go exits right after srv.Shutdown and
+// a rolling deploy kills those goroutines mid-flight — stranding PENDING rows
+// with no backend_uid (which only the reconciler's orphan sweep can recover).
+// Group lets main.go drain them, bounded, before exiting.
+package async
+
+import (
+	"context"
+	"sync"
+)
+
+// Group tracks detached goroutines so shutdown can wait (bounded) for them.
+//
+// The zero value is ready to use. A nil *Group is also valid: Go falls back
+// to a plain detached goroutine and Wait reports drained immediately, so
+// tests and callers that don't inject one keep working unchanged.
+//
+// Unlike a raw sync.WaitGroup, Go may be called concurrently with Wait in any
+// interleaving: if srv.Shutdown times out with requests still in flight, a
+// handler can legitimately call Go while main.go is already draining, which
+// would be a WaitGroup misuse panic. Group uses a counter + broadcast channel
+// instead, and Wait simply re-checks until the count reaches zero or ctx
+// expires.
+type Group struct {
+	mu    sync.Mutex
+	count int
+	idle  chan struct{} // closed when count drops to 0; nil until a waiter needs it
+}
+
+// Go runs fn in a new goroutine tracked by the group. On a nil receiver it
+// degrades to a plain `go fn()`.
+func (g *Group) Go(fn func()) {
+	if g == nil {
+		go fn()
+		return
+	}
+	g.mu.Lock()
+	g.count++
+	g.mu.Unlock()
+	go func() {
+		defer func() {
+			g.mu.Lock()
+			g.count--
+			if g.count == 0 && g.idle != nil {
+				close(g.idle)
+				g.idle = nil
+			}
+			g.mu.Unlock()
+		}()
+		fn()
+	}()
+}
+
+// Wait blocks until every tracked goroutine has finished, or ctx expires.
+// Returns true when fully drained, false when ctx expired first (some tasks
+// were abandoned). Safe on a nil receiver (trivially drained). A task started
+// while Wait is blocked extends the drain — the caller's ctx bounds it.
+func (g *Group) Wait(ctx context.Context) bool {
+	if g == nil {
+		return true
+	}
+	for {
+		g.mu.Lock()
+		if g.count == 0 {
+			g.mu.Unlock()
+			return true
+		}
+		if g.idle == nil {
+			g.idle = make(chan struct{})
+		}
+		idle := g.idle
+		g.mu.Unlock()
+
+		select {
+		case <-idle:
+			// Count hit zero, but a new task may have started since — re-check.
+		case <-ctx.Done():
+			return false
+		}
+	}
+}

--- a/dc-api/internal/async/group_test.go
+++ b/dc-api/internal/async/group_test.go
@@ -1,0 +1,63 @@
+package async
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestGroup_WaitDrains proves Wait returns true only after every Go'd task
+// has finished, and that the tasks actually ran.
+func TestGroup_WaitDrains(t *testing.T) {
+	g := &Group{}
+	var ran atomic.Int32
+	for i := 0; i < 5; i++ {
+		g.Go(func() {
+			time.Sleep(10 * time.Millisecond)
+			ran.Add(1)
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if !g.Wait(ctx) {
+		t.Fatal("Wait returned false, expected a full drain well within the deadline")
+	}
+	if got := ran.Load(); got != 5 {
+		t.Fatalf("expected 5 tasks to have run, got %d", got)
+	}
+}
+
+// TestGroup_WaitTimesOut proves Wait returns false when a task outlives the
+// context deadline.
+func TestGroup_WaitTimesOut(t *testing.T) {
+	g := &Group{}
+	release := make(chan struct{})
+	g.Go(func() { <-release })
+	defer close(release) // let the goroutine exit after the test
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if g.Wait(ctx) {
+		t.Fatal("Wait returned true, expected false: the task outlives the context")
+	}
+}
+
+// TestGroup_NilReceiver proves the nil-Group fallbacks: Go still runs the
+// task (plain detached goroutine, no panic) and Wait reports drained.
+func TestGroup_NilReceiver(t *testing.T) {
+	var g *Group
+	done := make(chan struct{})
+	g.Go(func() { close(done) })
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("nil-Group Go never ran the task")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !g.Wait(ctx) {
+		t.Fatal("nil-Group Wait must report drained")
+	}
+}

--- a/dc-api/internal/db/db.go
+++ b/dc-api/internal/db/db.go
@@ -672,6 +672,103 @@ func (r *Repository) UpdateStatus(ctx context.Context, id uuid.UUID, status mode
 	return nil
 }
 
+// FailOrphanedUnprovisioned recovers every PENDING/DELETING resource that has
+// NO backend_uid and hasn't been touched for olderThan. These rows are
+// stranded by a crash/redeploy that interrupted an async operation before the
+// backend confirmed anything: ListPending filters on backend_uid IS NOT NULL,
+// so the reconciler would never see them again and their unique name would
+// stay blocked forever.
+//
+//   - PENDING rows become FAILED — a tombstone Create() replaces, so the name
+//     is reusable and the interruption is visible instead of silent.
+//   - DELETING rows are deleted outright: nothing was ever created on the
+//     backend, so removing the row completes the user's delete.
+//
+// olderThan must STRICTLY exceed the handlers' largest async-provision
+// context ceiling — 15 minutes for cluster creates, 10 minutes for everything
+// else — so an in-flight create is never reaped. The reconciler passes 20
+// minutes. Returns the number of rows reaped.
+//
+// Each reaped row produces a real audit event (STATUS_CHANGE or DELETE), same
+// as any other lifecycle transition.
+func (r *Repository) FailOrphanedUnprovisioned(ctx context.Context, olderThan time.Duration) (int, error) {
+	const pendingMsg = "provisioning was interrupted before the backend resource was created; retry the create"
+
+	// Collect first, audit after — recordAudit issues its own Exec and must
+	// not interleave with an open result set on the same conn.
+	var reaped []auditInsert
+
+	// Stranded creates: PENDING → FAILED (a tombstone Create() replaces).
+	const failQ = `
+		UPDATE resources
+		SET    status  = 'FAILED',
+		       message = $1
+		WHERE  backend_uid IS NULL
+		AND    status = 'PENDING'
+		AND    updated_at < now() - make_interval(secs => $2)
+		RETURNING id, name, type::text, tenant_uuid, project_uuid`
+	rows, err := r.pool.Query(ctx, failQ, pendingMsg, olderThan.Seconds())
+	if err != nil {
+		return 0, fmt.Errorf("db fail orphaned pending resources: %w", err)
+	}
+	for rows.Next() {
+		var id uuid.UUID
+		var name, kind string
+		var tuid, puid *uuid.UUID
+		if err := rows.Scan(&id, &name, &kind, &tuid, &puid); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("db scan orphaned pending resource: %w", err)
+		}
+		reaped = append(reaped, auditInsert{
+			ID: id, Name: name, Kind: kind, TenantUUID: tuid, ProjectUUID: puid,
+			Action: audit.ActionStatusChange,
+			From:   models.StatusPending, To: models.StatusFailed, Message: pendingMsg,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("db fail orphaned pending resources: %w", err)
+	}
+	rows.Close()
+
+	// Stranded deletes: the user asked for deletion and no backend resource
+	// was ever created, so removing the row COMPLETES the delete — flipping it
+	// to FAILED would resurrect a resource the user already discarded.
+	const deleteQ = `
+		DELETE FROM resources
+		WHERE  backend_uid IS NULL
+		AND    status = 'DELETING'
+		AND    updated_at < now() - make_interval(secs => $1)
+		RETURNING id, name, type::text, tenant_uuid, project_uuid`
+	rows, err = r.pool.Query(ctx, deleteQ, olderThan.Seconds())
+	if err != nil {
+		return len(reaped), fmt.Errorf("db delete orphaned deleting resources: %w", err)
+	}
+	for rows.Next() {
+		var id uuid.UUID
+		var name, kind string
+		var tuid, puid *uuid.UUID
+		if err := rows.Scan(&id, &name, &kind, &tuid, &puid); err != nil {
+			rows.Close()
+			return len(reaped), fmt.Errorf("db scan orphaned deleting resource: %w", err)
+		}
+		reaped = append(reaped, auditInsert{
+			ID: id, Name: name, Kind: kind, TenantUUID: tuid, ProjectUUID: puid,
+			Action: audit.ActionDelete,
+			From:   models.StatusDeleting, To: models.StatusDeleted,
+			Message: "deletion requested but no backend resource was ever created; row removed",
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return len(reaped), fmt.Errorf("db delete orphaned deleting resources: %w", err)
+	}
+	rows.Close()
+
+	for _, in := range reaped {
+		r.recordAudit(ctx, r.pool, in)
+	}
+	return len(reaped), nil
+}
+
 // GetQuota retrieves the quota for a tenant.
 // If no quota row exists, returns the __default__ quota.
 // The quotas table still uses tenant_id as primary key because __default__ is

--- a/dc-api/internal/providers/common/errors.go
+++ b/dc-api/internal/providers/common/errors.go
@@ -1,0 +1,32 @@
+package common
+
+import "fmt"
+
+// NotFoundError is the typed not-found sentinel provider drivers return when
+// the backend object for a resource does not exist (Harvester VM gone,
+// Rancher cluster 404). The reconciler detects it structurally via
+// errors.As(err, &interface{ NotFound() bool }) instead of substring-matching
+// "not found" in error text.
+//
+// It lives in common (not the providers package) because the drivers cannot
+// import providers — factory.go there imports the drivers, which would be an
+// import cycle. providers re-exports it as a type alias so callers outside
+// the driver tree keep a single import.
+type NotFoundError struct {
+	Kind string // resource kind, e.g. "VM", "cluster"
+	Name string // the backendUID / object name that was looked up
+	// Msg preserves the driver's original human-readable error text so log
+	// messages stay familiar. Empty falls back to a generic form.
+	Msg string
+}
+
+// Error returns the driver's original message when set, else a generic form.
+func (e *NotFoundError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return fmt.Sprintf("%s %q not found", e.Kind, e.Name)
+}
+
+// NotFound marks this error as a structural not-found for errors.As probing.
+func (e *NotFoundError) NotFound() bool { return true }

--- a/dc-api/internal/providers/common/errors_test.go
+++ b/dc-api/internal/providers/common/errors_test.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNotFoundError_ErrorPreservesDriverMessage(t *testing.T) {
+	e := &NotFoundError{Kind: "VM", Name: "vm-abc", Msg: "VM vm-abc not found in Harvester"}
+	if got := e.Error(); got != "VM vm-abc not found in Harvester" {
+		t.Fatalf("Error() = %q, want the driver's original message", got)
+	}
+}
+
+func TestNotFoundError_ErrorFallsBackWhenMsgEmpty(t *testing.T) {
+	e := &NotFoundError{Kind: "cluster", Name: "c-xyz"}
+	if got, want := e.Error(), `cluster "c-xyz" not found`; got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestNotFoundError_StructurallyDetectableThroughWrapping(t *testing.T) {
+	// The reconciler probes errors.As(err, &interface{ NotFound() bool }) —
+	// the sentinel must survive fmt.Errorf %w wrapping.
+	wrapped := fmt.Errorf("get VM for reconcile: %w",
+		&NotFoundError{Kind: "VM", Name: "vm-abc", Msg: "VM vm-abc not found in Harvester"})
+
+	var nf interface{ NotFound() bool }
+	if !errors.As(wrapped, &nf) {
+		t.Fatal("errors.As failed to find the NotFound() sentinel through wrapping")
+	}
+	if !nf.NotFound() {
+		t.Fatal("NotFound() = false, want true")
+	}
+}

--- a/dc-api/internal/providers/errors.go
+++ b/dc-api/internal/providers/errors.go
@@ -1,0 +1,11 @@
+// Package providers — shared error types.
+package providers
+
+import "github.com/wso2/dc-api/internal/providers/common"
+
+// NotFoundError is the typed not-found sentinel drivers return when the
+// backend object for a resource does not exist. Alias of common.NotFoundError
+// (the concrete type lives in common because the drivers cannot import this
+// package — factory.go imports them). Callers outside the driver tree should
+// use this name.
+type NotFoundError = common.NotFoundError

--- a/dc-api/internal/providers/harvester/client.go
+++ b/dc-api/internal/providers/harvester/client.go
@@ -160,6 +160,12 @@ func NewRemoteClient(access clusteraccess.Accessor, region, zone string) *Client
 	}
 }
 
+// k8sRequestTimeout bounds every request made through this client's
+// rest.Config so a hung Harvester API server can't block goroutines forever.
+// Mirrors the Rancher client's 30s http.Client timeout. Safe here: this
+// client does no Watch/exec/portforward streaming.
+const k8sRequestTimeout = 30 * time.Second
+
 // NewClient creates a Harvester client from a base64-encoded kubeconfig string.
 // The kubeconfig is stored in DCAPI_HARVESTER_KUBECONFIG.
 // It tries base64 decoding first; falls back to treating the input as a raw kubeconfig.
@@ -174,6 +180,7 @@ func NewClient(kubeconfigB64 string, namespace string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse harvester kubeconfig: %w", err)
 	}
+	restConfig.Timeout = k8sRequestTimeout
 
 	dynClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
@@ -315,7 +322,14 @@ func (c *Client) GetVM(ctx context.Context, backendUID string) (*models.Resource
 	obj, err := c.access.Get(ctx, harvesterVMResource, ns, name, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("VM %s not found in Harvester", backendUID)
+			// Typed sentinel: the reconciler detects deletion structurally via
+			// NotFound() instead of substring-matching the message. Msg keeps
+			// the pre-existing error text so log lines don't change.
+			return nil, &common.NotFoundError{
+				Kind: "VM",
+				Name: backendUID,
+				Msg:  fmt.Sprintf("VM %s not found in Harvester", backendUID),
+			}
 		}
 		return nil, fmt.Errorf("harvester get VM %s: %w", backendUID, err)
 	}

--- a/dc-api/internal/providers/kubeovn/client.go
+++ b/dc-api/internal/providers/kubeovn/client.go
@@ -256,6 +256,13 @@ func NewRemoteClient(access clusteraccess.Accessor, region, zone string) *Client
 	}
 }
 
+// k8sRequestTimeout bounds every request made through this client's
+// rest.Config so a hung KubeOVN/cluster API server can't block goroutines
+// forever. Mirrors the Rancher client's 30s http.Client timeout. Safe here:
+// this client does no Watch/exec/portforward streaming (readiness waits are
+// polling loops of individual bounded requests).
+const k8sRequestTimeout = 30 * time.Second
+
 // New creates a KubeOVN Client.
 //
 //   - kubeconfig: base64-encoded kubeconfig string (same as DCAPI_HARVESTER_KUBECONFIG).
@@ -274,6 +281,10 @@ func New(kubeconfig, namespace string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse kubeovn kubeconfig: %w", err)
 	}
+	// Covers every consumer of this rest.Config / dynamic client: the KubeOVN
+	// driver itself, the KVI OpenBao proxy (RESTConfig()), and the dbaas +
+	// private-endpoint provisioners (Dynamic()).
+	restConfig.Timeout = k8sRequestTimeout
 
 	dynClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
@@ -292,7 +303,9 @@ func New(kubeconfig, namespace string) (*Client, error) {
 
 	// Probe for VpcDns CRD availability (best-effort; if the probe call itself
 	// fails for non-404 reasons, we conservatively fall back to ConfigMap mode).
-	ctx := context.Background()
+	// Bounded: a hung API server at startup must not block boot indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), k8sRequestTimeout)
+	defer cancel()
 	_, probeErr := dynClient.Resource(vpcDnsGVR).List(ctx, metav1.ListOptions{Limit: 1})
 	if probeErr == nil {
 		c.vpcDnsAvailable = true

--- a/dc-api/internal/providers/rancher/client.go
+++ b/dc-api/internal/providers/rancher/client.go
@@ -355,9 +355,15 @@ func (c *Client) GetCluster(ctx context.Context, backendUID string) (*models.Res
 
 	cs, err := c.provisioner.GetClusterStatus(ctx, backendUID)
 	if err != nil {
-		// IsSteveNotFound → propagate as "not found" so the reconciler can clean up.
+		// IsSteveNotFound → propagate as a typed not-found sentinel so the
+		// reconciler can clean up structurally (NotFound()) instead of
+		// substring-matching. Msg keeps the pre-existing error text.
 		if IsSteveNotFound(err) {
-			return nil, fmt.Errorf("cluster %q not found in Rancher", backendUID)
+			return nil, &common.NotFoundError{
+				Kind: "cluster",
+				Name: backendUID,
+				Msg:  fmt.Sprintf("cluster %q not found in Rancher", backendUID),
+			}
 		}
 		return nil, err
 	}

--- a/dc-api/internal/reconciler/notfound_test.go
+++ b/dc-api/internal/reconciler/notfound_test.go
@@ -1,0 +1,37 @@
+package reconciler
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wso2/dc-api/internal/providers"
+)
+
+// TestIsNotFound covers both detection paths deletion-handling depends on:
+// the typed providers.NotFoundError sentinel (preferred, survives wrapping)
+// and the legacy substring fallback for providers that don't return it yet.
+func TestIsNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"typed sentinel", &providers.NotFoundError{Kind: "VM", Name: "vm-1"}, true},
+		{"typed sentinel wrapped", fmt.Errorf("reconcile: %w",
+			&providers.NotFoundError{Kind: "cluster", Name: "c-1", Msg: `cluster "c-1" not found in Rancher`}), true},
+		{"substring fallback", errors.New("VM vm-1 not found in Harvester"), true},
+		// The fallback is deliberately case-sensitive (drivers emit lowercase
+		// "not found"); mixed-case texts rely on the typed sentinel instead.
+		{"substring fallback is case-sensitive", errors.New("404 Not Found"), false},
+		{"unrelated error", errors.New("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNotFound(tc.err); got != tc.want {
+				t.Fatalf("isNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/dc-api/internal/reconciler/reconciler.go
+++ b/dc-api/internal/reconciler/reconciler.go
@@ -20,11 +20,24 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/audit"
+	"github.com/wso2/dc-api/internal/db"
 	"github.com/wso2/dc-api/internal/models"
 	"github.com/wso2/dc-api/internal/providers"
 )
+
+// reconcileTimeout bounds one resource's reconcile so a hung backend can't
+// stall every other PENDING/DELETING resource in the sequential reconcileAll
+// loop; matches the per-request client timeout on the provider rest.Configs.
+const reconcileTimeout = 30 * time.Second
+
+// orphanTimeout is how long a PENDING/DELETING row may sit with no
+// backend_uid before the orphan sweep recovers it (PENDING → FAILED,
+// DELETING → row removed). Must STRICTLY exceed the largest async-provision
+// context ceiling in the handlers — 15 minutes for cluster creates, 10 for
+// everything else — so an in-flight create is never reaped while its
+// goroutine is still working. 20 minutes gives clusters a 5-minute margin.
+const orphanTimeout = 20 * time.Minute
 
 // Reconciler polls PENDING and DELETING resources and syncs their status
 // from the provider back into PostgreSQL.
@@ -97,6 +110,18 @@ func (r *Reconciler) Run(ctx context.Context) {
 
 // reconcileAll fetches all PENDING/DELETING resources and reconciles each one.
 func (r *Reconciler) reconcileAll(ctx context.Context) {
+	// Crash recovery: rows stranded before backend creation (backend_uid IS
+	// NULL) are invisible to ListPending below and would stay PENDING/DELETING
+	// forever (blocking their unique name). Sweep them first — stranded
+	// creates become FAILED, stranded deletes are completed by removing the
+	// row. A sweep failure is logged and skipped — it must never abort the tick.
+	if reaped, err := r.repo.FailOrphanedUnprovisioned(ctx, orphanTimeout); err != nil {
+		r.log.Error().Err(err).Msg("orphan sweep failed — continuing with the reconcile tick")
+	} else if reaped > 0 {
+		r.log.Warn().Int("count", reaped).
+			Msg("orphan sweep: recovered resources stranded before backend creation (interrupted provisioning)")
+	}
+
 	resources, err := r.repo.ListPending(ctx)
 	if err != nil {
 		r.log.Error().Err(err).Msg("failed to list pending resources")
@@ -116,6 +141,11 @@ func (r *Reconciler) reconcileAll(ctx context.Context) {
 
 // reconcileOne reconciles a single resource against its provider.
 func (r *Reconciler) reconcileOne(ctx context.Context, res *models.Resource) {
+	// Bound this resource's reconcile so a hung backend can't stall every
+	// other PENDING/DELETING resource; matches the per-request client timeout.
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
+
 	log := r.log.With().
 		Str("id", res.ID.String()).
 		Str("name", res.Name).
@@ -275,14 +305,14 @@ func isNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	// Check wrapped errors for a not-found sentinel if providers define one.
-	// For now we use string matching — a sentinel error type would be cleaner
-	// but adds provider API surface area.
+	// Preferred path: the typed sentinel (providers.NotFoundError implements
+	// NotFound() bool; Harvester GetVM and Rancher GetCluster return it).
 	var nf interface{ NotFound() bool }
 	if errors.As(err, &nf) {
 		return nf.NotFound()
 	}
-	// Fallback: string match (both drivers use "not found" in their messages).
+	// Fallback: string match, for provider paths (and agent-routed errors)
+	// that don't return the typed sentinel yet.
 	return containsNotFound(err.Error())
 }
 

--- a/dc-api/test/integration/reaper_test.go
+++ b/dc-api/test/integration/reaper_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package integration
+
+// reaper_test.go — crash-recovery orphan sweep (FailOrphanedUnprovisioned).
+//
+// A create interrupted before the backend confirmed (crash/redeploy between
+// the PENDING insert and the backend_uid update) leaves a PENDING row with
+// backend_uid IS NULL. ListPending filters those out, so without the sweep
+// the row stays PENDING forever and its unique (tenant, name, type) slot is
+// blocked. These tests prove the sweep:
+//
+//	(a) fails an OLD orphaned PENDING row with the documented message, emits
+//	    a STATUS_CHANGE audit event, and frees the name for re-Create;
+//	(b) leaves a FRESH orphaned PENDING row alone (in-flight creates are
+//	    never reaped — the threshold strictly exceeds every handler's
+//	    provision budget: 15 min for cluster creates, 10 min otherwise);
+//	(c) leaves a row WITH a backend_uid alone regardless of age (that row is
+//	    the reconciler's job, not the sweep's);
+//	(d) completes an OLD orphaned DELETING row by removing it (nothing was
+//	    ever created on the backend, so deletion just finishes), with a
+//	    DELETE audit event.
+//
+// Cluster-free: pure DB behaviour, runs under DCAPI_TEST_NOP=1 in CI (the
+// authz workflow) exactly like the projects-cap suite.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/wso2/dc-api/internal/models"
+)
+
+// Documented sweep message (must match db.FailOrphanedUnprovisioned).
+const reaperPendingMsg = "provisioning was interrupted before the backend resource was created; retry the create"
+
+// reaperTenant registers a fresh tenant for one test and returns its slug +
+// UUID. Rows are cleaned up so repeated local runs against a shared DB stay
+// deterministic.
+func reaperTenant(t *testing.T) (string, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	tid := randomTenantID("reaper")
+	_, err := env.DB.UpsertTenant(ctx, tid, tid, "dc-tenant-"+tid, "reaper-test")
+	require.NoError(t, err, "UpsertTenant")
+	tuid, err := env.DB.GetTenantUUIDBySlug(ctx, tid)
+	require.NoError(t, err, "GetTenantUUIDBySlug")
+	t.Cleanup(func() {
+		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM resources WHERE tenant_uuid = $1`, tuid)
+		_, _ = env.DB.Pool().Exec(ctx, `DELETE FROM tenants WHERE id = $1`, tid)
+	})
+	return tid, tuid
+}
+
+// seedReaperResource inserts a resource row through the Repository (same
+// path production uses, so region/zone stamping and the CREATE audit event
+// behave identically). backendUID "" ⇒ NULL in the row.
+func seedReaperResource(t *testing.T, tid string, tuid uuid.UUID, name string, status models.ResourceStatus, backendUID string) uuid.UUID {
+	t.Helper()
+	res, err := env.DB.Create(context.Background(), &models.Resource{
+		TenantID:     tid,
+		TenantUUID:   tuid,
+		OwnerID:      "reaper-test",
+		Name:         name,
+		Type:         models.ResourceTypeVM,
+		Status:       status,
+		ProviderType: "harvester",
+		BackendUID:   backendUID,
+	})
+	require.NoError(t, err, "seed resource %s", name)
+	return res.ID
+}
+
+// ageReaperResource pushes a row's updated_at into the past. The resources
+// table has a BEFORE UPDATE trigger (resources_updated_at) that forces
+// updated_at = NOW() on every UPDATE, so a plain SET would be overridden —
+// disable the trigger around the backdate, inside one transaction.
+func ageReaperResource(t *testing.T, id uuid.UUID, age time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := env.DB.Pool().Begin(ctx)
+	require.NoError(t, err, "begin age tx")
+	defer tx.Rollback(ctx) //nolint:errcheck
+	_, err = tx.Exec(ctx, `ALTER TABLE resources DISABLE TRIGGER resources_updated_at`)
+	require.NoError(t, err, "disable updated_at trigger")
+	tag, err := tx.Exec(ctx,
+		`UPDATE resources SET updated_at = now() - make_interval(secs => $2) WHERE id = $1`,
+		id, age.Seconds())
+	require.NoError(t, err, "backdate updated_at")
+	require.EqualValues(t, 1, tag.RowsAffected(), "expected to age exactly one row")
+	_, err = tx.Exec(ctx, `ALTER TABLE resources ENABLE TRIGGER resources_updated_at`)
+	require.NoError(t, err, "re-enable updated_at trigger")
+	require.NoError(t, tx.Commit(ctx), "commit age tx")
+}
+
+// TestReaper_OrphanedPendingReaped — (a): an old PENDING row with NULL
+// backend_uid is moved to FAILED with the documented message, the transition
+// is audited, and the name becomes reusable via Repository.Create (FAILED
+// tombstone replaced).
+func TestReaper_OrphanedPendingReaped(t *testing.T) {
+	ctx := context.Background()
+	tid, tuid := reaperTenant(t)
+	name := randomName("orphan-pending")
+
+	id := seedReaperResource(t, tid, tuid, name, models.StatusPending, "")
+	ageReaperResource(t, id, 20*time.Minute)
+
+	n, err := env.DB.FailOrphanedUnprovisioned(ctx, 15*time.Minute)
+	require.NoError(t, err, "FailOrphanedUnprovisioned")
+	// The shared test DB may hold aged orphans from elsewhere; assert ours is
+	// included rather than demanding an exact global count.
+	require.GreaterOrEqual(t, n, 1, "expected at least our orphan to be reaped")
+
+	res, err := env.DB.Get(ctx, id, tuid)
+	require.NoError(t, err, "Get reaped resource")
+	require.Equal(t, models.StatusFailed, res.Status, "orphaned PENDING row must be FAILED")
+	require.Equal(t, reaperPendingMsg, res.Message, "reaped row must carry the documented message")
+
+	// The sweep must audit like any other status transition.
+	var audits int
+	require.NoError(t, env.DB.Pool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM audit_events
+		 WHERE resource_id = $1 AND action = 'STATUS_CHANGE'
+		 AND from_status = 'PENDING' AND to_status = 'FAILED'`, id).Scan(&audits))
+	require.Equal(t, 1, audits, "expected exactly one PENDING→FAILED audit event for the reaped row")
+
+	// FAILED is a tombstone: creating the same (tenant, name, type) again
+	// must succeed — proving the stuck name is released.
+	id2 := seedReaperResource(t, tid, tuid, name, models.StatusPending, "")
+	require.NotEqual(t, id, id2, "re-create must produce a fresh row")
+}
+
+// TestReaper_FreshPendingNotReaped — (b): a fresh orphaned PENDING row (an
+// in-flight create) is NOT reaped.
+func TestReaper_FreshPendingNotReaped(t *testing.T) {
+	ctx := context.Background()
+	tid, tuid := reaperTenant(t)
+
+	id := seedReaperResource(t, tid, tuid, randomName("fresh-pending"), models.StatusPending, "")
+
+	_, err := env.DB.FailOrphanedUnprovisioned(ctx, 15*time.Minute)
+	require.NoError(t, err, "FailOrphanedUnprovisioned")
+
+	res, err := env.DB.Get(ctx, id, tuid)
+	require.NoError(t, err)
+	require.Equal(t, models.StatusPending, res.Status, "a fresh orphan (in-flight create) must NOT be reaped")
+}
+
+// TestReaper_BackendUIDNotReaped — (c): a PENDING row WITH a backend_uid is
+// never reaped regardless of age — the reconciler owns it.
+func TestReaper_BackendUIDNotReaped(t *testing.T) {
+	ctx := context.Background()
+	tid, tuid := reaperTenant(t)
+
+	id := seedReaperResource(t, tid, tuid, randomName("with-uid"), models.StatusPending, "dc-test:with-uid")
+	ageReaperResource(t, id, 48*time.Hour)
+
+	_, err := env.DB.FailOrphanedUnprovisioned(ctx, 15*time.Minute)
+	require.NoError(t, err, "FailOrphanedUnprovisioned")
+
+	res, err := env.DB.Get(ctx, id, tuid)
+	require.NoError(t, err)
+	require.Equal(t, models.StatusPending, res.Status, "a row with a backend_uid belongs to the reconciler, not the sweep")
+}
+
+// TestReaper_OrphanedDeletingReaped — (d): an old DELETING row that never had
+// a backend_uid is removed outright — the user asked for deletion and there
+// is nothing on the backend, so the sweep completes the delete — with a
+// DELETE audit event recording the transition.
+func TestReaper_OrphanedDeletingReaped(t *testing.T) {
+	ctx := context.Background()
+	tid, tuid := reaperTenant(t)
+
+	id := seedReaperResource(t, tid, tuid, randomName("orphan-deleting"), models.StatusDeleting, "")
+	ageReaperResource(t, id, 20*time.Minute)
+
+	n, err := env.DB.FailOrphanedUnprovisioned(ctx, 15*time.Minute)
+	require.NoError(t, err, "FailOrphanedUnprovisioned")
+	require.GreaterOrEqual(t, n, 1, "expected at least our orphan to be reaped")
+
+	_, err = env.DB.Get(ctx, id, tuid)
+	require.Error(t, err, "orphaned DELETING row must be deleted, not resurrected as FAILED")
+	require.Contains(t, err.Error(), "not found")
+
+	// The completed delete must be audited like any reconciler-driven delete.
+	var audits int
+	require.NoError(t, env.DB.Pool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM audit_events
+		 WHERE resource_id = $1 AND action = 'DELETE'
+		 AND from_status = 'DELETING' AND to_status = 'DELETED'`, id).Scan(&audits))
+	require.Equal(t, 1, audits, "expected exactly one DELETE audit event for the reaped row")
+}


### PR DESCRIPTION
## What this fixes

Three related reliability gaps: dc-api could pile up goroutines on a hung backend indefinitely, one stuck backend call could stall reconciliation of every other pending resource, and a crash or rolling deploy during provisioning could strand a resource in PENDING forever with its name permanently blocked.

## The changes

**Backend call timeouts.** Every Kubernetes REST config now sets a 30-second request timeout — Harvester, KubeOVN (which also covers the OpenBao proxy, DBaaS, and private-endpoint provisioners that reuse its config/client), and the admission webhook (both its in-cluster and kubeconfig paths). This matches the 30s timeout the Rancher HTTP client already had. The KubeOVN startup probe also gets a deadline instead of a bare background context. There is no watch/exec/streaming usage on these clients (verified by grep), so a request-level timeout is safe; long provisioning waits are polling loops of individual requests, each now individually bounded.

**Per-resource reconcile timeout.** The reconciler processes resources sequentially; each `reconcileOne` now runs under its own 30-second context so a hung backend can't wedge the loop for every other PENDING/DELETING resource.

**Orphan sweep (crash recovery).** A create interrupted before the backend confirmed the resource leaves a PENDING row with no `backend_uid`. `ListPending` filters those out, so the reconciler never saw them again — the row sat PENDING forever and its unique name stayed blocked. Each reconciler tick now first sweeps rows with no `backend_uid` older than 20 minutes — strictly above the largest async-provision budget (15 minutes for cluster creates, 10 for everything else), so an in-flight create is never reaped. Stranded creates become FAILED with an explanatory message (FAILED is a tombstone the create path already replaces, so the name frees up); stranded deletes are completed by removing the row, since nothing was ever created on the backend and flipping them to FAILED would resurrect a resource the user already discarded. Every reaped row emits a normal audit event (status-change or delete).

**Shutdown drain.** Handlers' fire-and-forget provisioning goroutines are now tracked by a small `internal/async.Group` (all 19 launch sites across 8 handlers), and `main.go` drains them for up to 60 seconds after the HTTP server stops. A rolling deploy no longer silently kills provisioning mid-flight; anything that outlives the drain window is picked up by the orphan sweep instead of hanging as PENDING. The tracker is safe against tasks being launched while the drain is already in progress (a raw `sync.WaitGroup` would panic in the srv.Shutdown-timed-out case), and it is nil-receiver-safe so existing tests and the contract harness run unchanged.

**Typed not-found errors.** Harvester `GetVM` and Rancher `GetCluster` now return an error implementing the `NotFound() bool` sentinel the reconciler already checks via `errors.As` (previously dead code — no provider implemented it), replacing substring matching on those paths. The substring fallback remains for other providers and agent-routed errors. The error text is unchanged, so logs read the same.

## Why it's safe

No API or schema changes. The timeout only bounds individual HTTP requests; the sweep only touches rows that are invisible to the reconciler today (nothing can ever transition them) and its threshold strictly exceeds every provisioning budget; the drain only delays process exit (bounded); handler goroutine context semantics are untouched (provisioning still survives client disconnects).

## Tests

Unit tests for `async.Group` (drain, timeout, nil receiver), the typed not-found sentinel (including wrapping and the case-sensitivity boundary of the substring fallback), and the reconciler's `isNotFound`. New `TestReaper_*` integration tests (cluster-free, real Postgres): an old orphaned PENDING row is swept to FAILED with the right message, audit event, and name reuse via the create path; an orphaned DELETING row is removed with a DELETE audit event; a fresh orphan and a row with a `backend_uid` are left alone. The reaper suite is added to the cluster-free CI job's filter.

## Verified

`go build`, `go vet` (incl. integration tags), the full unit suite, reaper suite 4/4, and the cluster-free CI filter 42/42. The full live-cluster integration suite was run against a dev Harvester+KubeOVN cluster: the suites this change touches all pass; the only failures are pre-existing on the unmodified base branch (verified by running the identical subset on the base against the same cluster — a KeyVault-environment issue and a handful of tests using tenant slugs that no longer pass the tightened slug validation; tracked separately). Self-reviewed: diff-scoped scanners (golangci-lint, govulncheck, gitleaks, actionlint) + a multi-lens adversarial review whose confirmed findings (cluster-create budget margin, drain/WaitGroup race, DELETING-orphan semantics, missing sentinel tests) were all fixed in this diff.

## Not included

The same orphan sweep for network resource families (vnets/subnets/etc. live in their own tables and have no reconciler at all today — a pre-existing gap, tracked). Conflict-retry on the KubeOVN read-modify-write patch helpers (separate concern, tracked). The pre-existing `govulncheck` findings on the toolchain (fixed by a Go patch-release bump) are also tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the authorization integration test workflow to include additional crash-recovery coverage.
  * Broadened the test run selection to execute the orphan-reaper test cases alongside the existing RBAC, membership, service account, tenant, phase-6a, and project capacity tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->