### PR TITLE
[Fix] Scope the OVN MAC webhook to dc-api namespaces and provisioning time

### DIFF
--- a/dc-api/cmd/webhook/README.md
+++ b/dc-api/cmd/webhook/README.md
@@ -25,6 +25,24 @@ no-ops when all annotations already match.
 failurePolicy is Ignore — if the webhook is down, VMs on non-OVN NADs are
 unaffected. VMs on OVN NADs fall back to the pre-webhook failure mode.
 
+## Scope guards (post-incident hardening)
+
+The webhook is deliberately narrow, in layers:
+
+1. **Namespace scope** — the MutatingWebhookConfiguration carries a
+   `namespaceSelector` matching `dc-api/managed: "true"`, the label dc-api puts
+   on the per-project namespaces it provisions VMs and tenant clusters into.
+   Platform-infra VMs (the dcapi-controlplane RKE2 nodes in `default`,
+   harvester-system, …) are structurally never intercepted.
+2. **NAD-type filter** — the handler resolves each multus network to its NAD
+   and no-ops unless the CNI type is `kube-ovn`.
+3. **Provisioning-time only** — the handler never mutates a VM that already
+   has a live VMI (`status.created`/`status.ready`/`printableStatus`).
+   The annotations only take effect at VMI creation anyway, and mutating
+   `spec.template` on a running VM can trigger KubeVirt/CDI reconciliation of
+   the live instance. UPDATE stays registered solely for the pre-boot window
+   where Rancher pins the MAC after create but before first start.
+
 ## Running locally
 
     # Build

--- a/dc-api/internal/webhook/mutate.go
+++ b/dc-api/internal/webhook/mutate.go
@@ -52,6 +52,24 @@ func (m *Mutator) Handle(ctx context.Context, req *admissionv1.AdmissionRequest)
 		return allow(nil)
 	}
 
+	// Provisioning-time only: never mutate a VM that already has a live VMI.
+	// The OVN annotations live in spec.template and only take effect when the
+	// VMI is (re)created, so patching a running VM buys nothing — and a
+	// spec.template mutation on a live VM can trigger KubeVirt/CDI
+	// reconciliation of the running instance (implicated in a control-plane
+	// cluster outage post-mortem). MAC heals that arrive after first boot
+	// apply naturally on the next restart, when this webhook sees the
+	// pre-boot UPDATE again.
+	if vmHasLiveVMI(vm) {
+		m.log.Info().
+			Str("uid", string(req.UID)).
+			Str("operation", string(req.Operation)).
+			Str("namespace", req.Namespace).
+			Str("name", req.Name).
+			Msg("webhook: VM already has a live VMI — provisioning-time only, skipping")
+		return allow(nil)
+	}
+
 	patch, err := m.buildPatch(ctx, vm)
 	if err != nil {
 		m.log.Error().Err(err).Str("uid", string(req.UID)).Msg("webhook: failed to build patch — allowing unchanged")
@@ -228,6 +246,31 @@ func (m *Mutator) buildPatch(ctx context.Context, vm map[string]interface{}) ([]
 	}
 
 	return ops, nil
+}
+
+// vmHasLiveVMI reports whether the VirtualMachine already has a live VMI
+// behind it. status.created flips true as soon as KubeVirt instantiates the
+// VMI (status.ready once it is running); printableStatus is checked as a
+// belt-and-suspenders signal for in-flight lifecycle states. Pre-boot states
+// (no status, Stopped, Provisioning, WaitingForVolumeBinding, …) return
+// false so provisioning-time UPDATEs — e.g. Rancher pinning the MAC after
+// create but before start — are still mutated.
+func vmHasLiveVMI(vm map[string]interface{}) bool {
+	status, ok := getNestedMap(vm, "status")
+	if !ok {
+		return false
+	}
+	if created, _ := status["created"].(bool); created {
+		return true
+	}
+	if ready, _ := status["ready"].(bool); ready {
+		return true
+	}
+	switch s, _ := status["printableStatus"].(string); s {
+	case "Starting", "Running", "Paused", "Stopping", "Terminating", "Migrating":
+		return true
+	}
+	return false
 }
 
 // annotationOp returns the right RFC 6902 op ("add" or "replace") for a single

--- a/dc-api/internal/webhook/mutate_test.go
+++ b/dc-api/internal/webhook/mutate_test.go
@@ -309,6 +309,120 @@ func TestMissingMAC(t *testing.T) {
 	assert.Empty(t, patch, "missing MAC must produce empty patch — we never synthesise MACs")
 }
 
+// withStatus returns a copy of vm with the given status block attached —
+// simulating the object state KubeVirt maintains once the VM has been
+// processed (status.created/ready flip true when a VMI exists).
+func withStatus(vm map[string]interface{}, status map[string]interface{}) map[string]interface{} {
+	vm["status"] = status
+	return vm
+}
+
+// TestHandle_LiveVMI_NotMutated verifies the provisioning-time guard: a VM
+// whose VMI already exists (status.created=true) must NOT be patched, even
+// when its OVN annotations are missing. Mutating spec.template on a live VM
+// was implicated in a control-plane cluster outage post-mortem.
+func TestHandle_LiveVMI_NotMutated(t *testing.T) {
+	const (
+		nadNS   = "dc-hiran"
+		nadName = "subnet-hiran-vm-sn"
+		mac     = "02:11:22:33:44:55"
+	)
+	nadRef := nadNS + "/" + nadName
+
+	vm := withStatus(
+		buildVM(
+			[]interface{}{multusNetwork("ovn", nadRef)},
+			[]interface{}{bridgeInterface("ovn", mac)},
+			nil, // annotations missing — would normally be patched
+		),
+		map[string]interface{}{
+			"created":         true,
+			"ready":           true,
+			"printableStatus": "Running",
+		},
+	)
+	raw, err := json.Marshal(vm)
+	require.NoError(t, err)
+
+	req := &admissionv1.AdmissionRequest{UID: "live-vmi-uid", Operation: admissionv1.Update}
+	req.Object.Raw = raw
+
+	lookup := newFake(nadRef, cniTypeKubeOVN)
+	m := NewMutator(lookup, silentLogger())
+	resp := m.Handle(context.Background(), req)
+
+	assert.True(t, resp.Allowed)
+	assert.Empty(t, resp.Patch, "a VM with a live VMI must never be mutated")
+}
+
+// TestHandle_PreBootUpdate_StillMutated verifies that the guard does not
+// close the legitimate heal window: an UPDATE on a VM whose VMI has not been
+// created yet (e.g. Rancher pinning the MAC after create, before start) must
+// still be patched.
+func TestHandle_PreBootUpdate_StillMutated(t *testing.T) {
+	const (
+		nadNS   = "dc-hiran"
+		nadName = "subnet-hiran-vm-sn"
+		mac     = "02:11:22:33:44:55"
+	)
+	nadRef := nadNS + "/" + nadName
+
+	vm := withStatus(
+		buildVM(
+			[]interface{}{multusNetwork("ovn", nadRef)},
+			[]interface{}{bridgeInterface("ovn", mac)},
+			nil,
+		),
+		map[string]interface{}{
+			"created":         false,
+			"ready":           false,
+			"printableStatus": "Stopped",
+		},
+	)
+	raw, err := json.Marshal(vm)
+	require.NoError(t, err)
+
+	req := &admissionv1.AdmissionRequest{UID: "pre-boot-uid", Operation: admissionv1.Update}
+	req.Object.Raw = raw
+
+	lookup := newFake(nadRef, cniTypeKubeOVN)
+	m := NewMutator(lookup, silentLogger())
+	resp := m.Handle(context.Background(), req)
+
+	assert.True(t, resp.Allowed)
+	assert.NotEmpty(t, resp.Patch, "pre-boot UPDATE must still be patched — the heal window stays open")
+}
+
+// TestVMHasLiveVMI table-tests the status interpretation.
+func TestVMHasLiveVMI(t *testing.T) {
+	cases := []struct {
+		name   string
+		status map[string]interface{}
+		want   bool
+	}{
+		{"no status at all", nil, false},
+		{"empty status", map[string]interface{}{}, false},
+		{"created true", map[string]interface{}{"created": true}, true},
+		{"ready true", map[string]interface{}{"ready": true}, true},
+		{"printableStatus Running", map[string]interface{}{"printableStatus": "Running"}, true},
+		{"printableStatus Starting", map[string]interface{}{"printableStatus": "Starting"}, true},
+		{"printableStatus Migrating", map[string]interface{}{"printableStatus": "Migrating"}, true},
+		{"printableStatus Stopped", map[string]interface{}{"printableStatus": "Stopped", "created": false}, false},
+		{"printableStatus Provisioning", map[string]interface{}{"printableStatus": "Provisioning"}, false},
+		{"printableStatus WaitingForVolumeBinding", map[string]interface{}{"printableStatus": "WaitingForVolumeBinding"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vm := buildVM(nil, nil, nil)
+			if tc.status != nil {
+				vm = withStatus(vm, tc.status)
+			}
+			assert.Equal(t, tc.want, vmHasLiveVMI(vm))
+		})
+	}
+}
+
 // TestHandle_NilRequest verifies that a nil request is handled gracefully
 // and returns an allow response without panicking.
 func TestHandle_NilRequest(t *testing.T) {

--- a/flux/platform/dc-webhook/base/webhook.yaml
+++ b/flux/platform/dc-webhook/base/webhook.yaml
@@ -1,8 +1,20 @@
 # Mutating admission webhook: injects MAC-pinning + KubeOVN annotations on
 # KubeVirt VMs. failurePolicy: Ignore is intentional — if the webhook is down,
 # non-OVN VMs must not be blocked; OVN VMs just miss the MAC pinning (same as
-# before the webhook existed). The handler filters internally by NAD type and
-# no-ops on non-OVN VMs, so no namespaceSelector is needed.
+# before the webhook existed).
+#
+# Scope is layered, defense-in-depth (post-mortem of a control-plane cluster
+# outage, where an unscoped webhook was implicated):
+#   1. namespaceSelector: only namespaces labeled dc-api/managed=true — the
+#      per-project namespaces dc-api provisions VMs and tenant clusters into.
+#      Infra VMs (the dcapi-controlplane RKE2 nodes in `default`,
+#      harvester-system, …) are structurally out of reach, regardless of any
+#      handler bug.
+#   2. The handler filters by NAD type and no-ops on non-OVN VMs.
+#   3. The handler is provisioning-time only: it never mutates a VM whose VMI
+#      is already live (see vmHasLiveVMI in dc-api/internal/webhook/mutate.go).
+#      UPDATE stays registered for the pre-boot window where Rancher pins the
+#      MAC after create.
 #
 # The caBundle is injected by cert-manager's cainjector from the serving
 # Certificate (the inject-ca-from annotation), so it is omitted here and kept in
@@ -28,6 +40,9 @@ webhooks:
         resources: ["virtualmachines"]
         operations: ["CREATE", "UPDATE"]
         scope: Namespaced
+    namespaceSelector:
+      matchLabels:
+        dc-api/managed: "true"
     failurePolicy: Ignore
     sideEffects: None
     timeoutSeconds: 5


### PR DESCRIPTION
The dc-api-webhook injects KubeOVN MAC-pinning annotations onto KubeVirt VMs so tenant VMs on VPC subnets get working networking. Its only legitimate job is fixing up that metadata on dc-api-managed VMs while they are being created — but it was registered with no namespace scoping, so it intercepted every VM on the Harvester cluster (including the control-plane cluster's own RKE2 node VMs), and it would mutate a VM's `spec.template` on UPDATE even when the VM was already up and serving. Mutating a live VM's spec can make KubeVirt/CDI reconcile the running instance, and exactly that failure mode was implicated in a recent control-plane cluster outage post-mortem. Safety relied entirely on an internal code check; this PR makes the webhook structurally incapable of touching anything outside its job.

## Changes

- **`flux/platform/dc-webhook/base/webhook.yaml`** — added `namespaceSelector: dc-api/managed=true`, so only the per-project namespaces dc-api provisions VMs and tenant clusters into are intercepted. Platform-infra VMs (RKE2 node VMs in `default`, harvester-system, …) are structurally out of reach regardless of any handler bug. Rewrote the header comment that previously asserted "no namespaceSelector is needed".
- **`dc-api/internal/webhook/mutate.go`** — new `vmHasLiveVMI()` guard: the handler never mutates a VM whose VMI already exists (`status.created` / `status.ready` / `printableStatus`). The OVN annotations only take effect at VMI creation anyway. UPDATE stays registered solely for the pre-boot window where Rancher pins the MAC after create but before first start. Declined mutations are logged at info with VM name/namespace, so future incident investigations can rule the webhook in or out from its own logs.
- **`dc-api/internal/webhook/mutate_test.go`** — 3 new tests: a running VM is never patched; a pre-boot UPDATE is still patched (the heal window stays open); table-test of the status interpretation.
- **`dc-api/cmd/webhook/README.md`** — documents the three-layer scope guard.

## Operational side-effect

After this merges and Flux rolls the new MutatingWebhookConfiguration, the webhook stops receiving admission requests for VMs outside `dc-api/managed=true` namespaces entirely. If a tenant-cluster VM namespace is ever created without that label, its VMs would silently miss MAC pinning — namespace labeling is now load-bearing.

## Testing

`go test ./internal/webhook/` — 15/15 pass, including the 3 new guard tests. `go build ./...` clean. Scanner gate (`make scan`) reports no findings in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The mutating webhook now only applies during VM provisioning, avoiding changes to already running virtual machines.
  * Webhook matching is now limited to namespaces explicitly marked for management.

* **Bug Fixes**
  * Prevents unnecessary updates on live VMs while still applying required settings before boot.
  * Adds stronger guardrails to reduce unintended mutations.

* **Documentation**
  * Expanded webhook documentation to explain the new scoping and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->