### PR TITLE
Ignore rke_config.etcd_snapshot_create to prevent plan drift

### DIFF
--- a/modules/tenancy/k8s-cluster/main.tf
+++ b/modules/tenancy/k8s-cluster/main.tf
@@ -187,6 +187,11 @@ resource "rancher2_cluster_v2" "this" {
       rke_config[0].machine_selector_config,
       rke_config[0].upgrade_strategy[0].control_plane_drain_options,
       rke_config[0].upgrade_strategy[0].worker_drain_options,
+      # On-demand snapshots taken via the Rancher UI/API ("Snapshot Now") set
+      # etcd_snapshot_create.generation on the cluster object. It is not managed
+      # here, so without this every subsequent plan shows spurious drift trying to
+      # null it. Ignore it — scheduled snapshots stay Terraform-managed via etcd_s3.
+      rke_config[0].etcd_snapshot_create,
     ]
     precondition {
       condition     = !var.manage_rke_config || length(var.machine_pools) > 0


### PR DESCRIPTION
## Purpose
Resolves #220. On-demand etcd snapshots taken via the Rancher UI/API ("Snapshot Now") set `rke_config.etcd_snapshot_create.generation` on the provisioning cluster object. The `k8s-cluster` module does not manage that field, so every subsequent `terraform plan` shows spurious in-place drift trying to null it (e.g. `etcd_snapshot_create { generation = 1 -> null }`).

## Goals
Stop the drift while keeping scheduled snapshots Terraform-managed.

## Approach
Add `rke_config[0].etcd_snapshot_create` to the cluster resource's existing `lifecycle { ignore_changes = [...] }` (alongside `chart_values` / `machine_selector_config`). On-demand snapshots stay a UI/API action; the *schedule* remains managed via the `etcd_s3` input.

## Release note
Fix: `k8s-cluster` no longer shows plan drift after an on-demand etcd snapshot is taken from the Rancher UI.

## Documentation
The behavior is noted in the backups guide (#219, `examples/BACKUPS.md` §A.6).

## Automation tests
N/A. Observed and reproduced on a live cluster: after a UI "Snapshot Now", `terraform plan` repeatedly proposed nulling `etcd_snapshot_create`; with this change the plan is clean. `terraform fmt -check` passes on the changed file.

## Security checks
- No secrets committed? yes — single-line `ignore_changes` addition, no values.

## Compatibility
Non-breaking — additive to `ignore_changes`, no variable/output surface change. 

## Related PRs
- #219 (docs: backups guide) — documents this drift in §A.6.

_Other template sections (Training, Certification, Marketing, Migrations, Samples): N/A._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unexpected Terraform plan drift for Kubernetes clusters after using the manual **Snapshot Now** action.
  * Subsequent applies should now stay stable while scheduled snapshot settings remain managed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->