### PR TITLE
[Feature] Route NSG, route-table, and peering writes through the agent

### DIFF
--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -313,19 +313,42 @@ func (a *AgentBacked) Update(ctx context.Context, gvr schema.GroupVersionResourc
 	return a.apply(ctx, gvr, ns, obj)
 }
 
-// Apply deliberately IGNORES the caller's fieldManager argument and uses
-// a.fieldManager instead: the agent owns the field-manager identity for every op
-// it applies (it is fixed at the agent boundary, not chosen per call site), so the
-// caller's value is intentionally not forwarded. This is by design, not a bug.
-func (a *AgentBacked) Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, _ string, force bool) (*unstructured.Unstructured, error) {
-	return a.applyForce(ctx, gvr, ns, obj, force)
+// Apply FORWARDS the caller's fieldManager (falling back to a.fieldManager when
+// empty), unlike Create/Update which always use the accessor's own manager.
+//
+// The distinction is load-bearing for the kubeovn network-plumbing writes, the
+// seam's only direct Apply callers: they server-side apply MINIMAL single-field
+// objects (spec.vpcPeerings / spec.staticRoutes / spec.acls) under a DEDICATED
+// field manager per spec list. SSA replaces a manager's whole applied field set
+// on every apply, so two of those writes sharing one manager on the same object
+// would prune each other's list (and, on an agent-created object, the create
+// manifest's labels/namespaces) — verified against the apiserver's own
+// managedfields engine. Collapsing every apply to a.fieldManager here would
+// silently reintroduce exactly that wipe on the agent path, so the caller's
+// manager identity must survive the wire. The dc-agent executor honours the
+// wire's field_manager and only defaults when it is empty, matching this
+// fallback.
+func (a *AgentBacked) Apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error) {
+	// Routability guard FIRST (mirrors Get/List): refuse to issue an agent apply
+	// for a family that does not declare VerbApply, rather than performing a write
+	// the allow-set never granted. The Routed decision already gates this per
+	// call; the guard keeps the contract uniform for any direct AgentBacked use.
+	// Create/Update do NOT pass through here (they call applyWith directly), so
+	// families that route VerbCreate without VerbApply are unaffected.
+	if verbs, ok := RoutableVerbs(gvr); !ok || !verbs[VerbApply] {
+		return nil, fmt.Errorf("clusteraccess: apply of %s not routable: %w", gvr.String(), agentgw.ErrOpNotRoutable)
+	}
+	if fieldManager == "" {
+		fieldManager = a.fieldManager
+	}
+	return a.applyWith(ctx, gvr, ns, obj, fieldManager, force)
 }
 
 func (a *AgentBacked) apply(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	return a.applyForce(ctx, gvr, ns, obj, false)
+	return a.applyWith(ctx, gvr, ns, obj, a.fieldManager, false)
 }
 
-func (a *AgentBacked) applyForce(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, force bool) (*unstructured.Unstructured, error) {
+func (a *AgentBacked) applyWith(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error) {
 	// Verify the GVR is mappable (loud log on a programming error) even though
 	// the manifest carries apiVersion/kind — keeps the not-routable contract
 	// uniform across verbs.
@@ -341,7 +364,7 @@ func (a *AgentBacked) applyForce(ctx context.Context, gvr schema.GroupVersionRes
 	}
 	ctx, cancel := a.bound(ctx)
 	defer cancel()
-	res, err := a.sess.Apply(ctx, manifest, a.fieldManager, force)
+	res, err := a.sess.Apply(ctx, manifest, fieldManager, force)
 	if err != nil {
 		return nil, a.translateErr(err)
 	}

--- a/dc-api/internal/providers/clusteraccess/agent.go
+++ b/dc-api/internal/providers/clusteraccess/agent.go
@@ -134,7 +134,7 @@ func (a *AgentBacked) Get(ctx context.Context, gvr schema.GroupVersionResource, 
 	// routable family for Get — e.g. the pre-seeded virtualmachineinstances, which
 	// has no RouteVerbs. Refuse rather than issue a read the agent's SA may not be
 	// permitted to serve; the caller falls back to the direct path.
-	if verbs, ok := RoutableVerbs(gvr); !ok || !verbs[VerbGet] {
+	if !VerbIsRoutable(gvr, VerbGet) {
 		return nil, fmt.Errorf("clusteraccess: get of %s not routable: %w", gvr.String(), agentgw.ErrOpNotRoutable)
 	}
 	ref, err := a.ref(gvr, ns, name)
@@ -250,7 +250,7 @@ func (a *AgentBacked) List(ctx context.Context, gvr schema.GroupVersionResource,
 	// virtualmachineinstances, which is in the mapper as a superset but has no
 	// RouteVerbs. Refuse to route such a family to the agent rather than issuing a
 	// list the agent's SA may not be permitted (least-privilege) to serve.
-	if verbs, ok := RoutableVerbs(gvr); !ok || !verbs[VerbList] {
+	if !VerbIsRoutable(gvr, VerbList) {
 		return nil, fmt.Errorf("clusteraccess: list of %s not routable: %w", gvr.String(), agentgw.ErrOpNotRoutable)
 	}
 	apiVersion, kind, ok := a.mapper.GVK(gvr)
@@ -333,9 +333,13 @@ func (a *AgentBacked) Apply(ctx context.Context, gvr schema.GroupVersionResource
 	// for a family that does not declare VerbApply, rather than performing a write
 	// the allow-set never granted. The Routed decision already gates this per
 	// call; the guard keeps the contract uniform for any direct AgentBacked use.
-	// Create/Update do NOT pass through here (they call applyWith directly), so
-	// families that route VerbCreate without VerbApply are unaffected.
-	if verbs, ok := RoutableVerbs(gvr); !ok || !verbs[VerbApply] {
+	// Create/Update are DELIBERATELY exempt: they call applyWith directly, are
+	// gated per call by the Routed decision's verb allow-set (VerbCreate/
+	// VerbUpdate), always use the accessor's own fieldManager, and have no direct
+	// AgentBacked callers — so a family that routes VerbCreate without VerbApply
+	// (SA/RoleBinding, provider-network-style creates) still creates via SSA
+	// without needing VerbApply in its routable set.
+	if !VerbIsRoutable(gvr, VerbApply) {
 		return nil, fmt.Errorf("clusteraccess: apply of %s not routable: %w", gvr.String(), agentgw.ErrOpNotRoutable)
 	}
 	if fieldManager == "" {

--- a/dc-api/internal/providers/clusteraccess/capabilities.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities.go
@@ -91,7 +91,12 @@ var vmCapability = AgentCapability{
 }
 
 // The network families (NAD, Vpc, Subnet) are onboarded for the kubeovn CRD
-// CRUD slice (RouteVerbs/AgentVerbs filled below). vmImageCapability is onboarded
+// CRUD slice (RouteVerbs/AgentVerbs filled below); Vpc and Subnet additionally
+// route VerbApply for the network-plumbing spec writes (peering/static-route/ACL
+// lists — server-side applied as minimal single-field objects). The NAD family
+// does NOT route VerbApply: no kubeovn op applies a NAD, and the rule is to
+// never widen a family's RouteVerbs ahead of the verb actually being routed.
+// vmImageCapability is onboarded
 // for the read/list path AND image create (ListImages/resolveImage/CreateImage
 // routed via the agent — RouteVerbs={Get,List,Create}, AgentVerbs={get,list,
 // create,patch}; create+patch because SSA is the agent's create mechanism).
@@ -139,23 +144,30 @@ var (
 		AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
 	}
 	// vpcCapability onboards the Vpc (VNet) CRUD that CreateVNet/GetVNet/DeleteVNet
-	// route through the kubeovn seam.
+	// route through the kubeovn seam, plus the spec-write plumbing (VerbApply):
+	// the peering (spec.vpcPeerings) and static-route (spec.staticRoutes)
+	// read-modify-write ops server-side apply exactly one spec list each. VerbApply
+	// maps to the k8s "patch" verb the AgentVerbs grant already carried, so adding
+	// it to RouteVerbs changes routing only — the RBAC output is unchanged.
 	vpcCapability = AgentCapability{
 		GVR:        schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"},
 		APIVersion: "kubeovn.io/v1",
 		Kind:       "Vpc",
 		Namespaced: false,
-		RouteVerbs: []Verb{VerbGet, VerbCreate, VerbDelete},
+		RouteVerbs: []Verb{VerbGet, VerbCreate, VerbApply, VerbDelete},
 		AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
 	}
 	// subnetCapability onboards the Subnet CRUD that CreateSubnet/GetSubnet/
-	// DeleteSubnet route through the kubeovn seam.
+	// DeleteSubnet route through the kubeovn seam, plus the spec-write plumbing
+	// (VerbApply): the NSG ACL (spec.acls) read-modify-write ops server-side apply
+	// that one spec list. As with vpcCapability, VerbApply's k8s verb ("patch") was
+	// already in AgentVerbs, so the RBAC output is unchanged.
 	subnetCapability = AgentCapability{
 		GVR:        schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "subnets"},
 		APIVersion: "kubeovn.io/v1",
 		Kind:       "Subnet",
 		Namespaced: false,
-		RouteVerbs: []Verb{VerbGet, VerbCreate, VerbDelete},
+		RouteVerbs: []Verb{VerbGet, VerbCreate, VerbApply, VerbDelete},
 		AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
 	}
 	// serviceAccountCapability onboards the ServiceAccount create that
@@ -270,11 +282,13 @@ func buildDerived() {
 // UnionRouteVerbs returns the union of RouteVerbs across all capabilities — the
 // set of seam Verbs that MAY route to the agent for ANY family. With the VM,
 // network, image, and cloud-provider-SA families onboarded this equals
-// {VerbGet, VerbList, VerbCreate, VerbDelete} (List added when ListVMs/Images/
-// Networks were routed through the agent; the image family also routes VerbCreate
-// for CreateImage, but VM/NAD already contribute it so the union is unchanged).
-// The SA/RoleBinding/Secret families (F32) route only Get/Create, both already
-// in the union, so the union is unchanged by them too.
+// {VerbGet, VerbList, VerbCreate, VerbApply, VerbDelete} (List added when
+// ListVMs/Images/Networks were routed through the agent; Apply added when the
+// kubeovn network-plumbing spec writes — peering/static-route/ACL lists — were
+// routed through the Vpc/Subnet families; the image family also routes
+// VerbCreate for CreateImage, but VM/NAD already contribute it so the union is
+// unchanged). The SA/RoleBinding/Secret families (F32) route only Get/Create,
+// both already in the union, so the union is unchanged by them too.
 // agentDecision consults this for
 // membership, then gates reads vs writes by the per-family env toggles
 // (VerbList falls on the read side — see IsReadVerb).

--- a/dc-api/internal/providers/clusteraccess/capabilities.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities.go
@@ -156,6 +156,11 @@ var (
 		Namespaced: false,
 		RouteVerbs: []Verb{VerbGet, VerbCreate, VerbApply, VerbDelete},
 		AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
+		// Explicitly false (the zero value, spelled out like vmCapability's explicit
+		// true): the Vpc Get consumers are full-object read-modify-writes — the
+		// peering (spec.vpcPeerings) and static-route (spec.staticRoutes) ops read
+		// .spec to rebuild it — so the status-only degrade must never engage.
+		StatusFallbackOK: false,
 	}
 	// subnetCapability onboards the Subnet CRUD that CreateSubnet/GetSubnet/
 	// DeleteSubnet route through the kubeovn seam, plus the spec-write plumbing
@@ -169,6 +174,10 @@ var (
 		Namespaced: false,
 		RouteVerbs: []Verb{VerbGet, VerbCreate, VerbApply, VerbDelete},
 		AgentVerbs: []Verb{VerbGet, VerbList, VerbWatch, VerbCreate, VerbApply, VerbDelete},
+		// Explicitly false (mirrors vpcCapability): the Subnet Get consumers are
+		// full-object read-modify-writes — the NSG ACL (spec.acls) ops read .spec
+		// to rebuild it — so the status-only degrade must never engage.
+		StatusFallbackOK: false,
 	}
 	// serviceAccountCapability onboards the ServiceAccount create that
 	// EnsureCloudProviderSA routes through the harvester seam (the cloud-provider
@@ -321,6 +330,15 @@ func RoutableVerbs(gvr schema.GroupVersionResource) (map[Verb]bool, bool) {
 		out[v] = true
 	}
 	return out, true
+}
+
+// VerbIsRoutable reports whether a single verb is in a GVR's routable set — a
+// direct lookup with no defensive map copy, for the per-call guards on the hot
+// read/write paths (AgentBacked.Get/List/Apply). Callers that need the whole
+// set keep using RoutableVerbs.
+func VerbIsRoutable(gvr schema.GroupVersionResource, v Verb) bool {
+	buildDerived()
+	return derivedRouteSet[gvr][v]
 }
 
 // StatusFallbackOK reports whether AgentBacked.Get may degrade a routed read of

--- a/dc-api/internal/providers/clusteraccess/capabilities_test.go
+++ b/dc-api/internal/providers/clusteraccess/capabilities_test.go
@@ -7,13 +7,14 @@ import (
 )
 
 // TestUnionRouteVerbs pins the registry-derived routing allow-set to the current
-// onboarded set EXACTLY: {VerbGet, VerbList, VerbCreate, VerbDelete}. VerbList
-// joined the union when ListVMs/ListImages/ListNetworks were routed through the
-// agent. Any further drift (e.g. accidentally routing VerbApply/VerbUpdate) fails
-// here.
+// onboarded set EXACTLY: {VerbGet, VerbList, VerbCreate, VerbApply, VerbDelete}.
+// VerbList joined the union when ListVMs/ListImages/ListNetworks were routed
+// through the agent; VerbApply joined it when the kubeovn network-plumbing spec
+// writes (peering/static-route/ACL lists on Vpc/Subnet) were routed. Any further
+// drift (e.g. accidentally routing VerbUpdate) fails here.
 func TestUnionRouteVerbs(t *testing.T) {
 	got := UnionRouteVerbs()
-	want := map[Verb]bool{VerbGet: true, VerbList: true, VerbCreate: true, VerbDelete: true}
+	want := map[Verb]bool{VerbGet: true, VerbList: true, VerbCreate: true, VerbApply: true, VerbDelete: true}
 
 	if len(got) != len(want) {
 		t.Fatalf("union route verbs size = %d, want %d (got %v)", len(got), len(want), got)
@@ -24,37 +25,92 @@ func TestUnionRouteVerbs(t *testing.T) {
 		}
 	}
 	// Explicitly assert the verbs that must NOT be routable.
-	for _, v := range []Verb{VerbApply, VerbUpdate, VerbWatch} {
+	for _, v := range []Verb{VerbUpdate, VerbWatch} {
 		if got[v] {
 			t.Errorf("verb %v must NOT be routable but is in the union", v)
 		}
 	}
-	// VerbList classifies as a read for the reads/writes toggle split.
+	// VerbList classifies as a read for the reads/writes toggle split; VerbApply
+	// classifies as a write (it is gated by DCAPI_AGENT_ROUTE_WRITES).
 	if !IsReadVerb(VerbList) {
 		t.Error("VerbList must classify as a read verb")
 	}
+	if !IsWriteVerb(VerbApply) {
+		t.Error("VerbApply must classify as a write verb")
+	}
 }
 
-// TestRoutableVerbs_VMEqualsUnionToday is the Part A equivalence guard: with the
-// VM family the only onboarded routable family before Part B, the per-GVR
-// RoutableVerbs(virtualmachines) must equal the cross-family UnionRouteVerbs()
-// EXACTLY — proving the GVR-threading change is bit-for-bit identical for VM
-// routing decisions. (After Part B, networks declare the SAME {Get,Create,Delete}
-// so the union is unchanged; this guard still holds for the VM GVR.)
-func TestRoutableVerbs_VMEqualsUnionToday(t *testing.T) {
+// TestRoutableVerbs_VMPinnedSet pins the VM family's routable set to exactly
+// {Get, List, Create, Delete}. The VM family deliberately does NOT gain
+// VerbApply with the network-plumbing slice — no VM op applies a spec field, and
+// a family's RouteVerbs never widen ahead of the verb actually being routed.
+// (This replaces the earlier VM-equals-union guard, which held only while no
+// family routed a verb the VM family didn't.)
+func TestRoutableVerbs_VMPinnedSet(t *testing.T) {
 	vmGVR := schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}
 	got, ok := RoutableVerbs(vmGVR)
 	if !ok {
 		t.Fatal("virtualmachines must be an onboarded routable family")
 	}
-	want := UnionRouteVerbs()
-	if len(got) != len(want) {
-		t.Fatalf("RoutableVerbs(vm) size = %d, want %d (union)", len(got), len(want))
-	}
-	for v := range want {
+	for _, v := range []Verb{VerbGet, VerbList, VerbCreate, VerbDelete} {
 		if !got[v] {
-			t.Errorf("RoutableVerbs(vm) missing %v that the union has", v)
+			t.Errorf("RoutableVerbs(vm) missing %v", v)
 		}
+	}
+	for _, v := range []Verb{VerbApply, VerbUpdate, VerbWatch} {
+		if got[v] {
+			t.Errorf("RoutableVerbs(vm) must NOT include %v", v)
+		}
+	}
+	if len(got) != 4 {
+		t.Errorf("RoutableVerbs(vm) = %v, want exactly {Get, List, Create, Delete}", got)
+	}
+}
+
+// TestRoutableVerbs_NetworkPlumbingApply pins the network families' routable
+// sets after the plumbing slice: Vpc and Subnet route exactly
+// {Get, Create, Apply, Delete} — Apply carries the peering (spec.vpcPeerings),
+// static-route (spec.staticRoutes), and NSG ACL (spec.acls) server-side-apply
+// writes — while the NAD family does NOT route Apply (nothing applies a NAD;
+// RouteVerbs never widen ahead of the routed verb). Vpc/Subnet must also keep
+// StatusFallbackOK=false: their seam Gets feed read-modify-write ops that need
+// the full object (.spec/.metadata.labels), so degrading to a status-only read
+// on an old agent would silently hand them an empty spec.
+func TestRoutableVerbs_NetworkPlumbingApply(t *testing.T) {
+	vpcGVR := schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}
+	subnetGVR := schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "subnets"}
+	nadGVR := schema.GroupVersionResource{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}
+
+	for _, gvr := range []schema.GroupVersionResource{vpcGVR, subnetGVR} {
+		verbs, ok := RoutableVerbs(gvr)
+		if !ok {
+			t.Errorf("%s must be an onboarded routable family", gvr.Resource)
+			continue
+		}
+		for _, v := range []Verb{VerbGet, VerbCreate, VerbApply, VerbDelete} {
+			if !verbs[v] {
+				t.Errorf("%s must route %v, got %v", gvr.Resource, v, verbs)
+			}
+		}
+		for _, v := range []Verb{VerbList, VerbUpdate, VerbWatch} {
+			if verbs[v] {
+				t.Errorf("%s must NOT route %v", gvr.Resource, v)
+			}
+		}
+		if len(verbs) != 4 {
+			t.Errorf("%s routable set = %v, want exactly {Get, Create, Apply, Delete}", gvr.Resource, verbs)
+		}
+		if StatusFallbackOK(gvr) {
+			t.Errorf("%s must keep StatusFallbackOK=false — its Gets are full-object consumers", gvr.Resource)
+		}
+	}
+
+	nadVerbs, ok := RoutableVerbs(nadGVR)
+	if !ok {
+		t.Fatal("network-attachment-definitions must be an onboarded routable family")
+	}
+	if nadVerbs[VerbApply] {
+		t.Error("network-attachment-definitions must NOT route VerbApply — nothing routes a NAD apply in this slice")
 	}
 }
 

--- a/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
@@ -546,5 +546,79 @@ func TestRouted_NilDecisionAlwaysDirect(t *testing.T) {
 	}
 }
 
+// ── AgentBacked.Apply: fieldManager forwarding + routability guard ────────────
+
+// TestAgentBackedApply_ForwardsCallerFieldManager proves Apply sends the
+// CALLER's fieldManager (and force flag) on the wire — the load-bearing
+// property for the kubeovn network-plumbing writes, whose per-spec-list
+// managers must not be collapsed to the accessor default (SSA would then prune
+// sibling lists on the same object). An empty caller manager falls back to the
+// accessor's own default, matching the dc-agent executor's empty-default.
+func TestAgentBackedApply_ForwardsCallerFieldManager(t *testing.T) {
+	vpcGVR := schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}
+
+	var gotFM string
+	var gotForce bool
+	sess := &fakeSession{apply: func(_ json.RawMessage, fm string, force bool) (agentgw.ApplyResult, error) {
+		gotFM, gotForce = fm, force
+		return agentgw.ApplyResult{APIVersion: "kubeovn.io/v1", Kind: "Vpc", Name: "vnet-a"}, nil
+	}}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeovn.io/v1", "kind": "Vpc",
+		"metadata": map[string]interface{}{"name": "vnet-a"},
+		"spec":     map[string]interface{}{"staticRoutes": []interface{}{}},
+	}}
+
+	if _, err := a.Apply(context.Background(), vpcGVR, "", obj, "dc-api-kubeovn-staticroutes", true); err != nil {
+		t.Fatalf("Apply error: %v", err)
+	}
+	if gotFM != "dc-api-kubeovn-staticroutes" {
+		t.Errorf("wire fieldManager = %q, want the caller's %q", gotFM, "dc-api-kubeovn-staticroutes")
+	}
+	if !gotForce {
+		t.Error("wire force = false, want the caller's true")
+	}
+
+	// Empty caller manager → the accessor default.
+	if _, err := a.Apply(context.Background(), vpcGVR, "", obj, "", false); err != nil {
+		t.Fatalf("Apply (empty manager) error: %v", err)
+	}
+	if gotFM != "dc-api" {
+		t.Errorf("wire fieldManager = %q for an empty caller value, want the accessor default %q", gotFM, "dc-api")
+	}
+}
+
+// TestAgentBackedApply_NotRoutableFamilyRefused mirrors the Get/List guards: an
+// apply for a family that does not declare VerbApply (the NAD family — mapped,
+// routable for other verbs, but nothing applies a NAD) is refused with
+// ErrOpNotRoutable BEFORE any agent op is issued.
+func TestAgentBackedApply_NotRoutableFamilyRefused(t *testing.T) {
+	nadGVR := schema.GroupVersionResource{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}
+
+	applyCalled := false
+	sess := &fakeSession{apply: func(json.RawMessage, string, bool) (agentgw.ApplyResult, error) {
+		applyCalled = true
+		return agentgw.ApplyResult{}, nil
+	}}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "k8s.cni.cncf.io/v1", "kind": "NetworkAttachmentDefinition",
+		"metadata": map[string]interface{}{"name": "n", "namespace": "ns"},
+	}}
+	_, err := a.Apply(context.Background(), nadGVR, "ns", obj, "dc-api", true)
+	if err == nil {
+		t.Fatal("Apply on a non-Apply-routable family must error")
+	}
+	if !errors.Is(err, agentgw.ErrOpNotRoutable) {
+		t.Errorf("error = %v, want ErrOpNotRoutable", err)
+	}
+	if applyCalled {
+		t.Error("agent Apply was issued despite the routability guard")
+	}
+}
+
 // Compile-time assertion that the fake satisfies the neutral Session interface.
 var _ agentgw.Session = (*fakeSession)(nil)

--- a/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
+++ b/dc-api/internal/providers/clusteraccess/clusteraccess_test.go
@@ -581,12 +581,61 @@ func TestAgentBackedApply_ForwardsCallerFieldManager(t *testing.T) {
 		t.Error("wire force = false, want the caller's true")
 	}
 
-	// Empty caller manager → the accessor default.
+	// Empty caller manager → the accessor default; force=false forwards too.
 	if _, err := a.Apply(context.Background(), vpcGVR, "", obj, "", false); err != nil {
 		t.Fatalf("Apply (empty manager) error: %v", err)
 	}
 	if gotFM != "dc-api" {
 		t.Errorf("wire fieldManager = %q for an empty caller value, want the accessor default %q", gotFM, "dc-api")
+	}
+	if gotForce {
+		t.Error("wire force = true for the second call, want the caller's false")
+	}
+}
+
+// TestAgentBackedApply_SessionErrorTranslated mirrors the Get/List
+// agent-unavailable tests: a wire failure from Session.Apply must surface
+// through translateErr so callers' errors.Is(ErrAgentUnavailable) checks fire.
+func TestAgentBackedApply_SessionErrorTranslated(t *testing.T) {
+	vpcGVR := schema.GroupVersionResource{Group: "kubeovn.io", Version: "v1", Resource: "vpcs"}
+	sess := &fakeSession{apply: func(json.RawMessage, string, bool) (agentgw.ApplyResult, error) {
+		return agentgw.ApplyResult{}, agentgw.ErrAgentUnavailable
+	}}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeovn.io/v1", "kind": "Vpc",
+		"metadata": map[string]interface{}{"name": "vnet-a"},
+	}}
+	_, err := a.Apply(context.Background(), vpcGVR, "", obj, "dc-api-kubeovn-staticroutes", true)
+	if !errors.Is(err, agentgw.ErrAgentUnavailable) {
+		t.Errorf("error does not wrap ErrAgentUnavailable: %v", err)
+	}
+}
+
+// TestAgentBackedApply_UnmappedGVRNotRoutable mirrors the Get/List unmapped-GVR
+// tests: an apply for a GVR outside the capability registry is refused with
+// ErrOpNotRoutable before any agent op is issued (the routability guard fires
+// first — an unmapped GVR is by definition not Apply-routable).
+func TestAgentBackedApply_UnmappedGVRNotRoutable(t *testing.T) {
+	bogusGVR := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	applyCalled := false
+	sess := &fakeSession{apply: func(json.RawMessage, string, bool) (agentgw.ApplyResult, error) {
+		applyCalled = true
+		return agentgw.ApplyResult{}, nil
+	}}
+	a := NewAgentBacked(sess, "lk", "zone-1", "dc-api", DefaultGVKMapper(), zerolog.Nop())
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "example.com/v1", "kind": "Widget",
+		"metadata": map[string]interface{}{"name": "w"},
+	}}
+	_, err := a.Apply(context.Background(), bogusGVR, "", obj, "dc-api", true)
+	if !errors.Is(err, agentgw.ErrOpNotRoutable) {
+		t.Errorf("error = %v, want ErrOpNotRoutable", err)
+	}
+	if applyCalled {
+		t.Error("agent Apply was issued for an unmapped GVR")
 	}
 }
 

--- a/dc-api/internal/providers/kubeovn/client.go
+++ b/dc-api/internal/providers/kubeovn/client.go
@@ -1021,6 +1021,9 @@ func (c *Client) AssociateRouteTable(_ context.Context, _, _ string) error {
 
 // DisassociateRouteTable is a no-op for the same reason as AssociateRouteTable.
 func (c *Client) DisassociateRouteTable(_ context.Context, _, _ string) error {
+	// M2 stance (a): routes apply VPC-wide.  No backend change (and therefore no
+	// c.dynamic guard — a remote zone's disassociation is the same pure no-op).
+	// See AssociateRouteTable.
 	return nil
 }
 

--- a/dc-api/internal/providers/kubeovn/client.go
+++ b/dc-api/internal/providers/kubeovn/client.go
@@ -26,8 +26,11 @@
 //
 // When updating or deleting, the driver reads the current slice, filters out
 // entries whose comment/name starts with the owning tag, then writes the
-// remainder (plus any new entries) back via JSON MergePatch.  The parent CRD
-// is NEVER deleted just to change a field.
+// remainder (plus any new entries) back via a server-side apply of exactly
+// that one spec list (see the fieldManager* constants for the SSA ownership
+// model; SSA is also the only write mechanism a remote zone's dc-agent
+// exposes, which is what makes these writes routable).  The parent CRD is
+// NEVER deleted just to change a field.
 //
 // ── Phantom IP detection (gotcha 5) ─────────────────────────────────────────
 //
@@ -123,6 +126,51 @@ var (
 	namespacesGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 )
 
+// ── Server-side-apply field managers for the network-plumbing spec writes ─────
+//
+// The peering/static-route/ACL writes each server-side apply a MINIMAL object
+// carrying exactly ONE spec list (see minimalSpecListApply). Each list gets a
+// DEDICATED field manager because SSA replaces a manager's ENTIRE applied field
+// set on every apply: if the vpcPeerings and staticRoutes writes shared one
+// manager, applying one list would prune the other from the live Vpc — and on
+// an agent-provisioned Vpc (whose create is itself an SSA under the agent
+// default manager "dc-api") a shared manager would additionally prune the
+// create manifest's labels and spec.namespaces. One manager per list keeps
+// every apply's ownership disjoint: each write replaces exactly the list it
+// names and nothing else. Verified against the apiserver's own managedfields
+// engine (k8s.io/apimachinery/pkg/util/managedfields).
+//
+// force=true on every such apply because dc-api is the sole intended owner of
+// these user-intent spec lists — it must be able to take the fields over from
+// the create manager and from the legacy merge-patch managedFields entries on
+// pre-existing objects.
+const (
+	fieldManagerVpcPeerings  = "dc-api-kubeovn-vpcpeerings"
+	fieldManagerStaticRoutes = "dc-api-kubeovn-staticroutes"
+	fieldManagerSubnetACLs   = "dc-api-kubeovn-acls"
+)
+
+// minimalSpecListApply builds the minimal server-side-apply object for one
+// managed spec list: apiVersion/kind/metadata.name — no namespace, because both
+// Vpc and Subnet are cluster-scoped — and ONLY the one spec field being written.
+// The staticRoutes/vpcPeerings/acls lists are atomic on the KubeOVN CRDs, so
+// SSA-replacing a list through this minimal object is semantically the same
+// "set this field" write as the JSON MergePatch it replaces, while never
+// claiming ownership of any other field on the object.
+func minimalSpecListApply(apiVersion, kind, name, specField string, list []interface{}) *unstructured.Unstructured {
+	if list == nil {
+		// Preserve the merge-patch semantics of writing an explicit empty list
+		// (JSON-marshals to [] rather than null).
+		list = []interface{}{}
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": name},
+		"spec":       map[string]interface{}{specField: list},
+	}}
+}
+
 // Client is the KubeOVN NetworkProvider driver.
 type Client struct {
 	dynamic    dynamic.Interface
@@ -131,14 +179,18 @@ type Client struct {
 
 	// access is the per-zone cluster-access seam (mirrors harvester.Client.access).
 	// It defaults to clusteraccess.Direct over `dynamic` (byte-identical to the
-	// pre-seam behaviour) unless WithRoutedAccessor injects a Routed accessor. ONLY
-	// the CRD CRUD lifecycle of the three onboarded network families routes through
-	// it: CreateVNet/GetVNet/DeleteVNet (Vpc), the Subnet+NAD create/get/delete in
-	// CreateSubnet/GetSubnet/DeleteSubnet. Everything else (the stuck-finalizer
-	// recovery, ACL/route/peering patches, DNS ConfigMaps, NAT/CoreDNS plumbing,
-	// namespace/quota provisioning) still calls c.dynamic directly — those GVRs are
-	// not in the agent's mapper/RBAC and are deferred to a later slice. The seam
-	// never leaks an agent concept past the NetworkProvider interface.
+	// pre-seam behaviour) unless WithRoutedAccessor injects a Routed accessor.
+	// Routed through it: the CRD CRUD lifecycle of the three onboarded network
+	// families — CreateVNet/GetVNet/DeleteVNet (Vpc), the Subnet+NAD
+	// create/get/delete in CreateSubnet/GetSubnet/DeleteSubnet — AND the
+	// VPC/Subnet spec-write plumbing (peering spec.vpcPeerings, route-table
+	// spec.staticRoutes, NSG spec.acls), whose read-modify-write ops read via the
+	// seam Get and write via the seam Apply (SSA of a minimal single-field
+	// object). Still local-only on c.dynamic: the stuck-finalizer recovery, DNS
+	// zone/record ConfigMaps, NAT/per-VPC-CoreDNS plumbing, and namespace/quota
+	// provisioning — those GVRs/verbs are not in the agent's mapper/RBAC and are
+	// deferred to a later slice. The seam never leaks an agent concept past the
+	// NetworkProvider interface.
 	access clusteraccess.Accessor
 
 	// vpcDnsAvailable is set to true at construction time if the
@@ -157,38 +209,44 @@ type Client struct {
 	// remoteRegion/remoteZone are non-empty ONLY for a credential-free REMOTE
 	// client built by NewRemoteClient. For such a client c.dynamic is nil but the
 	// access seam is an agent-only Routed accessor, so the ONBOARDED CRD lifecycle
-	// (VPC/Subnet/NAD create/get/delete) DOES route through the zone's agent —
-	// every such method runs its k8s I/O through c.access, never c.dynamic. Only
-	// the VPC network plumbing (NAT/per-VPC DNS/CoreDNS, ACL/route/peering patches,
-	// NSG, namespace/quota provisioning, stuck-finalizer recovery) remains
-	// local-only for a remote zone and returns a clear localOnlyErr instead of
-	// dereferencing the nil dynamic client. Empty for the LOCAL client → today's
-	// behaviour. This is the documented boundary of the remote-zone build: the CRD
-	// lifecycle reaches the agent; the plumbing is deferred behind an explicit
+	// (VPC/Subnet/NAD create/get/delete) AND the VPC/Subnet spec-write plumbing
+	// (peering, static routes, ACLs) DO route through the zone's agent — every
+	// such method runs its k8s I/O through c.access, never c.dynamic. Only the
+	// remaining plumbing (NAT, per-VPC DNS/CoreDNS, DNS zone/record ConfigMaps,
+	// namespace/quota provisioning) is local-only for a remote zone and returns a
+	// clear localOnlyErr instead of dereferencing the nil dynamic client; the
+	// best-effort local cleanups (stuck-finalizer recovery, the pre-delete ACL
+	// clear) are silently skipped, with the agent-side delete owning finalizer
+	// convergence. Empty for the LOCAL client → today's behaviour. This is the
+	// documented boundary of the remote-zone build: the CRD lifecycle and the
+	// spec-write plumbing reach the agent; the rest is deferred behind an explicit
 	// error rather than silently misrouting to the local cluster.
 	remoteRegion, remoteZone string
 }
 
-// localOnlyErr is returned by a REMOTE client's PLUMBING methods (NAT, per-VPC
-// DNS/CoreDNS, ACL/route/peering patches, NSG, namespace/quota provisioning,
-// stuck-finalizer recovery). dc-api holds no kubeconfig for a remote zone and
-// those operations lean on c.dynamic for GVRs that the agent's mapper/RBAC do
-// not onboard. The onboarded CRD lifecycle (VPC/Subnet/NAD create/get/delete)
-// does NOT use this — it routes through c.access to the zone's agent.
+// localOnlyErr is returned by a REMOTE client's remaining local-only PLUMBING
+// methods (NAT, per-VPC DNS/CoreDNS, DNS zone/record ConfigMaps, namespace/
+// quota provisioning). dc-api holds no kubeconfig for a remote zone and those
+// operations lean on c.dynamic for GVRs that the agent's mapper/RBAC do not
+// onboard. The onboarded CRD lifecycle (VPC/Subnet/NAD create/get/delete) and
+// the VPC/Subnet spec-write plumbing (peering, static routes, ACLs) do NOT use
+// this — they route through c.access to the zone's agent.
 func (c *Client) localOnlyErr(op string) error {
 	return fmt.Errorf(
-		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct KubeOVN credentials there and the VPC network plumbing (NAT/DNS/ACL/route/peering) is local-only for now (the VPC/Subnet/NAD CRD lifecycle does route through the zone's agent)",
+		"%s is not supported for remote zone %s/%s yet: dc-api holds no direct KubeOVN credentials there and this plumbing (NAT/per-VPC DNS) is local-only for now (the VPC/Subnet/NAD CRD lifecycle and the peering/route/ACL spec writes do route through the zone's agent)",
 		op, c.remoteRegion, c.remoteZone)
 }
 
 // NewRemoteClient builds a credential-free KubeOVN client for a REMOTE zone. It
 // has NO kubeconfig and NO dynamic client; the onboarded CRD lifecycle
 // (CreateVNet/GetVNet/DeleteVNet, CreateSubnet/GetSubnet/DeleteSubnet and the
-// NAD create/get/delete inside them) runs through the supplied agent-only
+// NAD create/get/delete inside them) AND the VPC/Subnet spec-write plumbing
+// (peering, route tables, NSG ACLs) run through the supplied agent-only
 // Accessor (a clusteraccess.Routed whose Direct fallback is a clusteraccess.
 // NoCreds, so a missing agent fails clearly rather than hitting the local
-// cluster). The VPC network-plumbing methods return localOnlyErr. region/zone
-// are carried only for clear error messages. Mirrors harvester.NewRemoteClient.
+// cluster). The remaining plumbing methods (NAT, per-VPC DNS) return
+// localOnlyErr. region/zone are carried only for clear error messages. Mirrors
+// harvester.NewRemoteClient.
 func NewRemoteClient(access clusteraccess.Accessor, region, zone string) *Client {
 	return &Client{
 		// dynamic + restConfig deliberately nil — guarded on plumbing methods.
@@ -618,10 +676,11 @@ func (c *Client) DeleteSubnet(ctx context.Context, backendUID string) error {
 		}
 	}
 
-	// Clear ACLs before deleting to avoid finalizer deadlock (gotcha 4). This is a
-	// local-only plumbing patch (ACL Patch on the Subnet is not a routed verb), so
-	// skip it on a remote client (c.dynamic == nil) — the agent-side delete of an
-	// onboarded Subnet handles its own finalizers.
+	// Clear ACLs before deleting to avoid finalizer deadlock (gotcha 4). The ACL
+	// write itself is seam-routable now (patchSubnetACLs), but this pre-delete
+	// clear stays a deliberately LOCAL-ONLY best-effort cleanup: a remote client
+	// (c.dynamic == nil) skips it, and the agent-side delete of an onboarded
+	// Subnet owns its own finalizer convergence in that zone.
 	if c.dynamic != nil {
 		if err := c.patchSubnetACLs(ctx, backendUID, []interface{}{}); err != nil {
 			log.Warn().Err(err).Str("subnet", backendUID).Msg("kubeovn: failed to clear ACLs before subnet delete; proceeding anyway")
@@ -848,9 +907,9 @@ func (c *Client) forceRemoveNADFinalizerIfStuck(ctx context.Context, ns, nadName
 //
 // This method is synchronous (no reconciler loop needed).
 func (c *Client) CreateRouteTable(ctx context.Context, vnetUID string, spec models.RouteTableSpec) (*models.RouteTableResource, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("CreateRouteTable")
-	}
+	// No c.dynamic guard: this method performs no k8s I/O itself (the routes are
+	// written by UpdateRouteTableRoutes, whose read+write both run through
+	// c.access on the onboarded vpcGVR), so it works for a remote zone too.
 	if len(spec.Routes) == 0 {
 		// Nothing to write to the VPC — return immediately.
 		return &models.RouteTableResource{
@@ -890,18 +949,19 @@ func (c *Client) CreateRouteTable(ctx context.Context, vnetUID string, spec mode
 //  1. Read current Vpc.spec.staticRoutes.
 //  2. Remove all entries whose routetable-tag matches <routeTableUUID>.
 //  3. Append new entries tagged with <routeTableUUID>.
-//  4. JSON MergePatch the Vpc — never delete the CRD (gotcha 4).
+//  4. Server-side apply Vpc.spec.staticRoutes — never delete the CRD (gotcha 4).
 func (c *Client) UpdateRouteTableRoutes(ctx context.Context, backendUID string, routes []models.RouteRule) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("UpdateRouteTableRoutes")
-	}
+	// No c.dynamic guard: the read (c.access.Get) and the write
+	// (patchVPCStaticRoutes → c.access.Apply) both run through the seam on the
+	// onboarded vpcGVR, so a remote client routes them to the zone's agent.
 	vnetUID, rtUUID, err := parseRouteTableUID(backendUID)
 	if err != nil {
 		return fmt.Errorf("update route table routes: %w", err)
 	}
 
-	// Fetch current VPC.
-	vpc, err := c.dynamic.Resource(vpcGVR).Get(ctx, vnetUID, metav1.GetOptions{})
+	// Fetch current VPC. Cluster-scoped → ns="". Routes via the agent under
+	// DCAPI_AGENT_ROUTE_READS + a live agent; otherwise the byte-identical Direct Get.
+	vpc, err := c.access.Get(ctx, vpcGVR, "", vnetUID, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("update route table routes: fetch vpc %q: %w", vnetUID, err)
 	}
@@ -926,15 +986,14 @@ func (c *Client) UpdateRouteTableRoutes(ctx context.Context, backendUID string, 
 // backendUID format: "<vnetUID>/<routeTableUUID>" (same as UpdateRouteTableRoutes).
 // The Vpc CRD itself is NOT deleted.
 func (c *Client) DeleteRouteTable(ctx context.Context, backendUID string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("DeleteRouteTable")
-	}
+	// No c.dynamic guard: read and write both run through the seam (see
+	// UpdateRouteTableRoutes), so a remote client routes them to the zone's agent.
 	vnetUID, rtUUID, err := parseRouteTableUID(backendUID)
 	if err != nil {
 		return fmt.Errorf("delete route table: %w", err)
 	}
 
-	vpc, err := c.dynamic.Resource(vpcGVR).Get(ctx, vnetUID, metav1.GetOptions{})
+	vpc, err := c.access.Get(ctx, vpcGVR, "", vnetUID, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil // VPC already gone — nothing to clean
@@ -954,19 +1013,14 @@ func (c *Client) DeleteRouteTable(ctx context.Context, backendUID string) error 
 // DC-API DB only.  When OVN policy routes land in M2.5 (issue #152), this
 // method will patch Vpc.spec.policyRoutes.
 func (c *Client) AssociateRouteTable(_ context.Context, _, _ string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("AssociateRouteTable")
-	}
-	// M2 stance (a): routes apply VPC-wide.  No backend change.
+	// M2 stance (a): routes apply VPC-wide.  No backend change (and therefore no
+	// c.dynamic guard — a remote zone's association is the same pure no-op).
 	// See m2-network-api-design.md § 13 Decision 3.
 	return nil
 }
 
 // DisassociateRouteTable is a no-op for the same reason as AssociateRouteTable.
 func (c *Client) DisassociateRouteTable(_ context.Context, _, _ string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("DisassociateRouteTable")
-	}
 	return nil
 }
 
@@ -979,9 +1033,8 @@ func (c *Client) DisassociateRouteTable(_ context.Context, _, _ string) error {
 // itself (no KubeOVN CRD created here).  Rule application happens at attach
 // time.
 func (c *Client) CreateNSG(_ context.Context, _, _ string, spec models.NSGSpec) (*models.NSGResource, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("CreateNSG")
-	}
+	// No c.dynamic guard: no k8s I/O happens here (rules are written at
+	// attach/update time through the seam), so a remote zone works identically.
 	// No KubeOVN object created.  BackendUID = "" (will be populated when
 	// attached to a subnet).  The handler generates the UUID and stores it.
 	return &models.NSGResource{
@@ -1009,9 +1062,10 @@ func (c *Client) CreateNSG(_ context.Context, _, _ string, spec models.NSGSpec) 
 // If no subnets are attached (no "|" separator), the method is a no-op
 // (rules are buffered in the DB only).
 func (c *Client) UpdateNSGRules(ctx context.Context, backendUID string, rules []models.NSGRule) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("UpdateNSGRules")
-	}
+	// No c.dynamic guard: the per-subnet read-modify-write
+	// (replaceNSGACLsOnSubnet → c.access.Get + patchSubnetACLs → c.access.Apply)
+	// runs through the seam on the onboarded subnetGVR, so a remote client
+	// routes it to the zone's agent.
 	nsgUID, subnetUIDs := parseNSGBackendUID(backendUID)
 	if len(subnetUIDs) == 0 {
 		// NSG not yet attached — rules are buffered in DC-API DB.
@@ -1031,11 +1085,9 @@ func (c *Client) UpdateNSGRules(ctx context.Context, backendUID string, rules []
 // DeleteNSG removes the NSG.  The caller (handler) guarantees no attachments
 // exist (returns 409 if attachments remain).  Nothing to do at the backend.
 func (c *Client) DeleteNSG(_ context.Context, _ string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("DeleteNSG")
-	}
-	// No backend CRD exists for an unattached NSG.  Attached NSGs must be
-	// detached (which patches the Subnet CRD) before calling DeleteNSG.
+	// No backend CRD exists for an unattached NSG (and thus no c.dynamic guard —
+	// nothing to do in any zone).  Attached NSGs must be detached (which writes
+	// the Subnet CRD through the seam) before calling DeleteNSG.
 	return nil
 }
 
@@ -1046,15 +1098,14 @@ func (c *Client) DeleteNSG(_ context.Context, _ string) error {
 //  1. Read current Subnet.spec.acls.
 //  2. Remove any existing entries with name prefix "nsg-<nsgUID>/".
 //  3. Append new entries for each rule.
-//  4. MergePatch Subnet.spec.acls.
+//  4. Server-side apply Subnet.spec.acls.
 //
 // Rule translation: DC-API NSGRule → KubeOVN ACL entry.
 // nsgUID is the NSG UUID (no "nsg-" prefix — the driver adds it internally).
 // subnetUID is the KubeOVN Subnet CRD name.
 func (c *Client) AttachNSGToSubnet(ctx context.Context, nsgUID, subnetUID string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("AttachNSGToSubnet")
-	}
+	// No c.dynamic guard: the existence check below is a seam Get on the
+	// onboarded subnetGVR, so a remote client routes it to the zone's agent.
 	// For attach with no rules provided, we fetch the NSG rules from the
 	// backendUID.  However, this interface only gives us nsgUID and subnetUID.
 	// The caller should ensure UpdateNSGRules is called after attach to push
@@ -1067,7 +1118,8 @@ func (c *Client) AttachNSGToSubnet(ctx context.Context, nsgUID, subnetUID string
 	//   2. UpdateNSGRules(backendUID, rules)    — writes the ACLs
 	//
 	// For attach we do a no-op read-then-verify to ensure the subnet exists.
-	_, err := c.dynamic.Resource(subnetGVR).Get(ctx, subnetUID, metav1.GetOptions{})
+	// Cluster-scoped → ns="".
+	_, err := c.access.Get(ctx, subnetGVR, "", subnetUID, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("attach nsg: get subnet %q: %w", subnetUID, err)
 	}
@@ -1075,14 +1127,13 @@ func (c *Client) AttachNSGToSubnet(ctx context.Context, nsgUID, subnetUID string
 	return nil
 }
 
-// DetachNSGFromSubnet removes the NSG's ACL entries from the Subnet CRD
-// via PATCH.  The Subnet CRD is NOT deleted (gotcha 4).
+// DetachNSGFromSubnet removes the NSG's ACL entries from the Subnet CRD via a
+// server-side apply of spec.acls.  The Subnet CRD is NOT deleted (gotcha 4).
 func (c *Client) DetachNSGFromSubnet(ctx context.Context, nsgUID, subnetUID string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("DetachNSGFromSubnet")
-	}
-	// Read current ACLs.
-	subnet, err := c.dynamic.Resource(subnetGVR).Get(ctx, subnetUID, metav1.GetOptions{})
+	// No c.dynamic guard: read and write both run through the seam on the
+	// onboarded subnetGVR, so a remote client routes them to the zone's agent.
+	// Read current ACLs. Cluster-scoped → ns="".
+	subnet, err := c.access.Get(ctx, subnetGVR, "", subnetUID, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil // subnet already gone — nothing to do
@@ -1122,9 +1173,10 @@ func (c *Client) DetachNSGFromSubnet(ctx context.Context, nsgUID, subnetUID stri
 // Reciprocal staticRoutes addition keeps the same per-peering tag so they
 // can be cleanly removed on delete.
 func (c *Client) CreatePeering(ctx context.Context, vnetUID, peerVnetUID string, spec models.PeeringSpec) (*models.PeeringResource, error) {
-	if c.dynamic == nil {
-		return nil, c.localOnlyErr("CreatePeering")
-	}
+	// No c.dynamic guard: every k8s op below (the vpcPeerings and staticRoutes
+	// read-modify-writes, and the legacy subnet-CIDR fallback List) runs through
+	// c.access, so a remote client routes them to the zone's agent (the fallback
+	// List fails closed on a remote zone — see subnetCIDRsForVPC).
 	backendUID := vnetUID + "/" + peerVnetUID
 
 	// F6: the peering handler allocates the transit /24 from a DB-backed
@@ -1195,9 +1247,8 @@ func (c *Client) CreatePeering(ctx context.Context, vnetUID, peerVnetUID string,
 // Both are required to identify which staticRoutes to remove now that routes
 // are in the default (empty) routeTable and cannot be filtered by a named tag.
 func (c *Client) DeletePeering(ctx context.Context, backendUID string, localCIDRs, peerCIDRs []string) error {
-	if c.dynamic == nil {
-		return c.localOnlyErr("DeletePeering")
-	}
+	// No c.dynamic guard: the vpcPeerings and staticRoutes read-modify-writes all
+	// run through the seam, so a remote client routes them to the zone's agent.
 	parts := strings.SplitN(backendUID, "/", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("delete peering: backendUID %q must be \"<vnetA>/<vnetB>\"", backendUID)
@@ -1228,7 +1279,13 @@ func (c *Client) DeletePeering(ctx context.Context, backendUID string, localCIDR
 }
 
 // appendVpcPeering reads the Vpc, upserts a {remoteVpc, localConnectIP} entry
-// in spec.vpcPeerings, and MergePatches the result.
+// in spec.vpcPeerings, and server-side applies the result back as a minimal
+// single-field object (spec.vpcPeerings is atomic on the Vpc CRD, so the SSA
+// replace is the same "set this list" write the old JSON MergePatch performed —
+// and SSA is the only write mechanism the zone's dc-agent exposes, which is
+// what makes this op routable to a remote zone). Read and write both run
+// through c.access. force=true + a dedicated field manager: see the
+// fieldManager* constants.
 //
 // localConnectIP is a /24 from the 100.64.0.0/10 range (RFC 6598 Shared
 // Address Space — safe for transit links). Both sides of the peering pick
@@ -1242,7 +1299,7 @@ func (c *Client) DeletePeering(ctx context.Context, backendUID string, localCIDR
 //
 // If an entry for peerVpcName already exists it is REPLACED (idempotent).
 func (c *Client) appendVpcPeering(ctx context.Context, vpcName, peerVpcName, transitNetwork string) error {
-	obj, err := c.dynamic.Resource(vpcGVR).Get(ctx, vpcName, metav1.GetOptions{})
+	obj, err := c.access.Get(ctx, vpcGVR, "", vpcName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("get vpc %s: %w", vpcName, err)
 	}
@@ -1269,12 +1326,9 @@ func (c *Client) appendVpcPeering(ctx context.Context, vpcName, peerVpcName, tra
 		existing = append(existing, newEntry)
 	}
 
-	patch := map[string]interface{}{"spec": map[string]interface{}{"vpcPeerings": existing}}
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("marshal vpcPeerings patch: %w", err)
-	}
-	_, err = c.dynamic.Resource(vpcGVR).Patch(ctx, vpcName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = c.access.Apply(ctx, vpcGVR, "",
+		minimalSpecListApply("kubeovn.io/v1", "Vpc", vpcName, "vpcPeerings", existing),
+		fieldManagerVpcPeerings, true)
 	return err
 }
 
@@ -1337,10 +1391,11 @@ func transitLocalIPAddr(vpcName, peerVpcName, transitNetwork string) string {
 	return cidr
 }
 
-// removeVpcPeering reads the Vpc and MergePatches spec.vpcPeerings with the
-// matching entry filtered out. Idempotent.
+// removeVpcPeering reads the Vpc and server-side applies spec.vpcPeerings with
+// the matching entry filtered out (same minimal-object SSA as appendVpcPeering
+// — the semantics of the old MergePatch, routable through the seam). Idempotent.
 func (c *Client) removeVpcPeering(ctx context.Context, vpcName, peerVpcName string) error {
-	obj, err := c.dynamic.Resource(vpcGVR).Get(ctx, vpcName, metav1.GetOptions{})
+	obj, err := c.access.Get(ctx, vpcGVR, "", vpcName, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
@@ -1357,12 +1412,9 @@ func (c *Client) removeVpcPeering(ctx context.Context, vpcName, peerVpcName stri
 		}
 		filtered = append(filtered, e)
 	}
-	patch := map[string]interface{}{"spec": map[string]interface{}{"vpcPeerings": filtered}}
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("marshal vpcPeerings patch: %w", err)
-	}
-	_, err = c.dynamic.Resource(vpcGVR).Patch(ctx, vpcName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = c.access.Apply(ctx, vpcGVR, "",
+		minimalSpecListApply("kubeovn.io/v1", "Vpc", vpcName, "vpcPeerings", filtered),
+		fieldManagerVpcPeerings, true)
 	return err
 }
 
@@ -1500,37 +1552,31 @@ func (c *Client) waitForNADReady(ctx context.Context, ns, nadName string) error 
 	}
 }
 
-// patchVPCStaticRoutes replaces Vpc.spec.staticRoutes via JSON MergePatch.
-// This is the core of the patch-not-delete pattern (gotcha 4).
+// patchVPCStaticRoutes replaces Vpc.spec.staticRoutes via a server-side apply
+// of a minimal single-field object through the seam (spec.staticRoutes is
+// atomic on the Vpc CRD, so the SSA replace is the same "set this list" write
+// as the old JSON MergePatch — and SSA is the only write mechanism the zone's
+// dc-agent exposes, which is what makes this op routable to a remote zone).
+// This is the core of the patch-not-delete pattern (gotcha 4). force=true + a
+// dedicated field manager: see the fieldManager* constants.
 func (c *Client) patchVPCStaticRoutes(ctx context.Context, vpcName string, routes []interface{}) error {
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"staticRoutes": routes,
-		},
-	}
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("marshal staticRoutes patch: %w", err)
-	}
-	_, err = c.dynamic.Resource(vpcGVR).Patch(ctx, vpcName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err := c.access.Apply(ctx, vpcGVR, "",
+		minimalSpecListApply("kubeovn.io/v1", "Vpc", vpcName, "staticRoutes", routes),
+		fieldManagerStaticRoutes, true)
 	if err != nil {
 		return fmt.Errorf("patch vpc %q staticRoutes: %w", vpcName, err)
 	}
 	return nil
 }
 
-// patchSubnetACLs replaces Subnet.spec.acls via JSON MergePatch.
+// patchSubnetACLs replaces Subnet.spec.acls via a server-side apply of a
+// minimal single-field object through the seam (same rationale as
+// patchVPCStaticRoutes: the list is atomic, so the SSA replace matches the old
+// MergePatch semantics while being agent-routable).
 func (c *Client) patchSubnetACLs(ctx context.Context, subnetName string, acls []interface{}) error {
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"acls": acls,
-		},
-	}
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("marshal acls patch: %w", err)
-	}
-	_, err = c.dynamic.Resource(subnetGVR).Patch(ctx, subnetName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err := c.access.Apply(ctx, subnetGVR, "",
+		minimalSpecListApply("kubeovn.io/v1", "Subnet", subnetName, "acls", acls),
+		fieldManagerSubnetACLs, true)
 	if err != nil {
 		return fmt.Errorf("patch subnet %q acls: %w", subnetName, err)
 	}
@@ -1538,9 +1584,10 @@ func (c *Client) patchSubnetACLs(ctx context.Context, subnetName string, acls []
 }
 
 // replaceNSGACLsOnSubnet reads the current ACL list, removes entries owned
-// by nsgUID, appends the new aclEntries, then patches the Subnet.
+// by nsgUID, appends the new aclEntries, then server-side applies the Subnet's
+// spec.acls. Read and write both run through the seam (agent-routable).
 func (c *Client) replaceNSGACLsOnSubnet(ctx context.Context, subnetUID, nsgUID string, newEntries []interface{}) error {
-	subnet, err := c.dynamic.Resource(subnetGVR).Get(ctx, subnetUID, metav1.GetOptions{})
+	subnet, err := c.access.Get(ctx, subnetGVR, "", subnetUID, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("fetch subnet %q: %w", subnetUID, err)
 	}
@@ -1572,7 +1619,7 @@ func (c *Client) replaceNSGACLsOnSubnet(ctx context.Context, subnetUID, nsgUID s
 // policy=="policyDst" && nextHopIP starts with "100.64.") — see
 // removePeeringRoutes.
 func (c *Client) appendPeeringRoutes(ctx context.Context, vpcName string, cidrs []string, peerNextHopIP string) error {
-	vpc, err := c.dynamic.Resource(vpcGVR).Get(ctx, vpcName, metav1.GetOptions{})
+	vpc, err := c.access.Get(ctx, vpcGVR, "", vpcName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("fetch vpc %q: %w", vpcName, err)
 	}
@@ -1629,7 +1676,7 @@ func (c *Client) appendPeeringRoutes(ctx context.Context, vpcName string, cidrs 
 // peerCIDRs must be the address-space of the VNet whose routes we are
 // removing from vpcName (i.e. the remote VNet's CIDRs).
 func (c *Client) removePeeringRoutes(ctx context.Context, vpcName string, peerCIDRs []string) error {
-	vpc, err := c.dynamic.Resource(vpcGVR).Get(ctx, vpcName, metav1.GetOptions{})
+	vpc, err := c.access.Get(ctx, vpcGVR, "", vpcName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -1669,9 +1716,15 @@ func (c *Client) removePeeringRoutes(ctx context.Context, vpcName string, peerCI
 }
 
 // subnetCIDRsForVPC returns the cidrBlock for every Subnet whose spec.vpc
-// matches vpcName.
+// matches vpcName. It is the LEGACY fallback for peerings created without an
+// address-space in the spec. The List runs through the seam, but VerbList is
+// deliberately NOT in the subnet family's RouteVerbs (never widen ahead of the
+// routed verb — nothing modern calls this): on a local client the decision
+// declines and the List is the byte-identical Direct read; on a remote client
+// it fails CLOSED with the NoCreds error instead of dereferencing the nil
+// dynamic client (remote peerings always carry the address-space).
 func (c *Client) subnetCIDRsForVPC(ctx context.Context, vpcName string) ([]string, error) {
-	list, err := c.dynamic.Resource(subnetGVR).List(ctx, metav1.ListOptions{
+	list, err := c.access.List(ctx, subnetGVR, "", metav1.ListOptions{
 		LabelSelector: "dc-api/parent-vnet=" + vpcName,
 	})
 	if err != nil {

--- a/dc-api/internal/providers/kubeovn/network_plumbing_seam_test.go
+++ b/dc-api/internal/providers/kubeovn/network_plumbing_seam_test.go
@@ -1,0 +1,714 @@
+package kubeovn
+
+// network_plumbing_seam_test.go proves the VPC/Subnet spec-write plumbing slice
+// of the credential-locality work: the peering (Vpc.spec.vpcPeerings),
+// route-table (Vpc.spec.staticRoutes), and NSG ACL (Subnet.spec.acls)
+// read-modify-write ops run through the cluster-access seam — reads via
+// c.access.Get, writes via c.access.Apply of a MINIMAL single-field object —
+// so they work for a REMOTE (agent-only) zone while the local Direct path keeps
+// the exact list semantics of the old JSON MergePatch.
+//
+// Coverage:
+//   - Each of the four converted write sites (appendVpcPeering, removeVpcPeering,
+//     patchVPCStaticRoutes, patchSubnetACLs) issues ONE seam Apply with the right
+//     GVR/name, a minimal apply object (apiVersion, kind, metadata.name, exactly
+//     the one spec list — no status, no other spec fields, no namespace: both
+//     CRDs are cluster-scoped), the dedicated per-list field manager, force=true,
+//     and list CONTENT equal to what the old merge patch would have written.
+//   - The public read-modify-write ops (UpdateRouteTableRoutes, UpdateNSGRules,
+//     DetachNSGFromSubnet) read through the seam Get and write the filter+build
+//     result of the SAME helpers the merge-patch path used.
+//   - Routed toggle: with the decision allowing {Get, Apply} the ops hit the
+//     agent accessor and never Direct; with the decision declining they hit
+//     Direct and never the agent.
+//   - Remote client (NewRemoteClient, c.dynamic == nil): the peering/route/ACL
+//     ops work purely through the seam — the regression guard against
+//     re-introducing a c.dynamic dereference (which would panic) or a
+//     localOnlyErr guard (which would re-open the remote gap). The legacy
+//     subnet-CIDR fallback List stays fail-closed (NoCreds) on a remote zone.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/wso2/dc-api/internal/models"
+	"github.com/wso2/dc-api/internal/providers/clusteraccess"
+)
+
+// ── A recording accessor serving canned objects and capturing applies ─────────
+
+type recordedApply struct {
+	gvr          schema.GroupVersionResource
+	ns           string
+	obj          *unstructured.Unstructured
+	fieldManager string
+	force        bool
+}
+
+// plumbRecordingAccessor serves programmable objects from Get (keyed by name)
+// and records every Apply with its full argument set. List returns an empty
+// list unless listErr is set. Create/Update/Delete satisfy the interface inertly
+// — the plumbing ops under test never call them.
+type plumbRecordingAccessor struct {
+	mu sync.Mutex
+
+	// objects maps name → the object Get returns. A missing name returns a
+	// k8s NotFound, matching the seam contract on both Direct and AgentBacked.
+	objects map[string]*unstructured.Unstructured
+
+	getCalls []schema.GroupVersionResource
+	applies  []recordedApply
+
+	listCalls int
+	listErr   error
+}
+
+var _ clusteraccess.Accessor = (*plumbRecordingAccessor)(nil)
+
+func (a *plumbRecordingAccessor) Get(_ context.Context, gvr schema.GroupVersionResource, _, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.getCalls = append(a.getCalls, gvr)
+	obj, ok := a.objects[name]
+	if !ok {
+		return nil, k8serrors.NewNotFound(gvr.GroupResource(), name)
+	}
+	return obj.DeepCopy(), nil
+}
+
+func (a *plumbRecordingAccessor) List(_ context.Context, _ schema.GroupVersionResource, _ string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.listCalls++
+	if a.listErr != nil {
+		return nil, a.listErr
+	}
+	return &unstructured.UnstructuredList{}, nil
+}
+
+func (a *plumbRecordingAccessor) Create(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ metav1.CreateOptions) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *plumbRecordingAccessor) Apply(_ context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	// Store the object as-is (no DeepCopy): the driver builds list entries from
+	// model structs whose ints are plain `int`, which the unstructured JSON
+	// deep-copier rejects — json.Marshal (what both real seams do) handles them
+	// fine, and the driver never mutates the object after the apply returns.
+	a.applies = append(a.applies, recordedApply{gvr: gvr, ns: ns, obj: obj, fieldManager: fieldManager, force: force})
+	return obj, nil
+}
+
+func (a *plumbRecordingAccessor) Update(_ context.Context, _ schema.GroupVersionResource, _ string, obj *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (a *plumbRecordingAccessor) Delete(context.Context, schema.GroupVersionResource, string, string, metav1.DeleteOptions) error {
+	return nil
+}
+
+func (a *plumbRecordingAccessor) applyCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.applies)
+}
+
+func (a *plumbRecordingAccessor) applyAt(t *testing.T, i int) recordedApply {
+	t.Helper()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if i >= len(a.applies) {
+		t.Fatalf("apply[%d] requested but only %d applies recorded", i, len(a.applies))
+	}
+	return a.applies[i]
+}
+
+// seededVpc returns a Vpc carrying MORE than the plumbing lists — labels,
+// annotations, spec.namespaces, and a status — so the minimal-apply assertions
+// prove those fields were NOT copied into the apply object.
+func seededVpc(name string, peerings, routes []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeovn.io/v1", "kind": "Vpc",
+		"metadata": map[string]interface{}{
+			"name":   name,
+			"labels": map[string]interface{}{"dc-api/managed": "true", "dc-api/tenant": "tenant"},
+		},
+		"spec": map[string]interface{}{
+			"namespaces":   []interface{}{"dc-tenant-proj"},
+			"vpcPeerings":  peerings,
+			"staticRoutes": routes,
+		},
+		"status": map[string]interface{}{"standby": true},
+	}}
+}
+
+func seededSubnet(name string, acls []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeovn.io/v1", "kind": "Subnet",
+		"metadata": map[string]interface{}{
+			"name":   name,
+			"labels": map[string]interface{}{"dc-api/managed": "true"},
+		},
+		"spec": map[string]interface{}{
+			"cidrBlock": "10.0.1.0/24",
+			"vpc":       "vnet-a",
+			"acls":      acls,
+		},
+		"status": map[string]interface{}{"v4availableIPs": float64(200)},
+	}}
+}
+
+// assertMinimalApply asserts the captured apply object is EXACTLY the minimal
+// single-field shape: top-level {apiVersion, kind, metadata, spec}, metadata
+// exactly {name}, spec exactly {specField}, and no status. It returns the spec
+// list for content assertions.
+func assertMinimalApply(t *testing.T, rec recordedApply, wantGVR schema.GroupVersionResource, wantKind, wantName, specField, wantManager string) []interface{} {
+	t.Helper()
+
+	if rec.gvr != wantGVR {
+		t.Errorf("apply GVR = %v, want %v", rec.gvr, wantGVR)
+	}
+	// Vpc and Subnet are cluster-scoped — the seam namespace must be empty.
+	if rec.ns != "" {
+		t.Errorf("apply namespace = %q, want \"\" (cluster-scoped)", rec.ns)
+	}
+	if rec.fieldManager != wantManager {
+		t.Errorf("apply fieldManager = %q, want %q", rec.fieldManager, wantManager)
+	}
+	if !rec.force {
+		t.Error("apply force = false, want true (dc-api is the sole intended owner of these spec lists)")
+	}
+
+	obj := rec.obj.Object
+	if av, _ := obj["apiVersion"].(string); av != "kubeovn.io/v1" {
+		t.Errorf("apply apiVersion = %q, want kubeovn.io/v1", av)
+	}
+	if k, _ := obj["kind"].(string); k != wantKind {
+		t.Errorf("apply kind = %q, want %q", k, wantKind)
+	}
+
+	wantTop := map[string]bool{"apiVersion": true, "kind": true, "metadata": true, "spec": true}
+	for k := range obj {
+		if !wantTop[k] {
+			t.Errorf("apply object carries unexpected top-level field %q — the object must be minimal (in particular: no status)", k)
+		}
+	}
+	meta, _ := obj["metadata"].(map[string]interface{})
+	if name, _ := meta["name"].(string); name != wantName {
+		t.Errorf("apply metadata.name = %q, want %q", name, wantName)
+	}
+	for k := range meta {
+		if k != "name" {
+			t.Errorf("apply metadata carries unexpected field %q — labels/annotations/namespace must not be claimed", k)
+		}
+	}
+	spec, _ := obj["spec"].(map[string]interface{})
+	if spec == nil {
+		t.Fatal("apply object has no spec")
+	}
+	for k := range spec {
+		if k != specField {
+			t.Errorf("apply spec carries unexpected field %q — only %q may be written (claiming a sibling list would let SSA prune it)", k, specField)
+		}
+	}
+	list, ok := spec[specField].([]interface{})
+	if !ok {
+		t.Fatalf("apply spec.%s is %T, want []interface{}", specField, spec[specField])
+	}
+	return list
+}
+
+// assertJSONEqual asserts two values marshal to identical JSON — the
+// captured-apply-list vs old-merge-patch-list equivalence check.
+func assertJSONEqual(t *testing.T, got, want interface{}, what string) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal got %s: %v", what, err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal want %s: %v", what, err)
+	}
+	if string(gotJSON) != string(wantJSON) {
+		t.Errorf("%s mismatch:\n  applied:      %s\n  merge-patch would have written: %s", what, gotJSON, wantJSON)
+	}
+}
+
+// ── The four write sites: minimal apply + merge-patch-equivalent content ──────
+
+func TestAppendVpcPeering_SeamApply_MinimalObjectAndUpsert(t *testing.T) {
+	keepEntry := map[string]interface{}{"remoteVpc": "vnet-old", "localConnectIP": "100.64.5.1/24"}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{keepEntry}, []interface{}{}),
+	}}
+	c := &Client{access: acc}
+
+	if err := c.appendVpcPeering(context.Background(), "vnet-a", "vnet-b", "100.64.10.0/24"); err != nil {
+		t.Fatalf("appendVpcPeering: %v", err)
+	}
+
+	// The read went through the seam on the vpc family.
+	if len(acc.getCalls) != 1 || acc.getCalls[0] != vpcGVR {
+		t.Errorf("seam Get calls = %v, want exactly one vpcGVR Get", acc.getCalls)
+	}
+	if got := acc.applyCount(); got != 1 {
+		t.Fatalf("seam Apply called %d times, want 1", got)
+	}
+
+	list := assertMinimalApply(t, acc.applyAt(t, 0), vpcGVR, "Vpc", "vnet-a", "vpcPeerings", fieldManagerVpcPeerings)
+
+	// Content equivalence: exactly what the old merge patch wrote — the existing
+	// entry preserved, the new upserted entry appended with the deterministic
+	// localConnectIP ("vnet-a" sorts before "vnet-b" → host octet .1).
+	want := []interface{}{
+		keepEntry,
+		map[string]interface{}{"remoteVpc": "vnet-b", "localConnectIP": "100.64.10.1/24"},
+	}
+	assertJSONEqual(t, list, want, "spec.vpcPeerings")
+}
+
+func TestAppendVpcPeering_SeamApply_ReplacesExistingEntry(t *testing.T) {
+	// An entry for the same peer already exists (retry) — it is REPLACED, not
+	// duplicated, exactly as the merge-patch path behaved.
+	stale := map[string]interface{}{"remoteVpc": "vnet-b", "localConnectIP": "100.64.99.1/24"}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{stale}, []interface{}{}),
+	}}
+	c := &Client{access: acc}
+
+	if err := c.appendVpcPeering(context.Background(), "vnet-a", "vnet-b", "100.64.10.0/24"); err != nil {
+		t.Fatalf("appendVpcPeering: %v", err)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), vpcGVR, "Vpc", "vnet-a", "vpcPeerings", fieldManagerVpcPeerings)
+	want := []interface{}{
+		map[string]interface{}{"remoteVpc": "vnet-b", "localConnectIP": "100.64.10.1/24"},
+	}
+	assertJSONEqual(t, list, want, "spec.vpcPeerings")
+}
+
+func TestRemoveVpcPeering_SeamApply_FiltersEntry(t *testing.T) {
+	keep := map[string]interface{}{"remoteVpc": "vnet-c", "localConnectIP": "100.64.7.1/24"}
+	drop := map[string]interface{}{"remoteVpc": "vnet-b", "localConnectIP": "100.64.10.1/24"}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{keep, drop}, []interface{}{}),
+	}}
+	c := &Client{access: acc}
+
+	if err := c.removeVpcPeering(context.Background(), "vnet-a", "vnet-b"); err != nil {
+		t.Fatalf("removeVpcPeering: %v", err)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), vpcGVR, "Vpc", "vnet-a", "vpcPeerings", fieldManagerVpcPeerings)
+	assertJSONEqual(t, list, []interface{}{keep}, "spec.vpcPeerings")
+}
+
+func TestRemoveVpcPeering_NotFoundIsIdempotent(t *testing.T) {
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{}}
+	c := &Client{access: acc}
+
+	// The VPC is gone — the op must be a silent no-op (IsNotFound tolerance
+	// preserved) with no apply issued.
+	if err := c.removeVpcPeering(context.Background(), "vnet-gone", "vnet-b"); err != nil {
+		t.Fatalf("removeVpcPeering on a missing VPC must be nil, got %v", err)
+	}
+	if got := acc.applyCount(); got != 0 {
+		t.Errorf("seam Apply called %d times for a missing VPC, want 0", got)
+	}
+}
+
+func TestPatchVPCStaticRoutes_SeamApply_MinimalObject(t *testing.T) {
+	acc := &plumbRecordingAccessor{}
+	c := &Client{access: acc}
+
+	routes := []interface{}{
+		map[string]interface{}{"cidr": "10.9.0.0/16", "nextHopIP": "10.0.0.1", "policy": "policyDst", "routeTable": "routetable-rt-1"},
+	}
+	if err := c.patchVPCStaticRoutes(context.Background(), "vnet-a", routes); err != nil {
+		t.Fatalf("patchVPCStaticRoutes: %v", err)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), vpcGVR, "Vpc", "vnet-a", "staticRoutes", fieldManagerStaticRoutes)
+	assertJSONEqual(t, list, routes, "spec.staticRoutes")
+}
+
+func TestPatchVPCStaticRoutes_NilBecomesEmptyList(t *testing.T) {
+	acc := &plumbRecordingAccessor{}
+	c := &Client{access: acc}
+
+	if err := c.patchVPCStaticRoutes(context.Background(), "vnet-a", nil); err != nil {
+		t.Fatalf("patchVPCStaticRoutes(nil): %v", err)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), vpcGVR, "Vpc", "vnet-a", "staticRoutes", fieldManagerStaticRoutes)
+	// The merge patch wrote an explicit empty JSON array; the apply must too
+	// (a JSON null would not clear the list).
+	if b, _ := json.Marshal(list); string(b) != "[]" {
+		t.Errorf("spec.staticRoutes marshals to %s, want [] (explicit empty list)", b)
+	}
+}
+
+func TestPatchSubnetACLs_SeamApply_MinimalObject(t *testing.T) {
+	acc := &plumbRecordingAccessor{}
+	c := &Client{access: acc}
+
+	acls := []interface{}{
+		map[string]interface{}{"direction": "to-lport", "priority": int64(2001), "match": `inport == "nsg-x" || (tcp)`, "action": "allow-related"},
+	}
+	if err := c.patchSubnetACLs(context.Background(), "subnet-1", acls); err != nil {
+		t.Fatalf("patchSubnetACLs: %v", err)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), subnetGVR, "Subnet", "subnet-1", "acls", fieldManagerSubnetACLs)
+	assertJSONEqual(t, list, acls, "spec.acls")
+}
+
+// ── Public read-modify-write ops: seam Get + filter/build + seam Apply ────────
+
+func TestUpdateRouteTableRoutes_SeamReadModifyApply(t *testing.T) {
+	ownedByRT := map[string]interface{}{"cidr": "10.1.0.0/16", "nextHopIP": "10.0.0.9", "policy": "policyDst", "routeTable": "routetable-rt-1"}
+	otherRT := map[string]interface{}{"cidr": "10.2.0.0/16", "nextHopIP": "10.0.0.8", "policy": "policyDst", "routeTable": "routetable-rt-2"}
+	peering := map[string]interface{}{"cidr": "10.3.0.0/16", "nextHopIP": "100.64.9.2", "policy": "policyDst", "routeTable": ""}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{}, []interface{}{ownedByRT, otherRT, peering}),
+	}}
+	c := &Client{access: acc}
+
+	rules := []models.RouteRule{{Name: "to-fw", DestinationCIDR: "10.1.0.0/16", NextHopType: "virtual_appliance", NextHopIP: "10.0.0.10"}}
+	if err := c.UpdateRouteTableRoutes(context.Background(), "vnet-a/rt-1", rules); err != nil {
+		t.Fatalf("UpdateRouteTableRoutes: %v", err)
+	}
+
+	if len(acc.getCalls) != 1 || acc.getCalls[0] != vpcGVR {
+		t.Errorf("seam Get calls = %v, want exactly one vpcGVR Get", acc.getCalls)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), vpcGVR, "Vpc", "vnet-a", "staticRoutes", fieldManagerStaticRoutes)
+
+	// Old merge-patch content: everything NOT owned by rt-1, then the freshly
+	// built rt-1 entries — computed with the same helpers the driver uses.
+	want := append(
+		filterSliceByTag([]interface{}{ownedByRT, otherRT, peering}, "routeTable", routeTableTag("rt-1")),
+		buildStaticRouteEntries(rules, routeTableTag("rt-1"))...,
+	)
+	assertJSONEqual(t, list, want, "spec.staticRoutes")
+}
+
+func TestDeleteRouteTable_SeamReadModifyApply(t *testing.T) {
+	ownedByRT := map[string]interface{}{"cidr": "10.1.0.0/16", "nextHopIP": "10.0.0.9", "policy": "policyDst", "routeTable": "routetable-rt-1"}
+	otherRT := map[string]interface{}{"cidr": "10.2.0.0/16", "nextHopIP": "10.0.0.8", "policy": "policyDst", "routeTable": "routetable-rt-2"}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{}, []interface{}{ownedByRT, otherRT}),
+	}}
+	c := &Client{access: acc}
+
+	if err := c.DeleteRouteTable(context.Background(), "vnet-a/rt-1"); err != nil {
+		t.Fatalf("DeleteRouteTable: %v", err)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), vpcGVR, "Vpc", "vnet-a", "staticRoutes", fieldManagerStaticRoutes)
+	assertJSONEqual(t, list, []interface{}{otherRT}, "spec.staticRoutes")
+}
+
+func TestDeleteRouteTable_VpcGoneIsIdempotent(t *testing.T) {
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{}}
+	c := &Client{access: acc}
+
+	if err := c.DeleteRouteTable(context.Background(), "vnet-gone/rt-1"); err != nil {
+		t.Fatalf("DeleteRouteTable on a missing VPC must be nil, got %v", err)
+	}
+	if got := acc.applyCount(); got != 0 {
+		t.Errorf("seam Apply called %d times for a missing VPC, want 0", got)
+	}
+}
+
+func TestUpdateNSGRules_SeamReadModifyApply(t *testing.T) {
+	const nsgUID = "6b6bd53d-0000-0000-0000-000000000001"
+	// One ACL owned by this NSG (to be replaced) and one foreign ACL (preserved).
+	owned := map[string]interface{}{"direction": "to-lport", "priority": int64(2500), "match": `inport == "` + nsgACLTag(nsgUID) + `" || (udp)`, "action": "drop"}
+	foreign := map[string]interface{}{"direction": "to-lport", "priority": int64(2400), "match": `inport == "nsg-other" || (icmp4)`, "action": "allow-related"}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"subnet-1": seededSubnet("subnet-1", []interface{}{owned, foreign}),
+	}}
+	c := &Client{access: acc}
+
+	rules := []models.NSGRule{{
+		Name: "allow-https", Priority: 200, Direction: "inbound", Action: "allow",
+		Protocol: "tcp", SourceAddressPrefix: "*", DestinationAddressPrefix: "*", DestinationPortRange: "443",
+	}}
+	if err := c.UpdateNSGRules(context.Background(), nsgUID+"|subnet-1", rules); err != nil {
+		t.Fatalf("UpdateNSGRules: %v", err)
+	}
+
+	list := assertMinimalApply(t, acc.applyAt(t, 0), subnetGVR, "Subnet", "subnet-1", "acls", fieldManagerSubnetACLs)
+	want := append(
+		filterACLsByTag([]interface{}{owned, foreign}, nsgACLTag(nsgUID)),
+		buildACLEntries(rules, nsgUID)...,
+	)
+	assertJSONEqual(t, list, want, "spec.acls")
+}
+
+func TestDetachNSGFromSubnet_SeamReadModifyApply(t *testing.T) {
+	const nsgUID = "6b6bd53d-0000-0000-0000-000000000001"
+	owned := map[string]interface{}{"direction": "to-lport", "priority": int64(2500), "match": `inport == "` + nsgACLTag(nsgUID) + `" || (udp)`, "action": "drop"}
+	foreign := map[string]interface{}{"direction": "to-lport", "priority": int64(2400), "match": `inport == "nsg-other" || (icmp4)`, "action": "allow-related"}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"subnet-1": seededSubnet("subnet-1", []interface{}{owned, foreign}),
+	}}
+	c := &Client{access: acc}
+
+	if err := c.DetachNSGFromSubnet(context.Background(), nsgUID, "subnet-1"); err != nil {
+		t.Fatalf("DetachNSGFromSubnet: %v", err)
+	}
+	list := assertMinimalApply(t, acc.applyAt(t, 0), subnetGVR, "Subnet", "subnet-1", "acls", fieldManagerSubnetACLs)
+	assertJSONEqual(t, list, []interface{}{foreign}, "spec.acls")
+}
+
+func TestDetachNSGFromSubnet_SubnetGoneIsIdempotent(t *testing.T) {
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{}}
+	c := &Client{access: acc}
+
+	if err := c.DetachNSGFromSubnet(context.Background(), "nsg-uid", "subnet-gone"); err != nil {
+		t.Fatalf("DetachNSGFromSubnet on a missing subnet must be nil, got %v", err)
+	}
+	if got := acc.applyCount(); got != 0 {
+		t.Errorf("seam Apply called %d times for a missing subnet, want 0", got)
+	}
+}
+
+// ── Routed toggle: agent vs Direct ────────────────────────────────────────────
+
+// plumbingRouted builds a Routed accessor whose decision activates ONLY the
+// plumbing allow-set ({VerbGet, VerbApply}) onto the agent accessor when
+// allow=true. allow=false models toggle-off / no-connected-agent (always
+// Direct). GVR-aware to match the registry's AgentDecision shape.
+func plumbingRouted(direct, agent clusteraccess.Accessor, allow bool) *clusteraccess.Routed {
+	return clusteraccess.NewRouted(direct, func(v clusteraccess.Verb, _ schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
+		if !allow {
+			return nil, false
+		}
+		switch v {
+		case clusteraccess.VerbGet, clusteraccess.VerbApply:
+			return agent, true
+		default:
+			return nil, false
+		}
+	})
+}
+
+func TestUpdateRouteTableRoutes_RoutedToggle_AgentVsDirect(t *testing.T) {
+	seed := func() map[string]*unstructured.Unstructured {
+		return map[string]*unstructured.Unstructured{
+			"vnet-a": seededVpc("vnet-a", []interface{}{}, []interface{}{}),
+		}
+	}
+	rules := []models.RouteRule{{Name: "r", DestinationCIDR: "10.1.0.0/16", NextHopType: "virtual_appliance", NextHopIP: "10.0.0.10"}}
+
+	t.Run("toggle on routes to agent", func(t *testing.T) {
+		agent := &plumbRecordingAccessor{objects: seed()}
+		direct := &plumbRecordingAccessor{objects: seed()}
+		c := &Client{access: plumbingRouted(direct, agent, true)}
+
+		if err := c.UpdateRouteTableRoutes(context.Background(), "vnet-a/rt-1", rules); err != nil {
+			t.Fatalf("UpdateRouteTableRoutes: %v", err)
+		}
+		if got := agent.applyCount(); got != 1 {
+			t.Errorf("agent Apply called %d times, want 1", got)
+		}
+		if len(agent.getCalls) != 1 {
+			t.Errorf("agent Get called %d times, want 1", len(agent.getCalls))
+		}
+		if got := direct.applyCount() + len(direct.getCalls); got != 0 {
+			t.Errorf("direct seam touched %d times with toggle ON, want 0", got)
+		}
+	})
+
+	t.Run("toggle off uses direct", func(t *testing.T) {
+		agent := &plumbRecordingAccessor{objects: seed()}
+		direct := &plumbRecordingAccessor{objects: seed()}
+		c := &Client{access: plumbingRouted(direct, agent, false)}
+
+		if err := c.UpdateRouteTableRoutes(context.Background(), "vnet-a/rt-1", rules); err != nil {
+			t.Fatalf("UpdateRouteTableRoutes: %v", err)
+		}
+		if got := direct.applyCount(); got != 1 {
+			t.Errorf("direct Apply called %d times, want 1", got)
+		}
+		if got := agent.applyCount() + len(agent.getCalls); got != 0 {
+			t.Errorf("agent seam touched %d times with toggle OFF, want 0", got)
+		}
+	})
+}
+
+// ── Remote client: the plumbing ops work with NO dynamic client ───────────────
+
+func TestRemoteClient_CreatePeering_RoutesThroughSeam(t *testing.T) {
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{}, []interface{}{}),
+		"vnet-b": seededVpc("vnet-b", []interface{}{}, []interface{}{}),
+	}}
+	c := NewRemoteClient(acc, "lk", "zone-2")
+	if c.dynamic != nil {
+		t.Fatal("remote client must have a nil dynamic client")
+	}
+
+	res, err := c.CreatePeering(context.Background(), "vnet-a", "vnet-b", models.PeeringSpec{
+		TransitCIDR:      "100.64.10.0/24",
+		AddressSpace:     []string{"10.1.0.0/16"},
+		PeerAddressSpace: []string{"10.2.0.0/16"},
+	})
+	if err != nil {
+		t.Fatalf("CreatePeering (remote): %v", err)
+	}
+	if res.Status != models.StatusActive {
+		t.Errorf("status = %q, want ACTIVE", res.Status)
+	}
+	// Four seam applies: vpcPeerings on both VPCs, then staticRoutes on both.
+	if got := acc.applyCount(); got != 4 {
+		t.Fatalf("seam Apply called %d times, want 4 (2 vpcPeerings + 2 staticRoutes)", got)
+	}
+	// The address-space was supplied, so the legacy subnet-CIDR fallback List
+	// must not have run.
+	if acc.listCalls != 0 {
+		t.Errorf("subnet-CIDR fallback List ran %d times, want 0 (address-space supplied)", acc.listCalls)
+	}
+
+	// Spot-check the vnet-a staticRoutes apply: destination = peer's CIDR,
+	// nextHop = the PEER side's transit IP (.2 — "vnet-b" sorts after "vnet-a").
+	var routesApply *recordedApply
+	for i := 0; i < acc.applyCount(); i++ {
+		rec := acc.applyAt(t, i)
+		spec, _ := rec.obj.Object["spec"].(map[string]interface{})
+		if _, isRoutes := spec["staticRoutes"]; isRoutes && rec.obj.GetName() == "vnet-a" {
+			r := rec
+			routesApply = &r
+			break
+		}
+	}
+	if routesApply == nil {
+		t.Fatal("no staticRoutes apply recorded for vnet-a")
+	}
+	list := assertMinimalApply(t, *routesApply, vpcGVR, "Vpc", "vnet-a", "staticRoutes", fieldManagerStaticRoutes)
+	want := []interface{}{map[string]interface{}{
+		"cidr": "10.2.0.0/16", "nextHopIP": "100.64.10.2", "policy": "policyDst", "routeTable": "",
+	}}
+	assertJSONEqual(t, list, want, "spec.staticRoutes (vnet-a)")
+}
+
+func TestRemoteClient_DeletePeering_RoutesThroughSeam(t *testing.T) {
+	peerEntryOnA := map[string]interface{}{"remoteVpc": "vnet-b", "localConnectIP": "100.64.10.1/24"}
+	peerEntryOnB := map[string]interface{}{"remoteVpc": "vnet-a", "localConnectIP": "100.64.10.2/24"}
+	routeOnA := map[string]interface{}{"cidr": "10.2.0.0/16", "nextHopIP": "100.64.10.2", "policy": "policyDst", "routeTable": ""}
+	routeOnB := map[string]interface{}{"cidr": "10.1.0.0/16", "nextHopIP": "100.64.10.1", "policy": "policyDst", "routeTable": ""}
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{peerEntryOnA}, []interface{}{routeOnA}),
+		"vnet-b": seededVpc("vnet-b", []interface{}{peerEntryOnB}, []interface{}{routeOnB}),
+	}}
+	c := NewRemoteClient(acc, "lk", "zone-2")
+
+	if err := c.DeletePeering(context.Background(), "vnet-a/vnet-b", []string{"10.1.0.0/16"}, []string{"10.2.0.0/16"}); err != nil {
+		t.Fatalf("DeletePeering (remote): %v", err)
+	}
+	if got := acc.applyCount(); got != 4 {
+		t.Fatalf("seam Apply called %d times, want 4 (2 vpcPeerings removals + 2 staticRoutes removals)", got)
+	}
+	// Every apply cleared its list (all owned entries removed).
+	for i := 0; i < 4; i++ {
+		rec := acc.applyAt(t, i)
+		spec, _ := rec.obj.Object["spec"].(map[string]interface{})
+		for field, v := range spec {
+			if list, ok := v.([]interface{}); !ok || len(list) != 0 {
+				t.Errorf("apply[%d] spec.%s = %v, want an empty list after peering teardown", i, field, v)
+			}
+		}
+	}
+}
+
+func TestRemoteClient_RouteTableAndNSGOps_RouteThroughSeam(t *testing.T) {
+	acc := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a":   seededVpc("vnet-a", []interface{}{}, []interface{}{}),
+		"subnet-1": seededSubnet("subnet-1", []interface{}{}),
+	}}
+	c := NewRemoteClient(acc, "lk", "zone-2")
+	ctx := context.Background()
+
+	// CreateRouteTable does no k8s I/O and must no longer be local-only.
+	if _, err := c.CreateRouteTable(ctx, "vnet-a", models.RouteTableSpec{
+		Routes: []models.RouteRule{{Name: "r", DestinationCIDR: "0.0.0.0/0", NextHopType: "virtual_appliance", NextHopIP: "10.0.0.1"}},
+	}); err != nil {
+		t.Errorf("CreateRouteTable (remote): %v", err)
+	}
+	if err := c.UpdateRouteTableRoutes(ctx, "vnet-a/rt-1", []models.RouteRule{{Name: "r", DestinationCIDR: "10.9.0.0/16", NextHopType: "virtual_appliance", NextHopIP: "10.0.0.1"}}); err != nil {
+		t.Errorf("UpdateRouteTableRoutes (remote): %v", err)
+	}
+	if err := c.DeleteRouteTable(ctx, "vnet-a/rt-1"); err != nil {
+		t.Errorf("DeleteRouteTable (remote): %v", err)
+	}
+	if err := c.AssociateRouteTable(ctx, "vnet-a/rt-1", "subnet-1"); err != nil {
+		t.Errorf("AssociateRouteTable (remote): %v", err)
+	}
+	if _, err := c.CreateNSG(ctx, "tenant", "proj", models.NSGSpec{Name: "web"}); err != nil {
+		t.Errorf("CreateNSG (remote): %v", err)
+	}
+	if err := c.AttachNSGToSubnet(ctx, "nsg-uid", "subnet-1"); err != nil {
+		t.Errorf("AttachNSGToSubnet (remote): %v", err)
+	}
+	if err := c.UpdateNSGRules(ctx, "nsg-uid|subnet-1", []models.NSGRule{{
+		Name: "allow-ssh", Priority: 100, Direction: "inbound", Action: "allow", Protocol: "tcp", DestinationPortRange: "22",
+	}}); err != nil {
+		t.Errorf("UpdateNSGRules (remote): %v", err)
+	}
+	if err := c.DetachNSGFromSubnet(ctx, "nsg-uid", "subnet-1"); err != nil {
+		t.Errorf("DetachNSGFromSubnet (remote): %v", err)
+	}
+	if err := c.DeleteNSG(ctx, "nsg-uid"); err != nil {
+		t.Errorf("DeleteNSG (remote): %v", err)
+	}
+
+	// Route-table update + delete (2 staticRoutes applies) and NSG update +
+	// detach (2 acls applies) all went through the seam.
+	if got := acc.applyCount(); got != 4 {
+		t.Errorf("seam Apply called %d times, want 4", got)
+	}
+}
+
+// TestRemoteClient_LegacyPeeringCIDRFallback_FailsClosed pins the deliberate
+// limit of the slice: a remote peering created WITHOUT an address-space (legacy
+// callers only) needs the subnet-CIDR fallback List, and VerbList is not in the
+// subnet family's RouteVerbs — so on a remote zone the List lands on the
+// NoCreds fallback and fails CLOSED with a clear error instead of panicking on
+// the nil dynamic client or silently listing the wrong cluster.
+func TestRemoteClient_LegacyPeeringCIDRFallback_FailsClosed(t *testing.T) {
+	agent := &plumbRecordingAccessor{objects: map[string]*unstructured.Unstructured{
+		"vnet-a": seededVpc("vnet-a", []interface{}{}, []interface{}{}),
+		"vnet-b": seededVpc("vnet-b", []interface{}{}, []interface{}{}),
+	}}
+	// Mirror buildRemoteSet: Routed whose Direct fallback is NoCreds, decision
+	// routing only the verbs the plumbing families declare (Get/Apply here; List
+	// deliberately absent — mirroring subnetCapability.RouteVerbs).
+	routed := clusteraccess.NewRouted(
+		clusteraccess.NewNoCreds("lk", "zone-2"),
+		func(v clusteraccess.Verb, _ schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
+			switch v {
+			case clusteraccess.VerbGet, clusteraccess.VerbApply:
+				return agent, true
+			default:
+				return nil, false
+			}
+		})
+	c := NewRemoteClient(routed, "lk", "zone-2")
+
+	_, err := c.CreatePeering(context.Background(), "vnet-a", "vnet-b", models.PeeringSpec{
+		TransitCIDR: "100.64.10.0/24", // no AddressSpace/PeerAddressSpace → legacy fallback
+	})
+	if err == nil {
+		t.Fatal("legacy CreatePeering (no address-space) on a remote zone must fail closed, got nil")
+	}
+	if !strings.Contains(err.Error(), "no agent connected for zone lk/zone-2") {
+		t.Errorf("error = %q, want the NoCreds fail-closed message naming the zone", err.Error())
+	}
+}

--- a/dc-api/internal/providers/kubeovn/network_plumbing_seam_test.go
+++ b/dc-api/internal/providers/kubeovn/network_plumbing_seam_test.go
@@ -30,6 +30,7 @@ package kubeovn
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -69,6 +70,11 @@ type plumbRecordingAccessor struct {
 
 	listCalls int
 	listErr   error
+
+	// getErr/applyErr, when set, make every Get/Apply fail — for asserting the
+	// driver propagates seam errors and stops (no apply after a failed read).
+	getErr   error
+	applyErr error
 }
 
 var _ clusteraccess.Accessor = (*plumbRecordingAccessor)(nil)
@@ -77,6 +83,9 @@ func (a *plumbRecordingAccessor) Get(_ context.Context, gvr schema.GroupVersionR
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.getCalls = append(a.getCalls, gvr)
+	if a.getErr != nil {
+		return nil, a.getErr
+	}
 	obj, ok := a.objects[name]
 	if !ok {
 		return nil, k8serrors.NewNotFound(gvr.GroupResource(), name)
@@ -101,6 +110,9 @@ func (a *plumbRecordingAccessor) Create(_ context.Context, _ schema.GroupVersion
 func (a *plumbRecordingAccessor) Apply(_ context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, fieldManager string, force bool) (*unstructured.Unstructured, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.applyErr != nil {
+		return nil, a.applyErr
+	}
 	// Store the object as-is (no DeepCopy): the driver builds list entries from
 	// model structs whose ints are plain `int`, which the unstructured JSON
 	// deep-copier rejects — json.Marshal (what both real seams do) handles them
@@ -690,12 +702,16 @@ func TestRemoteClient_LegacyPeeringCIDRFallback_FailsClosed(t *testing.T) {
 	// Mirror buildRemoteSet: Routed whose Direct fallback is NoCreds, decision
 	// routing only the verbs the plumbing families declare (Get/Apply here; List
 	// deliberately absent — mirroring subnetCapability.RouteVerbs).
+	sawListRequest := false
 	routed := clusteraccess.NewRouted(
 		clusteraccess.NewNoCreds("lk", "zone-2"),
 		func(v clusteraccess.Verb, _ schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
 			switch v {
 			case clusteraccess.VerbGet, clusteraccess.VerbApply:
 				return agent, true
+			case clusteraccess.VerbList:
+				sawListRequest = true // the legacy CIDR fallback engaged
+				return nil, false
 			default:
 				return nil, false
 			}
@@ -710,5 +726,76 @@ func TestRemoteClient_LegacyPeeringCIDRFallback_FailsClosed(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no agent connected for zone lk/zone-2") {
 		t.Errorf("error = %q, want the NoCreds fail-closed message naming the zone", err.Error())
+	}
+	// Explicit: the failure came from the CIDR-fallback List actually engaging —
+	// a refactor that silently skips the fallback must not pass this test.
+	if !sawListRequest {
+		t.Error("the legacy subnet-CIDR fallback List was never requested — the fail-closed path did not engage")
+	}
+}
+
+// ── Seam error propagation (Get/Apply failures) ──────────────────────────────
+
+// TestAppendVpcPeering_GetErrorPropagates_NoApply: a seam Get failure aborts the
+// read-modify-apply before any write — the error propagates and Apply is never
+// issued (no blind write on unknown state).
+func TestAppendVpcPeering_GetErrorPropagates_NoApply(t *testing.T) {
+	boom := fmt.Errorf("seam get exploded")
+	acc := &plumbRecordingAccessor{getErr: boom}
+	c := &Client{access: acc}
+
+	err := c.appendVpcPeering(context.Background(), "vnet-a", "vnet-b", "100.64.10.0/24")
+	if err == nil || !strings.Contains(err.Error(), "seam get exploded") {
+		t.Fatalf("appendVpcPeering must propagate the Get error, got %v", err)
+	}
+	if got := acc.applyCount(); got != 0 {
+		t.Errorf("seam Apply called %d times after a failed Get, want 0", got)
+	}
+}
+
+// TestAppendVpcPeering_ApplyErrorPropagates: a seam Apply failure propagates to
+// the caller (the handler surfaces it; nothing swallows the write error).
+func TestAppendVpcPeering_ApplyErrorPropagates(t *testing.T) {
+	boom := fmt.Errorf("seam apply exploded")
+	acc := &plumbRecordingAccessor{
+		objects: map[string]*unstructured.Unstructured{
+			"vnet-a": seededVpc("vnet-a", []interface{}{}, []interface{}{}),
+		},
+		applyErr: boom,
+	}
+	c := &Client{access: acc}
+
+	err := c.appendVpcPeering(context.Background(), "vnet-a", "vnet-b", "100.64.10.0/24")
+	if err == nil || !strings.Contains(err.Error(), "seam apply exploded") {
+		t.Fatalf("appendVpcPeering must propagate the Apply error, got %v", err)
+	}
+}
+
+// TestPatchSubnetACLs_ApplyErrorPropagates: the pure-apply subnet-ACL op (its
+// callers do the feeding Get) propagates a seam Apply failure unchanged.
+func TestPatchSubnetACLs_ApplyErrorPropagates(t *testing.T) {
+	boom := fmt.Errorf("seam apply exploded")
+	acc := &plumbRecordingAccessor{applyErr: boom}
+	c := &Client{access: acc}
+	err := c.patchSubnetACLs(context.Background(), "subnet-1", []interface{}{})
+	if err == nil || !strings.Contains(err.Error(), "seam apply exploded") {
+		t.Fatalf("patchSubnetACLs must propagate the Apply error, got %v", err)
+	}
+}
+
+// TestUpdateRouteTableRoutes_GetErrorPropagates_NoApply: the route-table op's
+// FEEDING read fails → the error propagates and the write never runs (same
+// no-blind-write property as the peering op, on the routes code path).
+func TestUpdateRouteTableRoutes_GetErrorPropagates_NoApply(t *testing.T) {
+	boom := fmt.Errorf("seam get exploded")
+	acc := &plumbRecordingAccessor{getErr: boom}
+	c := &Client{access: acc}
+
+	err := c.UpdateRouteTableRoutes(context.Background(), "vnet-a/rt-11111111-1111-1111-1111-111111111111", nil)
+	if err == nil || !strings.Contains(err.Error(), "seam get exploded") {
+		t.Fatalf("UpdateRouteTableRoutes must propagate the Get error, got %v", err)
+	}
+	if got := acc.applyCount(); got != 0 {
+		t.Errorf("seam Apply called %d times after a failed Get, want 0", got)
 	}
 }

--- a/dc-api/internal/providers/kubeovn/remote_client_test.go
+++ b/dc-api/internal/providers/kubeovn/remote_client_test.go
@@ -16,13 +16,15 @@ import (
 	"github.com/wso2/dc-api/internal/providers/common"
 )
 
-// This file proves the GAP this slice closes: a REMOTE kubeovn client
-// (NewRemoteClient, c.dynamic == nil) routes the ONBOARDED CRD lifecycle
+// This file proves the GAP the CRD-lifecycle slice closed: a REMOTE kubeovn
+// client (NewRemoteClient, c.dynamic == nil) routes the ONBOARDED CRD lifecycle
 // (Vpc/Subnet/NAD create/get/delete) through its agent-only Accessor instead of
-// returning a local-only error — while the VPC network PLUMBING (NAT/DNS/ACL/
-// route/peering) still returns localOnlyErr. It also proves a remote client built
-// with a NoCreds-only accessor (no agent) fails CLOSED with a clear "no agent
-// connected" error rather than nil-dereferencing c.dynamic.
+// returning a local-only error — while the REMAINING local-only plumbing (NAT,
+// per-VPC DNS) still returns localOnlyErr. The peering/route-table/NSG spec
+// writes are no longer in the local-only set — network_plumbing_seam_test.go
+// proves they route through the seam on a remote client. It also proves a
+// remote client built with a NoCreds-only accessor (no agent) fails CLOSED with
+// a clear "no agent connected" error rather than nil-dereferencing c.dynamic.
 //
 // The remote client has c.dynamic == nil by construction, so these tests are the
 // regression guard against re-introducing a `c.dynamic == nil` guard on a routed
@@ -142,7 +144,7 @@ func (a *remoteAgentAccessor) sawGet(gvr schema.GroupVersionResource) bool {
 
 func TestRemoteClient_CreateVNet_RoutesThroughAgent(t *testing.T) {
 	agent := &remoteAgentAccessor{}
-	c := NewRemoteClient(agent, "lk", "laptop")
+	c := NewRemoteClient(agent, "lk", "zone-2")
 	if c.dynamic != nil {
 		t.Fatal("remote client must have a nil dynamic client")
 	}
@@ -161,7 +163,7 @@ func TestRemoteClient_CreateVNet_RoutesThroughAgent(t *testing.T) {
 
 func TestRemoteClient_GetVNet_RoutesThroughAgent(t *testing.T) {
 	agent := &remoteAgentAccessor{}
-	c := NewRemoteClient(agent, "lk", "laptop")
+	c := NewRemoteClient(agent, "lk", "zone-2")
 
 	res, err := c.GetVNet(context.Background(), "vnet-tenant-proj-app")
 	if err != nil {
@@ -177,7 +179,7 @@ func TestRemoteClient_GetVNet_RoutesThroughAgent(t *testing.T) {
 
 func TestRemoteClient_DeleteVNet_RoutesThroughAgent(t *testing.T) {
 	agent := &remoteAgentAccessor{}
-	c := NewRemoteClient(agent, "lk", "laptop")
+	c := NewRemoteClient(agent, "lk", "zone-2")
 
 	if err := c.DeleteVNet(context.Background(), "vnet-tenant-proj-app"); err != nil {
 		t.Fatalf("DeleteVNet error: %v", err)
@@ -189,7 +191,7 @@ func TestRemoteClient_DeleteVNet_RoutesThroughAgent(t *testing.T) {
 
 func TestRemoteClient_CreateSubnet_RoutesThroughAgent(t *testing.T) {
 	agent := &remoteAgentAccessor{}
-	c := NewRemoteClient(agent, "lk", "laptop")
+	c := NewRemoteClient(agent, "lk", "zone-2")
 
 	vnetUID := vpcName("app", "tenant", "proj")
 	res, err := c.CreateSubnet(context.Background(), vnetUID, sampleSubnetSpec())
@@ -214,7 +216,7 @@ func TestRemoteClient_CreateSubnet_RoutesThroughAgent(t *testing.T) {
 
 func TestRemoteClient_DeleteSubnet_RoutesThroughAgent(t *testing.T) {
 	agent := &remoteAgentAccessor{}
-	c := NewRemoteClient(agent, "lk", "laptop")
+	c := NewRemoteClient(agent, "lk", "zone-2")
 
 	if err := c.DeleteSubnet(context.Background(), "subnet-tenant-proj-app-sub"); err != nil {
 		t.Fatalf("DeleteSubnet error: %v", err)
@@ -230,37 +232,36 @@ func TestRemoteClient_DeleteSubnet_RoutesThroughAgent(t *testing.T) {
 	}
 }
 
-// ── Remote PLUMBING methods stay local-only ──────────────────────────────────
+// ── Remaining remote PLUMBING methods stay local-only ────────────────────────
 
+// TestRemoteClient_PlumbingMethods_ReturnLocalOnlyErr pins the REMAINING
+// local-only boundary after the spec-write plumbing slice: the per-VPC DNS
+// zone/record ops (ConfigMap-backed — configmaps are not an onboarded family).
+// The peering/route-table/NSG ops that used to sit here are now agent-routable;
+// their remote-client coverage lives in network_plumbing_seam_test.go.
 func TestRemoteClient_PlumbingMethods_ReturnLocalOnlyErr(t *testing.T) {
 	agent := &remoteAgentAccessor{}
-	c := NewRemoteClient(agent, "lk", "laptop")
+	c := NewRemoteClient(agent, "lk", "zone-2")
 	ctx := context.Background()
 
-	t.Run("CreateRouteTable", func(t *testing.T) {
-		_, err := c.CreateRouteTable(ctx, "vnet-tenant-proj-app", models.RouteTableSpec{
-			Routes: []models.RouteRule{{Name: "default", DestinationCIDR: "0.0.0.0/0", NextHopType: "virtual_appliance", NextHopIP: "10.0.0.1"}},
-		})
-		assertLocalOnlyErr(t, err, "lk", "laptop")
-	})
-	t.Run("UpdateRouteTableRoutes", func(t *testing.T) {
-		err := c.UpdateRouteTableRoutes(ctx, "vnet-tenant-proj-app/rt-uuid", nil)
-		assertLocalOnlyErr(t, err, "lk", "laptop")
-	})
-	t.Run("CreatePeering", func(t *testing.T) {
-		_, err := c.CreatePeering(ctx, "vnet-a", "vnet-b", models.PeeringSpec{})
-		assertLocalOnlyErr(t, err, "lk", "laptop")
-	})
 	t.Run("CreatePrivateDnsZone", func(t *testing.T) {
 		_, err := c.CreatePrivateDnsZone(ctx, "vnet-tenant-proj-app", models.DnsZoneSpec{})
-		assertLocalOnlyErr(t, err, "lk", "laptop")
+		assertLocalOnlyErr(t, err, "lk", "zone-2")
+	})
+	t.Run("DeletePrivateDnsZone", func(t *testing.T) {
+		err := c.DeletePrivateDnsZone(ctx, "configmap-dc-tenant-proj/zone-uuid")
+		assertLocalOnlyErr(t, err, "lk", "zone-2")
 	})
 	t.Run("UpsertDnsRecord", func(t *testing.T) {
 		err := c.UpsertDnsRecord(ctx, "zone-uuid", models.DnsRecord{})
-		assertLocalOnlyErr(t, err, "lk", "laptop")
+		assertLocalOnlyErr(t, err, "lk", "zone-2")
+	})
+	t.Run("DeleteDnsRecord", func(t *testing.T) {
+		err := c.DeleteDnsRecord(ctx, "zone-uuid", "record-uuid")
+		assertLocalOnlyErr(t, err, "lk", "zone-2")
 	})
 
-	// None of the plumbing methods should have touched the agent.
+	// None of the local-only plumbing methods should have touched the agent.
 	if got := agent.createCount() + agent.deleteCount() + agent.getCount(); got != 0 {
 		t.Errorf("plumbing methods touched the agent %d times, want 0", got)
 	}
@@ -271,17 +272,17 @@ func TestRemoteClient_PlumbingMethods_ReturnLocalOnlyErr(t *testing.T) {
 func TestRemoteClient_NoAgent_FailsClosedOnCRDOp(t *testing.T) {
 	// Mirror buildRemoteSet with NO live agent: the Routed decision always declines,
 	// so the accessor falls back to NoCreds — which must error clearly, never panic.
-	noCreds := clusteraccess.NewNoCreds("lk", "laptop")
+	noCreds := clusteraccess.NewNoCreds("lk", "zone-2")
 	routed := clusteraccess.NewRouted(noCreds, func(clusteraccess.Verb, schema.GroupVersionResource) (clusteraccess.Accessor, bool) {
 		return nil, false // no agent connected
 	})
-	c := NewRemoteClient(routed, "lk", "laptop")
+	c := NewRemoteClient(routed, "lk", "zone-2")
 
 	_, err := c.CreateVNet(context.Background(), "tenant", "proj", sampleVNetSpec())
 	if err == nil {
 		t.Fatal("CreateVNet returned nil error with no agent; it must fail closed")
 	}
-	if !strings.Contains(err.Error(), "no agent connected for zone lk/laptop") {
+	if !strings.Contains(err.Error(), "no agent connected for zone lk/zone-2") {
 		t.Errorf("error = %q, want it to name the zone and the no-agent cause", err.Error())
 	}
 

--- a/dc-api/internal/providers/registry.go
+++ b/dc-api/internal/providers/registry.go
@@ -418,7 +418,9 @@ func (r *Registry) For(region, zone string) (*ProviderSet, error) {
 //
 // The routed allow-set is gated per family via clusteraccess.RoutableVerbs(gvr)
 // (the capability registry's RouteVerbs for that GVR), then split reads (VerbGet)
-// by AgentRouteReads, writes (VerbCreate, VerbDelete) by AgentRouteWrites.
+// by AgentRouteReads, writes (VerbCreate, VerbApply, VerbDelete) by
+// AgentRouteWrites (VerbApply routes only for the families that declare it —
+// the Vpc/Subnet network-plumbing spec writes).
 func (r *Registry) agentDecision(region, zone string) clusteraccess.AgentDecision {
 	mapper := clusteraccess.DefaultGVKMapper()
 	fieldManager := "dc-api"


### PR DESCRIPTION
## What this changes

The VPC-plumbing write slice of the credential-locality work: **VPC peering append/remove, VPC static routes (route tables), and subnet ACLs (NSGs)** now run through the cluster-access seam, so these operations work in a remote, agent-only zone. Their feeding reads (the VPC/Subnet gets in the same functions) route through the seam too. Previously all four writes were raw merge patches on the direct dynamic client — local-only by construction.

## How it works

Each write becomes: seam `Get` (full object, via the agent in a remote zone) → compute the new list exactly as before → **server-side apply of a minimal object** (`apiVersion`/`kind`/`metadata.name` + exactly the one spec list being written). SSA is the agent's only write mechanism, and for these atomic CRD lists a minimal-object apply is semantically the same "set this field" write as the old merge patch.

**Why each list gets its own fieldManager** (`dc-api-kubeovn-vpcpeerings` / `-staticroutes` / `-acls`): server-side apply replaces a manager's *entire* applied field-set on every apply, so two sequential minimal applies under one shared manager would silently prune each other's lists — writing static routes would erase the peerings, and on agent-created VPCs a shared-manager apply would drop the namespace binding and ownership labels. Verified against the apiserver's own field-management engine (`managedfields` test harness, same apimachinery version as go.mod). Per-list managers keep each apply independent; `force=true` migrates field ownership from the legacy merge-patch managedFields entry on pre-existing objects.

## Seam contract change (please review)

`AgentBacked.Apply` now **forwards the caller's fieldManager** (empty still defaults to the accessor's own) instead of always pinning it, and gains the same per-family routability guard `Get`/`List` already have. The agent executor honors the wire `field_manager` end-to-end, so no dc-agent change is needed. `Create`/`Update` keep the accessor default — no behavior change for any existing routed write.

## RBAC

None: `VerbApply` joins the *routable* set for the vpc/subnet families, but their agent RBAC already granted `patch` (SSA-create needed it), so the generated `rbac.yaml` is **byte-identical** — the drift check proves it.

## Behavioral notes / caveats

- **Local wire change**: with routing off, these writes switch from `MergePatchType` to SSA on the direct client — semantically equivalent for these atomic lists, but a wire-level change; the first apply per list force-takes ownership from the old merge-patch managedFields entry.
- **Known edge (pre-existing shape, newly observable)**: on the agent path, re-running a VNet create against an existing VPC that already has route-table routes can surface an SSA conflict on the create manifest's empty `staticRoutes` seed instead of the direct path's idempotent AlreadyExists. Tracked as a follow-up (either drop the empty seed from the create manifest or map SSA conflicts on re-create to AlreadyExists).
- **Legacy peerings without an address-space in the spec**: the subnet-CIDR fallback list is deliberately not agent-routable (VerbList not widened for subnets), so on a remote zone that legacy path fails closed with a clear error naming the zone.
- Remote-zone test fixtures are normalized to generic zone names.

## Verification

Both build + vet clean; full unit suite passes (0 fail / 0 skip) including 18 new seam tests: per-op equivalence of the applied minimal object with the old merge-patch body, fieldManager + force per op, NotFound tolerances, the routing toggle, and remote (nil-dynamic) coverage. golangci-lint adds 0 new issues (7 pre-existing in these packages, untouched).

## Remaining pre-merge checks

Per repo policy for KubeOVN driver changes: a **live integration run** against a real KubeOVN cluster (routing off must behave as today; routing on with a connected agent must serve peering/routes/ACLs), and a **structural diff** of a generated minimal apply against a known-good live Vpc/Subnet — in particular confirming the CRD schemas treat these lists as atomic. Needs cluster access.

## Not included

NAT (F15) and per-VPC DNS (F20) remain local-only — they are the next slices (new capability families: NAT gateway CRDs, ConfigMaps, Deployments). Best-effort local cleanups (finalizer force-removes) stay deliberately direct-and-skipped on remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for routed network-plumbing updates, including apply-based changes for VPC peering, static routes, and subnet ACLs.
  * Expanded remote-zone handling so more cluster operations can work without relying on a local client.

* **Bug Fixes**
  * Fixed several cases where valid requests could be rejected or routed inconsistently.
  * Preserved request identity details during apply operations, improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->