### PR TITLE
Remove cloudinit disk block from vm module & Sanitize role binding names

### DIFF
--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -264,7 +264,7 @@ resource "rancher2_project_role_template_binding" "this" {
     "${var.project_name}--${coalesce(b.group_principal_id, b.group_id, b.user_principal_id, b.user_id)}--${idx}" => b
   }
 
-  name               = substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63)
+  name               = trim(substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63), "-")
   project_id         = rancher2_project.this.id
   role_template_id   = each.value.role_template_id
   group_principal_id = each.value.group_principal_id
@@ -315,7 +315,7 @@ data "rancher2_project" "shared_images" {
 resource "rancher2_project_role_template_binding" "shared_image_access" {
   for_each = local.shared_image_bindings
 
-  name               = each.key
+  name               = trim(substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63), "-")
   project_id         = data.rancher2_project.shared_images[0].id
   role_template_id   = "read-only"
   group_principal_id = each.value.group_principal_id

--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -253,6 +253,36 @@ module "vyos_tenant" {
 }
 
 
+# ── Sanitized, collision-safe name for a rancher2_project_role_template_binding key ──
+# Rancher/Kubernetes object names are capped at 63 chars (RFC 1123), but a plain
+# substr() truncation can collapse two distinct long keys down to the same
+# 63-char prefix, causing a name collision. `name` is ForceNew on this resource,
+# so changing it always destroys+recreates the binding — keys short enough to
+# fit as-is are left completely untouched (the vast majority; existing tenant
+# spaces are unaffected). Only keys that would actually be truncated get a
+# hash-of-the-full-key suffix appended, guaranteeing uniqueness for just those.
+locals {
+  _rtb_name_max_len = 63
+  _rtb_hash_len     = 8
+
+  _rtb_sanitize = { for k in setunion(
+    keys({
+      for idx, b in var.group_role_bindings :
+      "${var.project_name}--${coalesce(b.group_principal_id, b.group_id, b.user_principal_id, b.user_id)}--${idx}" => b
+    }),
+    keys(local.shared_image_bindings),
+    ) : k => replace(replace(lower(k), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-")
+  }
+
+  rtb_names = {
+    for k, sanitized in local._rtb_sanitize : k => (
+      length(sanitized) <= local._rtb_name_max_len
+      ? trim(sanitized, "-")
+      : "${trim(substr(sanitized, 0, local._rtb_name_max_len - local._rtb_hash_len - 1), "-")}-${substr(sha1(k), 0, local._rtb_hash_len)}"
+    )
+  }
+}
+
 # ── One binding per (principal, role) pair. ───────────────────────────────────
 # Key is derived from the principal value + role so that switching principal
 # type (e.g. group_principal_id → user_principal_id) produces a different key,
@@ -264,7 +294,7 @@ resource "rancher2_project_role_template_binding" "this" {
     "${var.project_name}--${coalesce(b.group_principal_id, b.group_id, b.user_principal_id, b.user_id)}--${idx}" => b
   }
 
-  name               = trim(substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63), "-")
+  name               = local.rtb_names[each.key]
   project_id         = rancher2_project.this.id
   role_template_id   = each.value.role_template_id
   group_principal_id = each.value.group_principal_id
@@ -315,7 +345,7 @@ data "rancher2_project" "shared_images" {
 resource "rancher2_project_role_template_binding" "shared_image_access" {
   for_each = local.shared_image_bindings
 
-  name               = trim(substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63), "-")
+  name               = local.rtb_names[each.key]
   project_id         = data.rancher2_project.shared_images[0].id
   role_template_id   = "read-only"
   group_principal_id = each.value.group_principal_id

--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -253,36 +253,6 @@ module "vyos_tenant" {
 }
 
 
-# ── Sanitized, collision-safe name for a rancher2_project_role_template_binding key ──
-# Rancher/Kubernetes object names are capped at 63 chars (RFC 1123), but a plain
-# substr() truncation can collapse two distinct long keys down to the same
-# 63-char prefix, causing a name collision. `name` is ForceNew on this resource,
-# so changing it always destroys+recreates the binding — keys short enough to
-# fit as-is are left completely untouched (the vast majority; existing tenant
-# spaces are unaffected). Only keys that would actually be truncated get a
-# hash-of-the-full-key suffix appended, guaranteeing uniqueness for just those.
-locals {
-  _rtb_name_max_len = 63
-  _rtb_hash_len     = 8
-
-  _rtb_sanitize = { for k in setunion(
-    keys({
-      for idx, b in var.group_role_bindings :
-      "${var.project_name}--${coalesce(b.group_principal_id, b.group_id, b.user_principal_id, b.user_id)}--${idx}" => b
-    }),
-    keys(local.shared_image_bindings),
-    ) : k => replace(replace(lower(k), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-")
-  }
-
-  rtb_names = {
-    for k, sanitized in local._rtb_sanitize : k => (
-      length(sanitized) <= local._rtb_name_max_len
-      ? trim(sanitized, "-")
-      : "${trim(substr(sanitized, 0, local._rtb_name_max_len - local._rtb_hash_len - 1), "-")}-${substr(sha1(k), 0, local._rtb_hash_len)}"
-    )
-  }
-}
-
 # ── One binding per (principal, role) pair. ───────────────────────────────────
 # Key is derived from the principal value + role so that switching principal
 # type (e.g. group_principal_id → user_principal_id) produces a different key,
@@ -294,7 +264,11 @@ resource "rancher2_project_role_template_binding" "this" {
     "${var.project_name}--${coalesce(b.group_principal_id, b.group_id, b.user_principal_id, b.user_id)}--${idx}" => b
   }
 
-  name               = local.rtb_names[each.key]
+  # Long keys get a hash-of-the-key suffix instead of a plain 63-char truncation,
+  # so two long keys can't collide onto the same name. Short keys (the vast
+  # majority — existing tenant spaces) are untouched: name is ForceNew, so
+  # changing it would destroy+recreate the binding.
+  name               = length(each.key) <= 63 ? trim(substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63), "-") : "${substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 54)}-${substr(sha1(each.key), 0, 8)}"
   project_id         = rancher2_project.this.id
   role_template_id   = each.value.role_template_id
   group_principal_id = each.value.group_principal_id
@@ -345,7 +319,7 @@ data "rancher2_project" "shared_images" {
 resource "rancher2_project_role_template_binding" "shared_image_access" {
   for_each = local.shared_image_bindings
 
-  name               = local.rtb_names[each.key]
+  name               = length(each.key) <= 63 ? trim(substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 63), "-") : "${substr(replace(replace(lower(each.key), "/[^a-z0-9-]/", "-"), "/-{2,}/", "-"), 0, 54)}-${substr(sha1(each.key), 0, 8)}"
   project_id         = data.rancher2_project.shared_images[0].id
   role_template_id   = "read-only"
   group_principal_id = each.value.group_principal_id

--- a/modules/tenancy/vm/main.tf
+++ b/modules/tenancy/vm/main.tf
@@ -108,15 +108,8 @@ resource "harvester_virtualmachine" "this" {
     }
   }
 
-  # cloudinitdisk is automatically created when cloudinit is created.
-  dynamic "disk" {
-    for_each = local.has_cloudinit ? [1] : []
-    content {
-      name = "cloudinitdisk"
-      type = "disk"
-      bus  = "virtio"
-    }
-  }
+  # No explicit "disk" block for cloudinitdisk — known perpetual-diff
+  # provider issue, see https://github.com/harvester/harvester/issues/10728
 }
 
 # Optional scheduled backup — created only when backup_schedule is set.


### PR DESCRIPTION
## Summary

- **vm module**: Remove the explicit `cloudinitdisk` disk block in `harvester_virtualmachine`. Declaring it caused Harvester's webhook to provision a real, permanently-orphaned PVC for a volume that's actually backed by `cloudInitNoCloud` (not a PVC) — the PVC has no owner reference and is never cleaned up, even with `auto_delete = true`, because Harvester's delete-time cleanup only matches PVC-backed volumes. Omitting the block avoids the leak; the tradeoff is a harmless, permanent no-op diff on `terraform plan` for any VM using cloud-init, which is a known upstream provider bug ([harvester/harvester#10728](https://github.com/harvester/harvester/issues/10728)).

- **tenant-space module**: Sanitize `rancher2_project_role_template_binding` names with `trim(..., "-")` after the existing `substr`/`replace` pipeline. `substr` can truncate a sanitized name mid-word, leaving a trailing `-`, which is invalid per RFC 1123 label rules. Applied to both the per-binding `this` resource and the `shared_image_access` resource, the latter of which also lacked any sanitization at all (`each.key` used raw, but can contain spaces/uppercase from `var.project_name` like `"WSO2 Cloud"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated resource naming to meet naming requirements and prevent collisions.
  * Updated virtual machine provisioning to rely on automatic cloud-init disk handling for more consistent setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->