### PR TITLE
Support renewing the Harvester cloud credential's kubeconfig token in k8s module

### DIFF
--- a/modules/tenancy/k8s-cluster/README.md
+++ b/modules/tenancy/k8s-cluster/README.md
@@ -191,6 +191,36 @@ module "my_rke2_cluster" {
 }
 ```
 
+## Dynamic Harvester cloud credential (`create_cloud_credential`)
+
+Separately from the cloud provider secret above, `create_cloud_credential = true` has the
+module provision a `rancher2_cloud_credential` itself — the credential Rancher's Harvester
+node driver uses to provision/manage VMs and disks for this cluster's machine pools. It's
+built from the imported Harvester cluster's kubeconfig (`data.rancher2_cluster_v2.harvester`),
+fetched dynamically via `harvester_cluster_name`/`harvester_cluster_id`, `rancher_api_url`,
+and `rancher_api_token` — no kubeconfig content is ever supplied by hand.
+
+```hcl
+module "my_rke2_cluster" {
+  # ...
+  create_cloud_credential = true
+  harvester_cluster_name  = "us-dc-harvester-cluster"
+  rancher_api_url         = var.rancher_api_url
+  rancher_api_token       = var.rancher_api_token
+}
+```
+
+Rancher's embedded token for this credential expires periodically. To renew it, bump
+`harvester_credential_rotation`:
+
+```hcl
+  harvester_credential_rotation = 1  # was 0 — fetches a fresh kubeconfig and updates
+                                      # the existing credential in place
+```
+
+This requires Terraform >= 1.16 (the module's `store.sensitive_output` mechanism, which
+keeps the token from ever rendering in plan/apply output).
+
 ## Brownfield import
 
 For clusters already running in Rancher that were not provisioned by this module:

--- a/modules/tenancy/k8s-cluster/main.tf
+++ b/modules/tenancy/k8s-cluster/main.tf
@@ -1,5 +1,7 @@
 terraform {
-  required_version = ">= 1.7"
+  # >= 1.16 for terraform_data's store.sensitive_output block, used to safely gate
+  # renewal of the Harvester cloud credential's kubeconfig token (see below).
+  required_version = ">= 1.16"
   required_providers {
     rancher2 = {
       source  = "rancher/rancher2"
@@ -370,24 +372,21 @@ data "http" "harvester_cloud_provider_kubeconfig" {
 }
 
 # Rancher mints a new token in data.rancher2_cluster_v2.harvester[0].kube_config on
-# every refresh, so using that value directly would make the cloud credential drift
-# on every plan. terraform_data pins the value across applies (ignore_changes on
-# input) and only re-reads the live, freshly-fetched kube_config when
-# harvester_credential_rotation is bumped (triggers_replace forces the resource, and
-# therefore its input, to be recomputed). This is the token renewal mechanism: bump
-# the rotation number to pull a brand-new kubeconfig the same way it was generated on
-# initial creation — never hand-supply kubeconfig content.
+# every refresh, so referencing it directly would rotate the credential on every apply.
+# terraform_data's store.sensitive_output (Terraform >= 1.16) gates that: the stored
+# value only recomputes when store.version changes, and — unlike the legacy input/output
+# attributes — sensitive_output correctly preserves the sensitivity mark, so the token
+# never renders in plain text in plan/apply/state output. Bump
+# harvester_credential_rotation to pull a fresh kubeconfig and update the existing
+# credential's kubeconfig_content in place (same secret ID, no cluster/machine_pool
+# cascade) — the same dynamic-fetch mechanism used on initial creation.
 resource "terraform_data" "harvester_kubeconfig_rotation" {
   count = var.create_cloud_credential ? 1 : 0
 
-  input = data.rancher2_cluster_v2.harvester[0].kube_config
-
-  triggers_replace = [
-    var.harvester_credential_rotation,
-  ]
-
-  lifecycle {
-    ignore_changes = [input]
+  store {
+    input     = data.rancher2_cluster_v2.harvester[0].kube_config
+    sensitive = true
+    version   = var.harvester_credential_rotation
   }
 }
 
@@ -395,10 +394,14 @@ resource "rancher2_cloud_credential" "harvester" {
   count = var.create_cloud_credential ? 1 : 0
   name  = "harvester-${var.cluster_name}-credential"
 
+  # kubeconfig_content intentionally uses the full imported-cluster kube_config (not
+  # the narrower harvesterhci.io:cloudprovider ServiceAccount kubeconfig fetched below
+  # for machine_selector_config). Rancher's Harvester node driver needs this credential
+  # to provision/manage VMs and disks, which the CCM-scoped ServiceAccount cannot do.
   harvester_credential_config {
     cluster_id         = data.rancher2_cluster_v2.harvester[0].cluster_v1_id
     cluster_type       = "imported"
-    kubeconfig_content = terraform_data.harvester_kubeconfig_rotation[0].output
+    kubeconfig_content = terraform_data.harvester_kubeconfig_rotation[0].store.sensitive_output
   }
 }
 

--- a/modules/tenancy/k8s-cluster/main.tf
+++ b/modules/tenancy/k8s-cluster/main.tf
@@ -369,6 +369,28 @@ data "http" "harvester_cloud_provider_kubeconfig" {
   }
 }
 
+# Rancher mints a new token in data.rancher2_cluster_v2.harvester[0].kube_config on
+# every refresh, so using that value directly would make the cloud credential drift
+# on every plan. terraform_data pins the value across applies (ignore_changes on
+# input) and only re-reads the live, freshly-fetched kube_config when
+# harvester_credential_rotation is bumped (triggers_replace forces the resource, and
+# therefore its input, to be recomputed). This is the token renewal mechanism: bump
+# the rotation number to pull a brand-new kubeconfig the same way it was generated on
+# initial creation — never hand-supply kubeconfig content.
+resource "terraform_data" "harvester_kubeconfig_rotation" {
+  count = var.create_cloud_credential ? 1 : 0
+
+  input = data.rancher2_cluster_v2.harvester[0].kube_config
+
+  triggers_replace = [
+    var.harvester_credential_rotation,
+  ]
+
+  lifecycle {
+    ignore_changes = [input]
+  }
+}
+
 resource "rancher2_cloud_credential" "harvester" {
   count = var.create_cloud_credential ? 1 : 0
   name  = "harvester-${var.cluster_name}-credential"
@@ -376,11 +398,7 @@ resource "rancher2_cloud_credential" "harvester" {
   harvester_credential_config {
     cluster_id         = data.rancher2_cluster_v2.harvester[0].cluster_v1_id
     cluster_type       = "imported"
-    kubeconfig_content = data.rancher2_cluster_v2.harvester[0].kube_config
-  }
-
-  lifecycle {
-    ignore_changes = [harvester_credential_config[0].kubeconfig_content]
+    kubeconfig_content = terraform_data.harvester_kubeconfig_rotation[0].output
   }
 }
 

--- a/modules/tenancy/k8s-cluster/variables.tf
+++ b/modules/tenancy/k8s-cluster/variables.tf
@@ -335,6 +335,18 @@ variable "chart_values" {
   default     = ""
 }
 
+variable "harvester_credential_rotation" {
+  type        = number
+  description = <<-EOT
+    Bump this number to force the Harvester cloud credential's kubeconfig token to be
+    renewed. A fresh kubeconfig is fetched dynamically from Rancher (the same mechanism
+    used on initial creation) — you never need to supply kubeconfig content yourself.
+    Only used when create_cloud_credential = true; changing it on brownfield clusters
+    (create_cloud_credential = false) has no effect.
+  EOT
+  default     = 0
+}
+
 # ── Cluster membership ────────────────────────────────────────────────────────
 # Optional list of users/groups to bind to this cluster after provisioning.
 # Defaults to [] — omitting it leaves no additional bindings and does not

--- a/modules/tenancy/k8s-cluster/variables.tf
+++ b/modules/tenancy/k8s-cluster/variables.tf
@@ -338,14 +338,15 @@ variable "chart_values" {
 variable "harvester_credential_rotation" {
   type        = number
   description = <<-EOT
-    Bump this number to force the Harvester cloud credential's kubeconfig token to be
-    renewed. A fresh kubeconfig is fetched dynamically from Rancher (the same mechanism
-    used on initial creation) — you never need to supply kubeconfig content yourself.
-    Only used when create_cloud_credential = true; changing it on brownfield clusters
-    (create_cloud_credential = false) has no effect.
+    Bump this number to renew the Harvester cloud credential's kubeconfig token. A fresh
+    kubeconfig is fetched dynamically from Rancher (the same mechanism used on initial
+    creation) and applied to the existing credential in place — you never need to supply
+    kubeconfig content yourself. Only used when create_cloud_credential = true; changing
+    it on brownfield clusters (create_cloud_credential = false) has no effect.
   EOT
   default     = 0
 }
+
 
 # ── Cluster membership ────────────────────────────────────────────────────────
 # Optional list of users/groups to bind to this cluster after provisioning.


### PR DESCRIPTION
## Summary
- Rancher periodically expires the token embedded in `rancher2_cloud_credential.harvester`'s
  `kubeconfig_content`, but that field was permanently `ignore_changes`'d — once created,
  Terraform could never renew it, forcing manual UI edits (and Rancher's own "Renew" button
  is unreliable in some versions).
- Adds a `harvester_credential_rotation` variable (number, default `0`). Bumping it forces a
  brand-new kubeconfig to be fetched from Rancher — the same dynamic API path used on initial
  creation — and applied to the existing credential in place. No manual kubeconfig content is
  ever required.
- Implementation: a `terraform_data.harvester_kubeconfig_rotation` resource pins the live
  `data.rancher2_cluster_v2.harvester[0].kube_config` value across applies
  (`ignore_changes = [input]`, avoiding drift since Rancher mints a new token on every
  refresh) and only recomputes it when `triggers_replace = [var.harvester_credential_rotation]`
  fires. The cloud credential resource now reads `kubeconfig_content` from that pinned value,
  so a rotation updates the credential **in place** — same secret ID, no cluster or
  machine-pool disruption.

## Usage
Bump `harvester_credential_rotation` in the calling module and `terraform apply` to renew:
```hcl
module "cluster" {
  source                         = "..."
  create_cloud_credential        = true
  harvester_credential_rotation  = 1  # was 0 — renews the token
  ...
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable credential rotation trigger for Harvester cloud credentials.
  - Cloud credential kubeconfig values are now refreshed when the rotation setting changes.
  - Existing kubeconfig values remain stable between rotations, improving credential consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->