### PR TITLE
[Fix] Harden cloud-ui against crashes and expired sessions

### DIFF
--- a/cloud-ui/src/ThemedApp.tsx
+++ b/cloud-ui/src/ThemedApp.tsx
@@ -15,8 +15,10 @@ export default function ThemedApp() {
 
   return (
     <FluentProvider theme={theme}>
-      {/* Inside FluentProvider so the crash fallback is themed; around the
-          provider chain + RouterProvider so any render error is caught. */}
+      {/* Inside FluentProvider so the crash fallback is themed. Route render
+          errors are caught by the router's own errorElement (RouteErrorFallback,
+          see router.tsx) — this outer boundary is the last resort for errors
+          OUTSIDE the router (provider construction/render). */}
       <ErrorBoundary>
         <AuthProvider>
           <ApiProvider>

--- a/cloud-ui/src/ThemedApp.tsx
+++ b/cloud-ui/src/ThemedApp.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom';
 import { ApiProvider } from './api/ApiContext';
 import { AuthProvider } from './auth/AuthContext';
 import { ConfirmDialogProvider } from './components/ConfirmDialog';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { buildRouter } from './router';
 import { wso2DarkTheme, wso2LightTheme } from './theme/themes';
 
@@ -14,13 +15,17 @@ export default function ThemedApp() {
 
   return (
     <FluentProvider theme={theme}>
-      <AuthProvider>
-        <ApiProvider>
-          <ConfirmDialogProvider>
-            <RouterProvider router={router} />
-          </ConfirmDialogProvider>
-        </ApiProvider>
-      </AuthProvider>
+      {/* Inside FluentProvider so the crash fallback is themed; around the
+          provider chain + RouterProvider so any render error is caught. */}
+      <ErrorBoundary>
+        <AuthProvider>
+          <ApiProvider>
+            <ConfirmDialogProvider>
+              <RouterProvider router={router} />
+            </ConfirmDialogProvider>
+          </ApiProvider>
+        </AuthProvider>
+      </ErrorBoundary>
     </FluentProvider>
   );
 }

--- a/cloud-ui/src/ThemedApp.tsx
+++ b/cloud-ui/src/ThemedApp.tsx
@@ -17,8 +17,10 @@ export default function ThemedApp() {
     <FluentProvider theme={theme}>
       {/* Inside FluentProvider so the crash fallback is themed. Route render
           errors are caught by the router's own errorElement (RouteErrorFallback,
-          see router.tsx) — this outer boundary is the last resort for errors
-          OUTSIDE the router (provider construction/render). */}
+          see router.tsx) — this outer boundary is the last resort for render
+          errors in the provider chain below it. It cannot catch a throw from
+          ThemedApp's own body (e.g. buildRouter): boundaries only catch
+          errors in their children. */}
       <ErrorBoundary>
         <AuthProvider>
           <ApiProvider>

--- a/cloud-ui/src/api/client.test.ts
+++ b/cloud-ui/src/api/client.test.ts
@@ -72,3 +72,50 @@ describe('session-expiry middleware', () => {
     expect(onExpired).not.toHaveBeenCalled();
   });
 });
+
+describe('notifySessionExpiredOn401 (raw-fetch callers)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('fires once for repeated 401s on session-scoped paths', async () => {
+    // MembersPage's scopedJson bypasses the typed client, so it calls this
+    // helper directly with the relative request path.
+    const { notifySessionExpiredOn401, registerSessionExpiredHandler } = await freshClientModule();
+    const onExpired = vi.fn();
+    registerSessionExpiredHandler(onExpired);
+
+    notifySessionExpiredOn401('/v1/tenants/t/projects/p/virtual-machines/vm/role-assignments', 401);
+    notifySessionExpiredOn401('/v1/tenants/t/projects/p/virtual-machines/vm/role-assignments', 401);
+
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-401 statuses, /v1/auth/* and non-API paths', async () => {
+    const { notifySessionExpiredOn401, registerSessionExpiredHandler } = await freshClientModule();
+    const onExpired = vi.fn();
+    registerSessionExpiredHandler(onExpired);
+
+    notifySessionExpiredOn401('/v1/tenants', 403);
+    notifySessionExpiredOn401('/v1/auth/me', 401);
+    notifySessionExpiredOn401('/healthz', 401);
+
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it('shares the once-latch with the typed-client middleware', async () => {
+    // A 401 seen by the middleware and one seen by a raw fetch are the same
+    // session expiry — the auth layer must still hear about it exactly once.
+    const { makeApiClient, notifySessionExpiredOn401, registerSessionExpiredHandler } =
+      await freshClientModule();
+    const onExpired = vi.fn();
+    registerSessionExpiredHandler(onExpired);
+    stub401Fetch();
+
+    await makeApiClient().GET('/v1/tenants');
+    notifySessionExpiredOn401('/v1/tenants/t/role-assignments', 401);
+
+    expect(onExpired).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+});

--- a/cloud-ui/src/api/client.test.ts
+++ b/cloud-ui/src/api/client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * client.ts computes baseUrl at module scope from import.meta.env and keeps
+ * the session-expiry latch as module state, so each test stubs the env and
+ * dynamic-imports a fresh copy. An absolute VITE_API_BASE is required here:
+ * in the browser a relative /v1 path resolves against the page origin, but
+ * Node's Request constructor rejects relative URLs.
+ */
+async function freshClientModule() {
+  vi.resetModules();
+  vi.stubEnv('VITE_API_BASE', 'https://dcapi.test');
+  return import('./client');
+}
+
+function stub401Fetch() {
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify({ error: 'unauthenticated' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('session-expiry middleware', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('notifies the auth layer exactly once for parallel 401s', async () => {
+    const { makeApiClient, registerSessionExpiredHandler } = await freshClientModule();
+    const onExpired = vi.fn();
+    registerSessionExpiredHandler(onExpired);
+    const fetchMock = stub401Fetch();
+
+    const client = makeApiClient();
+    await Promise.all([client.GET('/v1/tenants'), client.GET('/v1/tenants')]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces across separately constructed clients', async () => {
+    // RequireProject builds its own ad-hoc client next to the shared
+    // ApiProvider one — a session expiry seen by both must still notify once.
+    const { makeApiClient, registerSessionExpiredHandler } = await freshClientModule();
+    const onExpired = vi.fn();
+    registerSessionExpiredHandler(onExpired);
+    stub401Fetch();
+
+    const a = makeApiClient();
+    const b = makeApiClient();
+    await Promise.all([a.GET('/v1/tenants'), b.GET('/v1/tenants')]);
+
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores 401 from the /v1/auth/* endpoints', async () => {
+    // The /v1/auth/me probe legitimately 401s for signed-out visitors —
+    // firing the handler there would loop the login flow.
+    const { makeApiClient, registerSessionExpiredHandler } = await freshClientModule();
+    const onExpired = vi.fn();
+    registerSessionExpiredHandler(onExpired);
+    stub401Fetch();
+
+    const client = makeApiClient();
+    await client.GET('/v1/auth/me');
+
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+});

--- a/cloud-ui/src/api/client.test.ts
+++ b/cloud-ui/src/api/client.test.ts
@@ -14,11 +14,12 @@ async function freshClientModule() {
 }
 
 function stub401Fetch() {
-  const fetchMock = vi.fn(async () =>
-    new Response(JSON.stringify({ error: 'unauthenticated' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ error: 'unauthenticated' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
   );
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
@@ -76,6 +77,7 @@ describe('session-expiry middleware', () => {
 describe('notifySessionExpiredOn401 (raw-fetch callers)', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it('fires once for repeated 401s on session-scoped paths', async () => {
@@ -116,6 +118,33 @@ describe('notifySessionExpiredOn401 (raw-fetch callers)', () => {
     notifySessionExpiredOn401('/v1/tenants/t/role-assignments', 401);
 
     expect(onExpired).toHaveBeenCalledTimes(1);
-    vi.unstubAllGlobals();
+  });
+
+  it('re-arms the once-latch on re-registration', async () => {
+    // AuthProvider re-registers on remount; the latch must reset so the
+    // next session expiry notifies the fresh handler.
+    const { notifySessionExpiredOn401, registerSessionExpiredHandler } = await freshClientModule();
+    const first = vi.fn();
+    registerSessionExpiredHandler(first);
+    notifySessionExpiredOn401('/v1/tenants', 401);
+
+    const second = vi.fn();
+    registerSessionExpiredHandler(second);
+    notifySessionExpiredOn401('/v1/tenants', 401);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op after the handler is detached with null', async () => {
+    // AuthProvider's unmount cleanup passes null — a late 401 must neither
+    // throw nor reach the stale handler.
+    const { notifySessionExpiredOn401, registerSessionExpiredHandler } = await freshClientModule();
+    const onExpired = vi.fn();
+    registerSessionExpiredHandler(onExpired);
+    registerSessionExpiredHandler(null);
+
+    expect(() => notifySessionExpiredOn401('/v1/tenants', 401)).not.toThrow();
+    expect(onExpired).not.toHaveBeenCalled();
   });
 });

--- a/cloud-ui/src/api/client.ts
+++ b/cloud-ui/src/api/client.ts
@@ -35,19 +35,27 @@ export function registerSessionExpiredHandler(handler: SessionExpiredHandler | n
   sessionExpiryNotified = false;
 }
 
+/**
+ * Shared 401 check for anything that talks to the API outside the typed
+ * client (e.g. the dynamic resource-scope calls in MembersPage). Same
+ * rules as the middleware: session-scoped /v1/* paths only, /v1/auth/*
+ * excluded, fires the registered handler once.
+ */
+export function notifySessionExpiredOn401(pathname: string, status: number) {
+  if (status !== 401) return;
+  // Only session-scoped API calls count. /v1/auth/* is excluded: the
+  // /v1/auth/me probe legitimately 401s for signed-out visitors, and
+  // login/logout/callback must never re-enter the handler (loop risk).
+  if (!pathname.startsWith('/v1/') || pathname.startsWith('/v1/auth/')) return;
+
+  if (sessionExpiryNotified) return;
+  sessionExpiryNotified = true;
+  sessionExpiredHandler?.();
+}
+
 const sessionExpiryMiddleware: Middleware = {
   async onResponse({ request, response }) {
-    if (response.status !== 401) return;
-
-    // Only session-scoped API calls count. /v1/auth/* is excluded: the
-    // /v1/auth/me probe legitimately 401s for signed-out visitors, and
-    // login/logout/callback must never re-enter the handler (loop risk).
-    const { pathname } = new URL(request.url);
-    if (!pathname.startsWith('/v1/') || pathname.startsWith('/v1/auth/')) return;
-
-    if (sessionExpiryNotified) return;
-    sessionExpiryNotified = true;
-    sessionExpiredHandler?.();
+    notifySessionExpiredOn401(new URL(request.url).pathname, response.status);
   },
 };
 

--- a/cloud-ui/src/api/client.ts
+++ b/cloud-ui/src/api/client.ts
@@ -11,6 +11,47 @@ const baseUrl =
   (import.meta.env.VITE_API_BASE as string | undefined)?.replace(/\/$/, '') ?? DEFAULT_BASE_URL;
 
 /**
+ * Session-expiry notification between the API client and the auth layer.
+ *
+ * client.ts must stay React-free, so instead of touching AuthContext the
+ * auth provider registers a callback here on mount. When any /v1/* call
+ * (except /v1/auth/*) comes back 401 mid-session, the handler fires and
+ * AuthProvider flips to signed-out — RequireAuth then redirects to /login.
+ *
+ * The latch is module-level (shared by every client instance) and fires
+ * once: when a session expires, every in-flight query 401s at the same
+ * time and the handler must not run N times. It never re-arms itself —
+ * re-login is a full-page navigation through /v1/auth/login, which resets
+ * module state anyway. Registering a handler resets the latch (tests, or
+ * a remounted AuthProvider).
+ */
+type SessionExpiredHandler = () => void;
+
+let sessionExpiredHandler: SessionExpiredHandler | null = null;
+let sessionExpiryNotified = false;
+
+export function registerSessionExpiredHandler(handler: SessionExpiredHandler | null) {
+  sessionExpiredHandler = handler;
+  sessionExpiryNotified = false;
+}
+
+const sessionExpiryMiddleware: Middleware = {
+  async onResponse({ request, response }) {
+    if (response.status !== 401) return;
+
+    // Only session-scoped API calls count. /v1/auth/* is excluded: the
+    // /v1/auth/me probe legitimately 401s for signed-out visitors, and
+    // login/logout/callback must never re-enter the handler (loop risk).
+    const { pathname } = new URL(request.url);
+    if (!pathname.startsWith('/v1/') || pathname.startsWith('/v1/auth/')) return;
+
+    if (sessionExpiryNotified) return;
+    sessionExpiryNotified = true;
+    sessionExpiredHandler?.();
+  },
+};
+
+/**
  * Typed DC-API client.
  *
  * Authentication uses the dc-api BFF cookie flow: every request carries
@@ -32,6 +73,7 @@ export function makeApiClient() {
     },
   };
   client.use(credentialsMiddleware);
+  client.use(sessionExpiryMiddleware);
 
   return client;
 }

--- a/cloud-ui/src/auth/AuthContext.test.tsx
+++ b/cloud-ui/src/auth/AuthContext.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { AuthProvider } from './AuthContext';
+import { useAuth } from './useAuth';
+
+/**
+ * AuthProvider owns the user-facing half of session-expiry handling: it
+ * registers a handler with the API client that flips `user` to null
+ * (sending the router through RequireAuth to /login) and detaches it on
+ * unmount. client.test.ts proves the client-side notification mechanism;
+ * these tests prove the hop that makes it visible to users. The client
+ * module is mocked so the registered handler can be captured and driven
+ * directly.
+ */
+const { registrations } = vi.hoisted(() => ({
+  registrations: [] as Array<(() => void) | null>,
+}));
+
+vi.mock('../api/client', () => ({
+  registerSessionExpiredHandler: (handler: (() => void) | null) => {
+    registrations.push(handler);
+  },
+}));
+
+function WhoAmI() {
+  const { user, loading } = useAuth();
+  if (loading) return <div>loading</div>;
+  return <div>{user ? user.sub : 'signed-out'}</div>;
+}
+
+function stubSignedInMeFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ sub: 'user-1', expires_at: '2027-01-01T00:00:00Z', is_admin: false }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    )
+  );
+}
+
+describe('AuthProvider session-expiry wiring', () => {
+  beforeEach(() => {
+    registrations.length = 0;
+    stubSignedInMeFetch();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('flips the app to signed-out when the registered handler fires', async () => {
+    render(
+      <AuthProvider>
+        <WhoAmI />
+      </AuthProvider>
+    );
+    expect(await screen.findByText('user-1')).toBeInTheDocument();
+
+    // The mid-session 401 path: the client detects expiry and invokes the
+    // handler AuthProvider registered on mount.
+    const handler = registrations.at(-1);
+    expect(handler).toBeTypeOf('function');
+    act(() => handler!());
+
+    expect(screen.getByText('signed-out')).toBeInTheDocument();
+  });
+
+  it('detaches the handler on unmount', async () => {
+    const { unmount } = render(
+      <AuthProvider>
+        <WhoAmI />
+      </AuthProvider>
+    );
+    await screen.findByText('user-1');
+
+    unmount();
+
+    expect(registrations.at(-1)).toBeNull();
+  });
+});

--- a/cloud-ui/src/auth/AuthContext.tsx
+++ b/cloud-ui/src/auth/AuthContext.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
+import { registerSessionExpiredHandler } from '../api/client';
 import { AuthContext, type AuthContextValue, type AuthUser } from './context';
 
 /**
@@ -20,6 +21,16 @@ import { AuthContext, type AuthContextValue, type AuthUser } from './context';
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // A 401 from any API call mid-session means the dcapi_session cookie
+  // expired (or was revoked). Flipping user to null sends the router
+  // through RequireAuth's existing <Navigate to="/login"> — the same
+  // sign-in flow as a fresh visit. The client-side middleware debounces,
+  // so this fires once even when many parallel queries 401 together.
+  useEffect(() => {
+    registerSessionExpiredHandler(() => setUser(null));
+    return () => registerSessionExpiredHandler(null);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/cloud-ui/src/components/ErrorBoundary.test.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { FluentProvider } from '@fluentui/react-components';
-import { ErrorBoundary } from './ErrorBoundary';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { ErrorBoundary, RouteErrorFallback } from './ErrorBoundary';
 import { wso2LightTheme } from '../theme/themes';
 
 /** Renders fine until told to throw — the classic boundary probe. */
@@ -44,5 +45,51 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('Something went wrong')).toBeInTheDocument();
     expect(screen.getByText('kaboom from render')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+  });
+});
+
+describe('RouteErrorFallback', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('shows the themed fallback when a route render throws', () => {
+    // Mirrors buildRouter: a pathless root route carrying the errorElement,
+    // so route crashes hit our fallback instead of react-router's default
+    // "Unexpected Application Error!" screen.
+    const router = createMemoryRouter([
+      {
+        errorElement: <RouteErrorFallback />,
+        children: [{ path: '/', element: <Boom /> }],
+      },
+    ]);
+    renderWithTheme(<RouterProvider router={router} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('kaboom from render')).toBeInTheDocument();
+  });
+
+  it('wraps non-Error route errors so the message still renders', async () => {
+    const router = createMemoryRouter([
+      {
+        errorElement: <RouteErrorFallback />,
+        children: [
+          {
+            path: '/',
+            loader: () => {
+              throw 'plain string failure';
+            },
+            element: <div>never reached</div>,
+          },
+        ],
+      },
+    ]);
+    renderWithTheme(<RouterProvider router={router} />);
+    expect(await screen.findByText('plain string failure')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 });

--- a/cloud-ui/src/components/ErrorBoundary.test.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FluentProvider } from '@fluentui/react-components';
+import { ErrorBoundary } from './ErrorBoundary';
+import { wso2LightTheme } from '../theme/themes';
+
+/** Renders fine until told to throw — the classic boundary probe. */
+function Boom(): never {
+  throw new Error('kaboom from render');
+}
+
+function renderWithTheme(ui: React.ReactNode) {
+  return render(<FluentProvider theme={wso2LightTheme}>{ui}</FluentProvider>);
+}
+
+describe('ErrorBoundary', () => {
+  // React logs caught render errors via console.error; silence them so the
+  // intentional throw doesn't pollute the test output.
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('renders its children when nothing throws', () => {
+    renderWithTheme(
+      <ErrorBoundary>
+        <div>ALL GOOD</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('ALL GOOD')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  });
+
+  it('renders the fallback with the error message when a child throws', () => {
+    renderWithTheme(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('kaboom from render')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+  });
+});

--- a/cloud-ui/src/components/ErrorBoundary.test.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.test.tsx
@@ -46,6 +46,20 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('kaboom from render')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
   });
+
+  it('normalizes a non-Error throw so the fallback still renders', () => {
+    function BoomLiteral(): never {
+      // Deliberately throwing a non-Error to exercise the normalization path.
+      throw 'raw string kaboom';
+    }
+    renderWithTheme(
+      <ErrorBoundary>
+        <BoomLiteral />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('raw string kaboom')).toBeInTheDocument();
+  });
 });
 
 describe('RouteErrorFallback', () => {

--- a/cloud-ui/src/components/ErrorBoundary.test.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.test.tsx
@@ -106,4 +106,26 @@ describe('RouteErrorFallback', () => {
     expect(await screen.findByText('plain string failure')).toBeInTheDocument();
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
+
+  it('renders the status line for thrown Response route errors', async () => {
+    // Loaders/actions may throw a Response; String() on it is useless
+    // ("[object Response]"), so the fallback shows the status line.
+    const router = createMemoryRouter([
+      {
+        errorElement: <RouteErrorFallback />,
+        children: [
+          {
+            path: '/',
+            loader: () => {
+              throw new Response(null, { status: 403, statusText: 'Forbidden' });
+            },
+            element: <div>never reached</div>,
+          },
+        ],
+      },
+    ]);
+    renderWithTheme(<RouterProvider router={router} />);
+    expect(await screen.findByText('403 Forbidden')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
 });

--- a/cloud-ui/src/components/ErrorBoundary.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,113 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Button, Text, Title2, makeStyles, tokens } from '@fluentui/react-components';
+import { ErrorCircle48Regular } from '@fluentui/react-icons';
+
+/**
+ * Last-resort catch for render errors. Without it a single throwing
+ * component white-screens the whole console. Mounted once in ThemedApp,
+ * inside FluentProvider so the fallback picks up the active theme.
+ *
+ * Error boundaries must be class components (React exposes
+ * getDerivedStateFromError only on classes), so the class stays minimal
+ * and delegates all presentation to a themed function component.
+ */
+
+const useStyles = makeStyles({
+  root: {
+    minHeight: '100vh',
+    display: 'grid',
+    placeItems: 'center',
+    backgroundColor: tokens.colorNeutralBackground2,
+    padding: tokens.spacingHorizontalXXL,
+  },
+  card: {
+    maxWidth: '480px',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    textAlign: 'center',
+    gap: tokens.spacingVerticalL,
+    padding: `${tokens.spacingVerticalXXL} ${tokens.spacingHorizontalXXL}`,
+    borderRadius: tokens.borderRadiusXLarge,
+    backgroundColor: tokens.colorNeutralBackground1,
+    boxShadow: tokens.shadow16,
+  },
+  icon: {
+    color: tokens.colorStatusDangerForeground1,
+  },
+  details: {
+    width: '100%',
+    textAlign: 'left',
+  },
+  summary: {
+    cursor: 'pointer',
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+  message: {
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: 0,
+    padding: tokens.spacingHorizontalM,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground3,
+    color: tokens.colorNeutralForeground2,
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    whiteSpace: 'pre-wrap',
+    overflowWrap: 'anywhere',
+  },
+});
+
+function ErrorFallback({ error }: { error: Error }) {
+  const styles = useStyles();
+  return (
+    <div className={styles.root} role="alert">
+      <div className={styles.card}>
+        <ErrorCircle48Regular className={styles.icon} />
+        <Title2>Something went wrong</Title2>
+        <Text>
+          The console hit an unexpected error. Reload to continue — if it keeps happening, share
+          the details below with the platform team.
+        </Text>
+        <details className={styles.details}>
+          <summary className={styles.summary}>Error details</summary>
+          <pre className={styles.message}>{error.message}</pre>
+        </details>
+        <Button appearance="primary" onClick={() => window.location.reload()}>
+          Reload
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    // Anything can be thrown; normalize so the fallback always has a message.
+    return { error: error instanceof Error ? error : new Error(String(error)) };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surface the component stack for debugging — the fallback only shows
+    // the message.
+    console.error('Unhandled render error:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return <ErrorFallback error={this.state.error} />;
+    }
+    return this.props.children;
+  }
+}

--- a/cloud-ui/src/components/ErrorBoundary.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.tsx
@@ -1,15 +1,23 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { Button, Text, Title2, makeStyles, tokens } from '@fluentui/react-components';
 import { ErrorCircle48Regular } from '@fluentui/react-icons';
+import { useRouteError } from 'react-router-dom';
 
 /**
- * Last-resort catch for render errors. Without it a single throwing
- * component white-screens the whole console. Mounted once in ThemedApp,
- * inside FluentProvider so the fallback picks up the active theme.
+ * Render-error fallbacks, in two layers:
  *
- * Error boundaries must be class components (React exposes
- * getDerivedStateFromError only on classes), so the class stays minimal
- * and delegates all presentation to a themed function component.
+ *  - RouteErrorFallback is the one that actually fires for page crashes.
+ *    Data routers (createBrowserRouter) install their own error boundary
+ *    at every route level and NEVER let render errors propagate out of
+ *    RouterProvider — without an errorElement of our own, users get
+ *    react-router's unthemed "Unexpected Application Error!" screen. The
+ *    router mounts this on a pathless root route so every route inherits it.
+ *
+ *  - ErrorBoundary is the last resort OUTSIDE the router (provider
+ *    construction, theming) where react-router can't help. Error boundaries
+ *    must be class components (React exposes getDerivedStateFromError only
+ *    on classes), so the class stays minimal and delegates all presentation
+ *    to the same themed function component.
  */
 
 const useStyles = makeStyles({
@@ -80,6 +88,16 @@ function ErrorFallback({ error }: { error: Error }) {
       </div>
     </div>
   );
+}
+
+/**
+ * Route-level error element: react-router catches the render error and
+ * exposes it via useRouteError; we render the same themed fallback.
+ */
+export function RouteErrorFallback() {
+  const raw = useRouteError();
+  const error = raw instanceof Error ? raw : new Error(String(raw));
+  return <ErrorFallback error={error} />;
 }
 
 interface ErrorBoundaryProps {

--- a/cloud-ui/src/components/ErrorBoundary.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.tsx
@@ -13,11 +13,11 @@ import { useRouteError } from 'react-router-dom';
  *    react-router's unthemed "Unexpected Application Error!" screen. The
  *    router mounts this on a pathless root route so every route inherits it.
  *
- *  - ErrorBoundary is the last resort OUTSIDE the router (provider
- *    construction, theming) where react-router can't help. Error boundaries
- *    must be class components (React exposes getDerivedStateFromError only
- *    on classes), so the class stays minimal and delegates all presentation
- *    to the same themed function component.
+ *  - ErrorBoundary is the last resort for render errors react-router can't
+ *    see: the provider chain it wraps in ThemedApp (Auth/Api/ConfirmDialog).
+ *    Error boundaries must be class components (React exposes
+ *    getDerivedStateFromError only on classes), so the class stays minimal
+ *    and delegates all presentation to the same themed function component.
  */
 
 const useStyles = makeStyles({
@@ -75,8 +75,8 @@ function ErrorFallback({ error }: { error: Error }) {
         <ErrorCircle48Regular className={styles.icon} />
         <Title2>Something went wrong</Title2>
         <Text>
-          The console hit an unexpected error. Reload to continue — if it keeps happening, share
-          the details below with the platform team.
+          The console hit an unexpected error. Reload to continue — if it keeps happening, share the
+          details below with the platform team.
         </Text>
         <details className={styles.details}>
           <summary className={styles.summary}>Error details</summary>
@@ -90,14 +90,17 @@ function ErrorFallback({ error }: { error: Error }) {
   );
 }
 
+/** Anything can be thrown; normalize so the fallback always has a message. */
+function toError(raw: unknown): Error {
+  return raw instanceof Error ? raw : new Error(String(raw));
+}
+
 /**
  * Route-level error element: react-router catches the render error and
  * exposes it via useRouteError; we render the same themed fallback.
  */
 export function RouteErrorFallback() {
-  const raw = useRouteError();
-  const error = raw instanceof Error ? raw : new Error(String(raw));
-  return <ErrorFallback error={error} />;
+  return <ErrorFallback error={toError(useRouteError())} />;
 }
 
 interface ErrorBoundaryProps {
@@ -112,8 +115,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   state: ErrorBoundaryState = { error: null };
 
   static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
-    // Anything can be thrown; normalize so the fallback always has a message.
-    return { error: error instanceof Error ? error : new Error(String(error)) };
+    return { error: toError(error) };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {

--- a/cloud-ui/src/components/ErrorBoundary.tsx
+++ b/cloud-ui/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { Button, Text, Title2, makeStyles, tokens } from '@fluentui/react-components';
 import { ErrorCircle48Regular } from '@fluentui/react-icons';
-import { useRouteError } from 'react-router-dom';
+import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
 
 /**
  * Render-error fallbacks, in two layers:
@@ -98,9 +98,15 @@ function toError(raw: unknown): Error {
 /**
  * Route-level error element: react-router catches the render error and
  * exposes it via useRouteError; we render the same themed fallback.
+ * Thrown Responses (loader/action shortcuts) stringify uselessly, so
+ * surface their status line instead.
  */
 export function RouteErrorFallback() {
-  return <ErrorFallback error={toError(useRouteError())} />;
+  const raw = useRouteError();
+  const error = isRouteErrorResponse(raw)
+    ? new Error(`${raw.status} ${raw.statusText}`.trim())
+    : toError(raw);
+  return <ErrorFallback error={error} />;
 }
 
 interface ErrorBoundaryProps {

--- a/cloud-ui/src/main.tsx
+++ b/cloud-ui/src/main.tsx
@@ -4,7 +4,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ThemedApp from './ThemedApp';
 import './index.css';
 
-const queryClient = new QueryClient();
+// Calm global fetching posture: the async-provisioning pages (VM / cluster /
+// VNet lists and detail pages) already poll explicitly with per-query
+// refetchInterval, so aggressive global refetch-on-focus and retry storms
+// only multiply dc-api load without making anything fresher. Per-query
+// options still override these defaults.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+      staleTime: 30_000,
+    },
+  },
+});
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/cloud-ui/src/pages/MembersPage.tsx
+++ b/cloud-ui/src/pages/MembersPage.tsx
@@ -53,6 +53,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { notifySessionExpiredOn401 } from '../api/client';
 import { useApi } from '../api/useApi';
 import { useConfirmDialog } from '../components/useConfirmDialog';
 import { EmptyState, ErrorState, LoadingState } from '../components/list/PageStates';
@@ -307,6 +308,9 @@ function RolePill({
  *  session regardless. Tenant/project keep using the typed client below. */
 async function scopedJson(path: string, init?: RequestInit): Promise<unknown> {
   const res = await fetch(path, { credentials: 'include', ...init });
+  // Raw fetch bypasses the typed client's middleware — apply the same
+  // session-expiry check so a 401 here also flips the app to signed-out.
+  notifySessionExpiredOn401(path, res.status);
   if (res.status === 204) return null;
   const text = await res.text();
   if (!res.ok) {

--- a/cloud-ui/src/router.tsx
+++ b/cloud-ui/src/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate, type RouteObject } from 'react-router-dom';
+import { RouteErrorFallback } from './components/ErrorBoundary';
 import RequireAuth from './auth/RequireAuth';
 import RequireTenants from './auth/RequireTenants';
 import RequireProject from './auth/RequireProject';
@@ -108,5 +109,9 @@ export function buildRouter({ isDark, onToggleDark }: BuildRouterArgs) {
     { path: '*', element: <Navigate to="/login" replace /> },
   ];
 
-  return createBrowserRouter(routes);
+  // Wrap everything in a pathless root route whose only job is the
+  // errorElement: data routers swallow render errors at the nearest route
+  // boundary and would otherwise show react-router's unthemed default error
+  // screen — this makes every route inherit the themed fallback instead.
+  return createBrowserRouter([{ errorElement: <RouteErrorFallback />, children: routes }]);
 }


### PR DESCRIPTION
## What this does

Part of the controlplane production-readiness hardening effort (epic: wso2-enterprise/wso2-datacenter-project#291). Three user-visible resilience gaps in cloud-ui, in plain English:

1. **A crash in any page no longer white-screens the console.** A render error used to blank the whole app. There are now two themed fallback layers: a route-level `errorElement` (data routers swallow render errors at the nearest route boundary, so this is the layer that actually fires for page crashes — without it users get react-router's unthemed "Unexpected Application Error!" screen) and an outer `ErrorBoundary` as last resort for the provider chain. Both show the error message with a Reload action.

2. **An expired session now signs you out instead of silently breaking every page.** When the `dcapi_session` cookie expires mid-use, every API call starts returning 401 and the UI previously just stopped working. An `openapi-fetch` middleware now notifies the auth layer on the first 401 from a session-scoped endpoint (once, via a module-level latch shared by all client instances), flipping the app to signed-out so the existing login flow takes over. `/v1/auth/*` is excluded to avoid loops, and MembersPage's raw-fetch resource-scope calls go through the same check so the behavior is uniform.

3. **Saner react-query defaults.** The query client ran on library defaults — refetch on window focus, three retries — multiplying load on an API whose provisioning pages already poll explicitly. Now `refetchOnWindowFocus: false`, `retry: 1`, `staleTime: 30s`; per-query polling is unaffected.

## Operational notes for reviewers

No API, backend, or deployment changes — this PR touches only `cloud-ui/src`. The retry/refetch tuning slightly reduces background request volume against dc-api; in-app mutations still refresh immediately via query invalidation.

## Self-review

Self-reviewed with the scanner gate (gitleaks, eslint, tsc — clean, scoped to this diff) plus the 8-lens adversarial LLM review. All confirmed findings were fixed in the last commit (the AuthProvider expiry wiring now has its own test; 17/17 tests pass). One trivial finding consciously skipped: the middleware derives the checked path from `VITE_API_BASE`, so a path-prefixed base URL (e.g. `https://host/api`) would bypass the 401 guard — that config is undocumented/unsupported and would already break the app's relative fetches, so it's noted here rather than papered over. Known pre-existing repo-wide Prettier drift was left untouched to keep this diff reviewable; only files created by this branch are formatter-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a polished, themed error screen with a reload action for unexpected app and route errors.
  * Improved session handling so the app can detect when a login expires and return users to a signed-out state.

* **Bug Fixes**
  * Session-expired notifications now fire reliably only once, even across multiple requests.
  * Added safer handling for API and route errors, including ignored auth-check requests and cleaner fallback behavior.

* **Performance**
  * Tuned default request behavior to reduce unnecessary refetching and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->