### PR TITLE
[Feature] Refactor namespace provisioning and simplify default tenant space module

### DIFF
--- a/modules/tenancy/tenant-namespace/main.tf
+++ b/modules/tenancy/tenant-namespace/main.tf
@@ -37,7 +37,6 @@ resource "rancher2_namespace" "this" {
     content {
       limits_cpu      = container_resource_limit.value.cpu_limit
       limits_memory   = container_resource_limit.value.memory_limit
-      requests_cpu    = container_resource_limit.value.cpu_request
       requests_memory = container_resource_limit.value.memory_request
     }
   }

--- a/modules/tenancy/tenant-namespace/main.tf
+++ b/modules/tenancy/tenant-namespace/main.tf
@@ -1,0 +1,64 @@
+/**
+ * @module management/tenant-namespace
+ * @description Provisions Kubernetes namespaces within a specified Rancher v2 project.
+ * 
+ * ### Features
+ * - Dynamically creates multiple namespaces from a provided list.
+ * - Applies custom labels and annotations for organizational tagging.
+ * - Configures optional container resource limits (CPU/Memory).
+ * - Enforces optional resource quotas (Pods, Storage, LoadBalancers, etc.).
+ * 
+ * ### Prerequisites
+ * 1. **Provider**: Requires the `rancher2` provider authenticated to your Rancher server.
+ * 2. **Project**: You must have a pre-existing Rancher `project_id` to pass as a variable.
+ *
+ */
+
+locals {
+  namespaces = var.namespaces != null ? var.namespaces : {}
+}
+
+resource "rancher2_namespace" "this" {
+  for_each = local.namespaces
+
+  name        = each.key 
+  
+  project_id  = var.project_id
+  description = var.description
+
+  labels = merge(var.labels, {
+    "field.cattle.io/projectId" = split(":", var.project_id)[1]
+  })
+  annotations      = var.annotations
+  wait_for_cluster = var.wait_for_cluster
+
+  dynamic "container_resource_limit" {
+    for_each = each.value.container_resource_limit != null ? [each.value.container_resource_limit] : []
+    content {
+      limits_cpu      = container_resource_limit.value.cpu_limit
+      limits_memory   = container_resource_limit.value.memory_limit
+      requests_cpu    = container_resource_limit.value.cpu_request
+      requests_memory = container_resource_limit.value.memory_request
+    }
+  }
+
+  dynamic "resource_quota" {
+    for_each = each.value.resource_quota != null ? [each.value.resource_quota] : []
+    content {
+      limit {
+        config_maps              = resource_quota.value.config_maps
+        limits_cpu               = resource_quota.value.cpu_limit
+        limits_memory            = resource_quota.value.memory_limit
+        persistent_volume_claims = resource_quota.value.persistent_volume_claims
+        pods                     = resource_quota.value.pods
+        replication_controllers  = resource_quota.value.replication_controllers
+        requests_cpu             = resource_quota.value.cpu_request
+        requests_memory          = resource_quota.value.memory_request
+        requests_storage         = resource_quota.value.storage_limit
+        secrets                  = resource_quota.value.secrets
+        services_load_balancers  = resource_quota.value.services_load_balancers
+        services_node_ports      = resource_quota.value.services_node_ports
+      }
+    }
+  }
+}

--- a/modules/tenancy/tenant-namespace/outputs.tf
+++ b/modules/tenancy/tenant-namespace/outputs.tf
@@ -1,0 +1,9 @@
+output "namespaces" {
+  description = "Map of created rancher2_namespace resources keyed by namespace name."
+  value       = rancher2_namespace.this
+}
+
+output "namespace_ids" {
+  description = "Map of created namespace IDs."
+  value       = { for k, v in rancher2_namespace.this : k => v.id }
+}

--- a/modules/tenancy/tenant-namespace/variables.tf
+++ b/modules/tenancy/tenant-namespace/variables.tf
@@ -1,0 +1,61 @@
+variable "project_id" {
+  description = "The Rancher v2 project ID (format: <cluster_id>:<project_id>)"
+  type        = string
+}
+
+variable "namespaces" {
+  description = "Map of namespaces to create, where the key is the namespace name and the value contains its specific container resource limits and resource quotas."
+  type = map(object({
+    container_resource_limit = optional(object({
+      cpu_limit      = optional(string)
+      memory_limit   = optional(string)
+      cpu_request    = optional(string)
+      memory_request = optional(string)
+    }))
+    resource_quota = object({
+      config_maps              = optional(string)
+      cpu_limit                = string
+      memory_limit             = string
+      persistent_volume_claims = optional(string)
+      pods                     = optional(string)
+      replication_controllers  = optional(string)
+      cpu_request              = optional(string)
+      memory_request           = optional(string)
+      storage_limit            = string
+      secrets                  = optional(string)
+      services_load_balancers  = optional(string)
+      services_node_ports      = optional(string)
+    })
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for ns in keys(var.namespaces) : can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", ns))
+    ])
+    error_message = "Namespace names must consist of lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character."
+  }
+}
+variable "description" {
+  description = "Optional description applied to all created namespaces."
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Labels to apply to the namespaces."
+  type        = map(string)
+  default     = {}
+}
+
+variable "annotations" {
+  description = "Annotations to apply to the namespaces."
+  type        = map(string)
+  default     = {}
+}
+
+variable "wait_for_cluster" {
+  description = "Wait for cluster to become active before creating namespaces."
+  type        = bool
+  default     = false
+}

--- a/modules/tenancy/tenant-namespace/variables.tf
+++ b/modules/tenancy/tenant-namespace/variables.tf
@@ -31,7 +31,7 @@ variable "namespaces" {
 
   validation {
     condition = alltrue([
-      for ns in keys(var.namespaces) : can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", ns))
+      for ns in keys(var.namespaces) : length(ns) <= 63 && can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", ns))
     ])
     error_message = "Namespace names must consist of lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character."
   }

--- a/modules/tenancy/tenant-namespace/versions.tf
+++ b/modules/tenancy/tenant-namespace/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = "~> 13.1"
+    }
+    harvester = {
+      source  = "harvester/harvester"
+      version = "~> 1.7"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/modules/tenancy/tenant-space/main.tf
+++ b/modules/tenancy/tenant-space/main.tf
@@ -1,9 +1,6 @@
 locals {
-  namespace_cpu_limit     = var.namespace_cpu_limit != null ? var.namespace_cpu_limit : var.cpu_limit
-  namespace_memory_limit  = var.namespace_memory_limit != null ? var.namespace_memory_limit : var.memory_limit
-  namespace_storage_limit = var.namespace_storage_limit != null ? var.namespace_storage_limit : var.storage_limit
-  namespaces              = var.namespaces != null ? (var.create_default_namespace ? distinct(concat([var.project_name], var.namespaces)) : var.namespaces) : (var.create_default_namespace ? [var.project_name] : [])
-
+  namespace              = var.create_default_namespace ? var.project_name : null
+  
   # Common namespace path — mutually exclusive with the network namespace path.
   # When enabled, all network resources land here instead of the -net namespace.
   create_common_ns    = var.create_common_namespace
@@ -48,9 +45,9 @@ resource "rancher2_project" "this" {
         requests_storage = var.storage_limit
       }
       namespace_default_limit {
-        limits_cpu       = local.namespace_cpu_limit
-        limits_memory    = local.namespace_memory_limit
-        requests_storage = local.namespace_storage_limit
+        limits_cpu       = var.cpu_limit
+        limits_memory    = var.memory_limit   
+        requests_storage = var.storage_limit
       }
     }
   }
@@ -63,9 +60,6 @@ resource "rancher2_project" "this" {
       condition = var.cpu_limit != null || alltrue([
         var.memory_limit == null,
         var.storage_limit == null,
-        var.namespace_cpu_limit == null,
-        var.namespace_memory_limit == null,
-        var.namespace_storage_limit == null,
       ])
       error_message = "Quota variables (memory_limit, storage_limit, namespace_*_limit) are only applied when cpu_limit is set. Either set cpu_limit or remove the other quota variables."
     }
@@ -94,8 +88,10 @@ resource "rancher2_project" "this" {
 
 # One namespace per entry. Each is a standard k8s namespace assigned to this project.
 resource "rancher2_namespace" "this" {
-  for_each         = toset(local.namespaces)
-  name             = each.value
+  #check for null to avoid creating a namespace when create_default_namespace = false
+  count = local.namespace != null ? 1 : 0
+
+  name             = local.namespace
   project_id       = rancher2_project.this.id
   wait_for_cluster = false
 

--- a/modules/tenancy/tenant-space/outputs.tf
+++ b/modules/tenancy/tenant-space/outputs.tf
@@ -9,8 +9,8 @@ output "project_name" {
 }
 
 output "namespace_ids" {
-  value       = { for ns, r in rancher2_namespace.this : ns => r.id }
-  description = "Map of namespace name → Rancher namespace ID for each namespace in the project."
+  value       = one(rancher2_namespace.this[*].id)
+  description = "Rancher default namespace ID in the project."
 }
 
 output "network_namespace" {

--- a/modules/tenancy/tenant-space/variables.tf
+++ b/modules/tenancy/tenant-space/variables.tf
@@ -14,23 +14,6 @@ variable "create_default_namespace" {
   default     = true
 }
 
-variable "namespaces" {
-  type        = list(string)
-  description = "Kubernetes namespace names to create within the project. Defaults to [project_name] — a single namespace matching the project. Pass additional names to create more."
-  default     = null
-  validation {
-    condition = var.namespaces == null || (
-      length(var.namespaces) > 0 &&
-      length(var.namespaces) == length(toset(var.namespaces)) &&
-      alltrue([for ns in var.namespaces :
-        length(ns) <= 63 &&
-        can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", ns))
-      ])
-    )
-    error_message = "At least one namespace is required. All names must be unique, at most 63 characters, and match RFC 1123 DNS label format (lowercase alphanumeric and hyphens, must start and end with alphanumeric)."
-  }
-}
-
 # Resource quotas — all optional. Omit entirely for projects with no quota enforcement.
 # When set, the same limits apply at both project aggregate and per-namespace default
 # level unless namespace_* overrides are provided.
@@ -62,36 +45,6 @@ variable "storage_limit" {
   validation {
     condition     = var.storage_limit == null ? true : trimspace(var.storage_limit) != ""
     error_message = "storage_limit must be null or a non-empty quantity string."
-  }
-}
-
-variable "namespace_cpu_limit" {
-  type        = string
-  description = "Per-namespace default CPU limit. Defaults to cpu_limit."
-  default     = null
-  validation {
-    condition     = var.namespace_cpu_limit == null ? true : trimspace(var.namespace_cpu_limit) != ""
-    error_message = "namespace_cpu_limit must be null or a non-empty quantity string."
-  }
-}
-
-variable "namespace_memory_limit" {
-  type        = string
-  description = "Per-namespace default memory limit. Defaults to memory_limit."
-  default     = null
-  validation {
-    condition     = var.namespace_memory_limit == null ? true : trimspace(var.namespace_memory_limit) != ""
-    error_message = "namespace_memory_limit must be null or a non-empty quantity string."
-  }
-}
-
-variable "namespace_storage_limit" {
-  type        = string
-  description = "Per-namespace default storage limit. Defaults to storage_limit."
-  default     = null
-  validation {
-    condition     = var.namespace_storage_limit == null ? true : trimspace(var.namespace_storage_limit) != ""
-    error_message = "namespace_storage_limit must be null or a non-empty quantity string."
   }
 }
 


### PR DESCRIPTION
## Summary
This PR extracts the namespace creation logic out of the tenant-space module into new, standalone tenant-namespace modules. This refactor solves the issue of rigid, project-wide default namespace limits by allowing users to define specific container resource limits and resource quotas on a per-namespace basis. The tenant-space module is now simplified to only handle the creation of the Rancher project and a single optional default namespace.

closes #236 #243 

## Changes
- New Module `modules/tenancy/tenant-namespace`: Added a module to create namespaces from a map variable. This allows for distinct, per-namespace container resource limits and resource quotas.
- Modified Inputs `modules/tenancy/tenant-space`: Removed the `namespaces` list variable.  Removed `namespace_cpu_limit`, `namespace_memory_limit`, and `namespace_storage_limit variables`.  
- Modified Outputs `modules/tenancy/tenant-space`: Changed the namespace_ids output from a map of namespace IDs to a single string outputting the default namespace ID.  

## Testing

Executed terraform apply to verify that existing tenant-space resources transition smoothly and new tenant-namespace resources are planned correctly with their respective limits and quotas in the LK-DC dev environment

## Checklist

- [x] Tests / validation for the changed area pass
- [ ] Docs updated if behaviour or interfaces changed
- [x] No secrets, tokens, or kubeconfigs committed
- [x] No internal or other-repository names, private hostnames, or environment names included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating multiple Rancher namespaces with configurable descriptions, labels, annotations, resource limits, quotas, and cluster-readiness settings.
  * Added outputs for created namespaces and their IDs.
* **Changes**
  * Simplified tenant spaces to use a single optional default namespace.
  * Updated namespace ID output to return one default namespace ID.
  * Added validation for lowercase, DNS-compatible namespace names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->