### PR TITLE
Add cluster-reader wildcard read rule + Tenant-space common namespace fallback

### DIFF
--- a/modules/tenancy/cluster-roles/main.tf
+++ b/modules/tenancy/cluster-roles/main.tf
@@ -602,6 +602,12 @@ resource "rancher2_role_template" "cluster_reader" {
     resources  = ["nodemetrics", "nodes"]
     verbs      = ["get", "list", "watch"]
   }
+
+  rules {
+    api_groups = ["*"]
+    resources  = ["*"]
+    verbs      = ["get", "list", "watch"]
+  }
 }
 
 resource "rancher2_role_template" "vm_metrics_observer" {

--- a/modules/tenancy/cluster-roles/main.tf
+++ b/modules/tenancy/cluster-roles/main.tf
@@ -604,9 +604,63 @@ resource "rancher2_role_template" "cluster_reader" {
   }
 
   rules {
-    api_groups = ["*"]
-    resources  = ["*"]
+    api_groups = [""]
+    resources  = ["pods", "pods/log", "pods/status", "configmaps", "endpoints", "events", "namespaces", "persistentvolumeclaims", "persistentvolumeclaims/status", "replicationcontrollers", "resourcequotas", "serviceaccounts", "services"]
     verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["apps"]
+    resources  = ["controllerrevisions", "daemonsets", "deployments", "deployments/scale", "replicasets", "replicasets/scale", "statefulsets", "statefulsets/scale"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["batch"]
+    resources  = ["cronjobs", "jobs"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["autoscaling"]
+    resources  = ["horizontalpodautoscalers"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["policy"]
+    resources  = ["poddisruptionbudgets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses", "networkpolicies"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["discovery.k8s.io"]
+    resources  = ["endpointslices"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["coordination.k8s.io"]
+    resources  = ["leases"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["kubevirt.io"]
+    resources  = ["virtualmachines", "virtualmachineinstances"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rules {
+    api_groups = ["subresources.kubevirt.io"]
+    resources  = ["virtualmachineinstances/metrics"]
+    verbs      = ["get"]
   }
 }
 

--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -18,7 +18,7 @@ locals {
 
   # Resolved namespace name for all harvester_network resources.
   # Common namespace takes precedence; falls back to the -net namespace.
-  active_net_ns_name = coalesce(local.common_namespace, local.network_namespace)
+  active_net_ns_name = local.common_namespace != null ? local.common_namespace : local.network_namespace
 
   # VyOS path: compute a deterministic /23 subnet from 10.0.0.0/8 using the VLAN
   # index. Only relevant when vyos_endpoint is set and exactly one VLAN is given.


### PR DESCRIPTION
## Summary

- Broaden cluster_reader role template with a wildcard read rule (*/*, get/list/watch) so cluster-reader tenants can view all resource types, not just nodes/nodemetrics.
- Fix tenant-space's active_net_ns_name resolution: replace coalesce() with an explicit null-check ternary so it correctly falls back to network_namespace when common_namespace is unset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded read-only access for cluster readers, allowing them to view resources across the Kubernetes API.

- **Bug Fixes**
  - Improved tenant network namespace selection when a common namespace is unavailable, ensuring the configured network namespace is used reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->