### PR TITLE
Remove cloud init disk size from VM module

### DIFF
--- a/modules/tenancy/vm/main.tf
+++ b/modules/tenancy/vm/main.tf
@@ -91,24 +91,14 @@ resource "harvester_virtualmachine" "this" {
     }
   }
 
-  # cloudinitdisk is automatically created when cloudinit is created. 
-  # We ignore the size of the cloudinitdisk as it is managed by cloudinit.
+  # cloudinitdisk is automatically created when cloudinit is created.
   dynamic "disk" {
     for_each = length(harvester_cloudinit_secret.this) > 0 ? [1] : []
     content {
       name = "cloudinitdisk"
       type = "disk"
       bus  = "virtio"
-      size = "0Gi"
     }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      # Ignore the entire cloudinitdisk at index 1.
-      # The Size of the cloudinit disk is managed automatically by cloudinit and ignored in terraform.
-      disk[1].size
-    ]
   }
 }
 

--- a/modules/tenancy/vm/main.tf
+++ b/modules/tenancy/vm/main.tf
@@ -11,11 +11,25 @@ locals {
   ) : null
 
   effective_user_data = var.user_data != null ? var.user_data : local._generated_user_data
+
+  # When cloudinit_secret_name is set, reference that
+  # existing secret directly instead of creating one named
+  # "${var.name}-cloud-config". Use for VMs whose cloud-init secret already
+  # exists under a name that doesn't match this module's derived convention
+  # (e.g. a Harvester-UI generated random suffix) — renaming it would be a
+  # ForceNew replace. Harvester-UI-created VMs commonly point both the
+  # user-data and network-data refs at the same secret object, so the
+  # override applies to both.
+  cloudinit_secret_name = var.cloudinit_secret_name != null ? var.cloudinit_secret_name : (
+    length(harvester_cloudinit_secret.this) > 0 ? harvester_cloudinit_secret.this[0].name : null
+  )
+  has_cloudinit = local.cloudinit_secret_name != null
 }
 
 # Optional Harvester Cloud-Init Secret to hold the cloud-init data.
+# Skipped when var.cloudinit_secret_name references a pre-existing secret.
 resource "harvester_cloudinit_secret" "this" {
-  count = local.effective_user_data != null ? 1 : 0
+  count = local.effective_user_data != null && var.cloudinit_secret_name == null ? 1 : 0
 
   name      = "${var.name}-cloud-config"
   namespace = var.namespace
@@ -84,16 +98,19 @@ resource "harvester_virtualmachine" "this" {
   }
 
   dynamic "cloudinit" {
-    for_each = length(harvester_cloudinit_secret.this) > 0 ? [1] : []
+    for_each = local.has_cloudinit ? [1] : []
     content {
-      user_data_secret_name = harvester_cloudinit_secret.this[0].name
+      user_data_secret_name = local.cloudinit_secret_name
       network_data          = var.network_data
+      # Only set when referencing a pre-existing secret (brownfield override) —
+      # module-created secrets only ever hold user_data.
+      network_data_secret_name = var.cloudinit_secret_name
     }
   }
 
   # cloudinitdisk is automatically created when cloudinit is created.
   dynamic "disk" {
-    for_each = length(harvester_cloudinit_secret.this) > 0 ? [1] : []
+    for_each = local.has_cloudinit ? [1] : []
     content {
       name = "cloudinitdisk"
       type = "disk"

--- a/modules/tenancy/vm/variables.tf
+++ b/modules/tenancy/vm/variables.tf
@@ -84,6 +84,12 @@ variable "network_data" {
   default     = ""
 }
 
+variable "cloudinit_secret_name" {
+  type        = string
+  description = "Name of a pre-existing harvester_cloudinit_secret to reference for both user_data and network_data, instead of creating one named \"<name>-cloud-config\". Brownfield override for VMs whose cloud-init secret already exists under a different name (e.g. Harvester-UI generated). When set, user_data/password/ssh_authorized_keys are ignored for secret creation purposes (no new secret is created)."
+  default     = null
+}
+
 variable "create_ssh_key" {
   type        = bool
   description = "When true, create a harvester_ssh_key from ssh_public_key and attach it to the VM. Must be true for ssh_public_key to have any effect."


### PR DESCRIPTION
## Summary

- We were adding 0Gi as the cloud init disk size and been ignoring it from lifecycle blocks, With this change we no longer need to ignore it. After removing the size field permanent drift of cloud init disk will be removed.
- New variable `cloudinit_secret_name` (string, default `null`) — brownfield override for VMs whose cloud-init secret already exists under a different name (e.g. Harvester-UI generated with a random suffix), where renaming to the module's derived convention would force a replace.
- Secret creation is now conditional: `harvester_cloudinit_secret.this` count is skipped whenever `cloudinit_secret_name` is set, avoiding a duplicate secret.
- New local `cloudinit_secret_name` resolves to the override if given, else falls back to the module-created secret's name.
- New local `has_cloudinit` replaces the old `length(harvester_cloudinit_secret.this) > 0` checks gating the `cloudinit`/`disk` blocks.
- The VM's `cloudinit` block now also sets `network_data_secret_name = var.cloudinit_secret_name`, populated only in the override case (module-created secrets only ever hold `user_data`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of automatically created cloud-init disks during infrastructure updates.
  * Prevented unnecessary conflicts caused by fixed cloud-init disk size settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->